### PR TITLE
feat(types): implement core TypeScript type definitions

### DIFF
--- a/src/types/index.test.ts
+++ b/src/types/index.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expectTypeOf } from "vitest";
+import {
+  // Re-exported Prisma types
+  Market,
+  Order,
+  UserPosition,
+  MarketStatus,
+  OrderSide,
+  OrderStatus,
+  Outcome,
+  Prisma,
+  // Additional types
+  OrderReceipt,
+  Trade,
+  OrderBookLevel,
+  OrderBook,
+  PositionWithPayout,
+  MarketWithStats,
+  ApiResponse,
+  PaginationParams,
+  PaginatedResponse,
+} from "./index";
+
+describe("Type Definitions", () => {
+  describe("Prisma Type Re-exports", () => {
+    it("should export Market type with expected properties", () => {
+      expectTypeOf<Market>().toHaveProperty("id");
+      expectTypeOf<Market>().toHaveProperty("question");
+      expectTypeOf<Market>().toHaveProperty("endTime");
+      expectTypeOf<Market>().toHaveProperty("resolutionTime");
+      expectTypeOf<Market>().toHaveProperty("oracleAddress");
+      expectTypeOf<Market>().toHaveProperty("status");
+      expectTypeOf<Market>().toHaveProperty("outcome");
+      expectTypeOf<Market>().toHaveProperty("createdAt");
+      expectTypeOf<Market>().toHaveProperty("updatedAt");
+    });
+
+    it("should export Order type with expected properties", () => {
+      expectTypeOf<Order>().toHaveProperty("id");
+      expectTypeOf<Order>().toHaveProperty("marketId");
+      expectTypeOf<Order>().toHaveProperty("userAddress");
+      expectTypeOf<Order>().toHaveProperty("side");
+      expectTypeOf<Order>().toHaveProperty("outcome");
+      expectTypeOf<Order>().toHaveProperty("price");
+      expectTypeOf<Order>().toHaveProperty("quantity");
+      expectTypeOf<Order>().toHaveProperty("filledQuantity");
+      expectTypeOf<Order>().toHaveProperty("status");
+      expectTypeOf<Order>().toHaveProperty("createdAt");
+    });
+
+    it("should export UserPosition type with expected properties", () => {
+      expectTypeOf<UserPosition>().toHaveProperty("id");
+      expectTypeOf<UserPosition>().toHaveProperty("marketId");
+      expectTypeOf<UserPosition>().toHaveProperty("userAddress");
+      expectTypeOf<UserPosition>().toHaveProperty("yesShares");
+      expectTypeOf<UserPosition>().toHaveProperty("noShares");
+      expectTypeOf<UserPosition>().toHaveProperty("lockedCollateral");
+      expectTypeOf<UserPosition>().toHaveProperty("isSettled");
+      expectTypeOf<UserPosition>().toHaveProperty("updatedAt");
+    });
+
+    it("should export MarketStatus enum", () => {
+      expectTypeOf<MarketStatus>().toBeString();
+      expectTypeOf<"ACTIVE">().toMatchTypeOf<MarketStatus>();
+      expectTypeOf<"RESOLVED">().toMatchTypeOf<MarketStatus>();
+      expectTypeOf<"CANCELLED">().toMatchTypeOf<MarketStatus>();
+    });
+
+    it("should export OrderSide enum", () => {
+      expectTypeOf<OrderSide>().toBeString();
+      expectTypeOf<"BUY">().toMatchTypeOf<OrderSide>();
+      expectTypeOf<"SELL">().toMatchTypeOf<OrderSide>();
+    });
+
+    it("should export OrderStatus enum", () => {
+      expectTypeOf<OrderStatus>().toBeString();
+      expectTypeOf<"OPEN">().toMatchTypeOf<OrderStatus>();
+      expectTypeOf<"FILLED">().toMatchTypeOf<OrderStatus>();
+      expectTypeOf<"CANCELLED">().toMatchTypeOf<OrderStatus>();
+      expectTypeOf<"PARTIALLY_FILLED">().toMatchTypeOf<OrderStatus>();
+    });
+
+    it("should export Outcome enum", () => {
+      expectTypeOf<Outcome>().toBeString();
+      expectTypeOf<"YES">().toMatchTypeOf<Outcome>();
+      expectTypeOf<"NO">().toMatchTypeOf<Outcome>();
+    });
+
+    it("should export Prisma namespace", () => {
+      expectTypeOf<typeof Prisma>().toBeObject();
+    });
+  });
+
+  describe("OrderReceipt Type", () => {
+    it("should have all Order properties plus signature and timestamp", () => {
+      expectTypeOf<OrderReceipt>().toHaveProperty("id");
+      expectTypeOf<OrderReceipt>().toHaveProperty("marketId");
+      expectTypeOf<OrderReceipt>().toHaveProperty("userAddress");
+      expectTypeOf<OrderReceipt>().toHaveProperty("side");
+      expectTypeOf<OrderReceipt>().toHaveProperty("outcome");
+      expectTypeOf<OrderReceipt>().toHaveProperty("price");
+      expectTypeOf<OrderReceipt>().toHaveProperty("quantity");
+      expectTypeOf<OrderReceipt>().toHaveProperty("signature");
+      expectTypeOf<OrderReceipt>().toHaveProperty("timestamp");
+    });
+
+    it("should have correct types for additional fields", () => {
+      expectTypeOf<OrderReceipt["signature"]>().toBeString();
+      expectTypeOf<OrderReceipt["timestamp"]>().toBeNumber();
+    });
+  });
+
+  describe("Trade Type", () => {
+    it("should have all expected properties", () => {
+      expectTypeOf<Trade>().toHaveProperty("id");
+      expectTypeOf<Trade>().toHaveProperty("marketId");
+      expectTypeOf<Trade>().toHaveProperty("outcome");
+      expectTypeOf<Trade>().toHaveProperty("buyerAddress");
+      expectTypeOf<Trade>().toHaveProperty("sellerAddress");
+      expectTypeOf<Trade>().toHaveProperty("price");
+      expectTypeOf<Trade>().toHaveProperty("quantity");
+      expectTypeOf<Trade>().toHaveProperty("buyOrderId");
+      expectTypeOf<Trade>().toHaveProperty("sellOrderId");
+      expectTypeOf<Trade>().toHaveProperty("timestamp");
+    });
+
+    it("should have correct types", () => {
+      expectTypeOf<Trade["id"]>().toBeString();
+      expectTypeOf<Trade["marketId"]>().toBeString();
+      expectTypeOf<Trade["outcome"]>().toMatchTypeOf<Outcome>();
+      expectTypeOf<Trade["buyerAddress"]>().toBeString();
+      expectTypeOf<Trade["sellerAddress"]>().toBeString();
+      expectTypeOf<Trade["price"]>().toBeNumber();
+      expectTypeOf<Trade["quantity"]>().toBeNumber();
+      expectTypeOf<Trade["buyOrderId"]>().toBeString();
+      expectTypeOf<Trade["sellOrderId"]>().toBeString();
+      expectTypeOf<Trade["timestamp"]>().toBeNumber();
+    });
+  });
+
+  describe("OrderBookLevel Type", () => {
+    it("should have expected properties", () => {
+      expectTypeOf<OrderBookLevel>().toHaveProperty("price");
+      expectTypeOf<OrderBookLevel>().toHaveProperty("totalQuantity");
+      expectTypeOf<OrderBookLevel>().toHaveProperty("orderCount");
+    });
+
+    it("should have correct types", () => {
+      expectTypeOf<OrderBookLevel["price"]>().toBeNumber();
+      expectTypeOf<OrderBookLevel["totalQuantity"]>().toBeNumber();
+      expectTypeOf<OrderBookLevel["orderCount"]>().toBeNumber();
+    });
+  });
+
+  describe("OrderBook Type", () => {
+    it("should have expected properties", () => {
+      expectTypeOf<OrderBook>().toHaveProperty("marketId");
+      expectTypeOf<OrderBook>().toHaveProperty("outcome");
+      expectTypeOf<OrderBook>().toHaveProperty("bids");
+      expectTypeOf<OrderBook>().toHaveProperty("asks");
+      expectTypeOf<OrderBook>().toHaveProperty("lastUpdated");
+    });
+
+    it("should have correct types", () => {
+      expectTypeOf<OrderBook["marketId"]>().toBeString();
+      expectTypeOf<OrderBook["outcome"]>().toMatchTypeOf<Outcome>();
+      expectTypeOf<OrderBook["bids"]>().toMatchTypeOf<OrderBookLevel[]>();
+      expectTypeOf<OrderBook["asks"]>().toMatchTypeOf<OrderBookLevel[]>();
+      expectTypeOf<OrderBook["lastUpdated"]>().toBeNumber();
+    });
+  });
+
+  describe("PositionWithPayout Type", () => {
+    it("should have all UserPosition properties plus payout fields", () => {
+      expectTypeOf<PositionWithPayout>().toHaveProperty("id");
+      expectTypeOf<PositionWithPayout>().toHaveProperty("marketId");
+      expectTypeOf<PositionWithPayout>().toHaveProperty("userAddress");
+      expectTypeOf<PositionWithPayout>().toHaveProperty("yesShares");
+      expectTypeOf<PositionWithPayout>().toHaveProperty("noShares");
+      expectTypeOf<PositionWithPayout>().toHaveProperty("lockedCollateral");
+      expectTypeOf<PositionWithPayout>().toHaveProperty("potentialPayoutIfYes");
+      expectTypeOf<PositionWithPayout>().toHaveProperty("potentialPayoutIfNo");
+      expectTypeOf<PositionWithPayout>().toHaveProperty("netPosition");
+    });
+
+    it("should have correct types for calculated fields", () => {
+      expectTypeOf<PositionWithPayout["potentialPayoutIfYes"]>().toBeNumber();
+      expectTypeOf<PositionWithPayout["potentialPayoutIfNo"]>().toBeNumber();
+      expectTypeOf<PositionWithPayout["netPosition"]>().toBeNumber();
+    });
+  });
+
+  describe("MarketWithStats Type", () => {
+    it("should have all Market properties plus stats fields", () => {
+      expectTypeOf<MarketWithStats>().toHaveProperty("id");
+      expectTypeOf<MarketWithStats>().toHaveProperty("question");
+      expectTypeOf<MarketWithStats>().toHaveProperty("endTime");
+      expectTypeOf<MarketWithStats>().toHaveProperty("status");
+      expectTypeOf<MarketWithStats>().toHaveProperty("totalVolume");
+      expectTypeOf<MarketWithStats>().toHaveProperty("openOrders");
+      expectTypeOf<MarketWithStats>().toHaveProperty("uniqueTraders");
+    });
+
+    it("should have correct types for calculated fields", () => {
+      expectTypeOf<MarketWithStats["totalVolume"]>().toBeNumber();
+      expectTypeOf<MarketWithStats["openOrders"]>().toBeNumber();
+      expectTypeOf<MarketWithStats["uniqueTraders"]>().toBeNumber();
+    });
+  });
+
+  describe("ApiResponse Generic Type", () => {
+    it("should have expected properties", () => {
+      expectTypeOf<ApiResponse<unknown>>().toHaveProperty("success");
+      expectTypeOf<ApiResponse<unknown>>().toHaveProperty("data");
+      expectTypeOf<ApiResponse<unknown>>().toHaveProperty("error");
+      expectTypeOf<ApiResponse<unknown>>().toHaveProperty("timestamp");
+    });
+
+    it("should have correct types", () => {
+      expectTypeOf<ApiResponse<unknown>["success"]>().toBeBoolean();
+      expectTypeOf<ApiResponse<unknown>["timestamp"]>().toBeString();
+    });
+
+    it("should work with generic types correctly", () => {
+      type StringResponse = ApiResponse<string>;
+      expectTypeOf<StringResponse["data"]>().toMatchTypeOf<string | undefined>();
+
+      type MarketResponse = ApiResponse<Market>;
+      expectTypeOf<MarketResponse["data"]>().toMatchTypeOf<Market | undefined>();
+    });
+  });
+
+  describe("PaginationParams Type", () => {
+    it("should have expected properties", () => {
+      expectTypeOf<PaginationParams>().toHaveProperty("page");
+      expectTypeOf<PaginationParams>().toHaveProperty("limit");
+      expectTypeOf<PaginationParams>().toHaveProperty("sortBy");
+      expectTypeOf<PaginationParams>().toHaveProperty("sortOrder");
+    });
+
+    it("should have correct types", () => {
+      expectTypeOf<PaginationParams["page"]>().toBeNumber();
+      expectTypeOf<PaginationParams["limit"]>().toBeNumber();
+      expectTypeOf<PaginationParams["sortBy"]>().toMatchTypeOf<string | undefined>();
+      expectTypeOf<PaginationParams["sortOrder"]>().toMatchTypeOf<"asc" | "desc" | undefined>();
+    });
+  });
+
+  describe("PaginatedResponse Generic Type", () => {
+    it("should have expected properties", () => {
+      expectTypeOf<PaginatedResponse<unknown>>().toHaveProperty("items");
+      expectTypeOf<PaginatedResponse<unknown>>().toHaveProperty("total");
+      expectTypeOf<PaginatedResponse<unknown>>().toHaveProperty("page");
+      expectTypeOf<PaginatedResponse<unknown>>().toHaveProperty("limit");
+      expectTypeOf<PaginatedResponse<unknown>>().toHaveProperty("totalPages");
+    });
+
+    it("should have correct types", () => {
+      expectTypeOf<PaginatedResponse<unknown>["total"]>().toBeNumber();
+      expectTypeOf<PaginatedResponse<unknown>["page"]>().toBeNumber();
+      expectTypeOf<PaginatedResponse<unknown>["limit"]>().toBeNumber();
+      expectTypeOf<PaginatedResponse<unknown>["totalPages"]>().toBeNumber();
+    });
+
+    it("should work with generic types correctly", () => {
+      type MarketList = PaginatedResponse<Market>;
+      expectTypeOf<MarketList["items"]>().toMatchTypeOf<Market[]>();
+
+      type OrderList = PaginatedResponse<Order>;
+      expectTypeOf<OrderList["items"]>().toMatchTypeOf<Order[]>();
+    });
+  });
+
+  describe("Type Inference", () => {
+    it("should correctly infer types from Prisma models", () => {
+      const market: Market = {} as Market;
+      expectTypeOf(market.id).toBeString();
+      expectTypeOf(market.status).toMatchTypeOf<MarketStatus>();
+    });
+
+    it("should correctly infer extended types", () => {
+      const receipt: OrderReceipt = {} as OrderReceipt;
+      expectTypeOf(receipt.id).toBeString();
+      expectTypeOf(receipt.signature).toBeString();
+    });
+
+    it("should correctly infer generic response types", () => {
+      const response: ApiResponse<Market[]> = {} as ApiResponse<Market[]>;
+      expectTypeOf(response.success).toBeBoolean();
+      expectTypeOf(response.data).toMatchTypeOf<Market[] | undefined>();
+    });
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,20 +1,177 @@
 // Core types for Vatix Protocol
 
-export type Order = {
-  id: string;
-  market_id: string;
-  user: string;
-  side: "BUY" | "SELL";
-  outcome: "YES" | "NO";
-  price: number; // 0-1
-  quantity: number;
+// ============================================================================
+// Re-export Prisma Types
+// ============================================================================
+
+/**
+ * Re-exported types from Prisma Client.
+ * These are generated from the database schema and provide type-safe access
+ * to database models and enums.
+ */
+export {
+  Market,
+  Order,
+  UserPosition,
+  MarketStatus,
+  OrderSide,
+  OrderStatus,
+  Outcome,
+  Prisma,
+} from "../generated/prisma/client";
+
+import type {
+  Market,
+  Order,
+  UserPosition,
+  Outcome,
+} from "../generated/prisma/client";
+
+// ============================================================================
+// Additional Types
+// ============================================================================
+
+/**
+ * Order with backend signature.
+ * Used for signed order receipts as part of the trust mechanism.
+ * Extends the Prisma Order type with cryptographic signature and timestamp.
+ */
+export interface OrderReceipt extends Order {
+  /** Cryptographic signature from the backend */
+  signature: string;
+  /** Timestamp when the receipt was generated */
   timestamp: number;
-};
+}
 
-export type UserPosition = {
-  yes_shares: number;
-  no_shares: number;
-  locked_collateral: number;
-};
+/**
+ * Trade execution record.
+ * Represents a matched trade between a buyer and seller.
+ * Note: This type is used for recording match executions (not stored in DB for MVP).
+ */
+export interface Trade {
+  /** Unique trade identifier */
+  id: string;
+  /** Market ID where the trade occurred */
+  marketId: string;
+  /** Outcome that was traded (YES or NO) */
+  outcome: Outcome;
+  /** Stellar address of the buyer */
+  buyerAddress: string;
+  /** Stellar address of the seller */
+  sellerAddress: string;
+  /** Price at which the trade executed (0-1) */
+  price: number;
+  /** Quantity of shares traded */
+  quantity: number;
+  /** ID of the buy order */
+  buyOrderId: string;
+  /** ID of the sell order */
+  sellOrderId: string;
+  /** Timestamp of the trade execution */
+  timestamp: number;
+}
 
-export type MarketStatus = "ACTIVE" | "RESOLVED" | "CANCELLED";
+/**
+ * Depth at a single price level in the order book.
+ * Aggregates all orders at a specific price point.
+ */
+export interface OrderBookLevel {
+  /** Price level (0-1) */
+  price: number;
+  /** Total quantity of shares at this price level */
+  totalQuantity: number;
+  /** Number of orders at this price level */
+  orderCount: number;
+}
+
+/**
+ * Complete order book for a market outcome.
+ * Contains all bid and ask levels for a specific outcome.
+ */
+export interface OrderBook {
+  /** Market ID */
+  marketId: string;
+  /** Outcome this order book represents (YES or NO) */
+  outcome: Outcome;
+  /** Array of bid levels (buy orders), sorted by price descending */
+  bids: OrderBookLevel[];
+  /** Array of ask levels (sell orders), sorted by price ascending */
+  asks: OrderBookLevel[];
+  /** Timestamp when the order book was last updated */
+  lastUpdated: number;
+}
+
+/**
+ * User position with calculated payout information.
+ * Extends the Prisma UserPosition type with potential payout calculations.
+ */
+export interface PositionWithPayout extends UserPosition {
+  /** Potential payout if the market resolves to YES (calculated) */
+  potentialPayoutIfYes: number;
+  /** Potential payout if the market resolves to NO (calculated) */
+  potentialPayoutIfNo: number;
+  /** Net position value (calculated: yesShares - noShares) */
+  netPosition: number;
+}
+
+/**
+ * Market with aggregated statistics.
+ * Extends the Prisma Market type with calculated statistics.
+ */
+export interface MarketWithStats extends Market {
+  /** Total trading volume in the market (calculated) */
+  totalVolume: number;
+  /** Number of currently open orders (calculated) */
+  openOrders: number;
+  /** Number of unique traders who have participated (calculated) */
+  uniqueTraders: number;
+}
+
+/**
+ * Generic API response wrapper.
+ * Provides a consistent structure for all API responses.
+ * @template T - The type of data contained in the response
+ */
+export interface ApiResponse<T> {
+  /** Whether the request was successful */
+  success: boolean;
+  /** Response data (present on success) */
+  data?: T;
+  /** Error message (present on failure) */
+  error?: string;
+  /** ISO timestamp of the response */
+  timestamp: string;
+}
+
+/**
+ * Pagination parameters for list queries.
+ * Used to request paginated data from API endpoints.
+ */
+export interface PaginationParams {
+  /** Page number (1-indexed) */
+  page: number;
+  /** Number of items per page */
+  limit: number;
+  /** Optional field to sort by */
+  sortBy?: string;
+  /** Optional sort direction */
+  sortOrder?: "asc" | "desc";
+}
+
+/**
+ * Paginated response containing a list of items.
+ * Provides metadata for pagination along with the data.
+ * @template T - The type of items in the response
+ */
+export interface PaginatedResponse<T> {
+  /** Array of items for the current page */
+  items: T[];
+  /** Total number of items across all pages */
+  total: number;
+  /** Current page number */
+  page: number;
+  /** Number of items per page */
+  limit: number;
+  /** Total number of pages */
+  totalPages: number;
+}


### PR DESCRIPTION
I've expanded the type system with comprehensive definitions that power our backend services. This includes re-exporting all Prisma types and creating custom types for order receipts, trades, order books, positions with payouts, markets with stats, and generic API response wrappers - all with full JSDoc documentation.

Added type tests using Vitest's expectTypeOf to ensure type safety.

Closes #9