### PR TITLE
feat: implement order validation logic

### DIFF
--- a/src/matching/validation.test.ts
+++ b/src/matching/validation.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  validateUserAddress,
+  validateOrderSide,
+  validateOutcome,
+  validatePrice,
+  validateQuantity,
+  validateOrderFields,
+  validateMarketState,
+  validateOrder,
+  assertValidOrder,
+  OrderValidationError,
+  type OrderInput,
+} from './validation.js';
+
+// Mock the prisma service
+const mockFindUnique = vi.fn();
+vi.mock('../services/prisma.js', () => ({
+  getPrismaClient: () => ({
+    market: {
+      findUnique: mockFindUnique,
+    },
+  }),
+}));
+
+// Test fixtures - Stellar addresses are exactly 56 characters starting with 'G'
+const validAddress = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+const validOrder: OrderInput = {
+  marketId: 'market-123',
+  userAddress: validAddress,
+  side: 'BUY',
+  outcome: 'YES',
+  price: 0.5,
+  quantity: 100,
+};
+
+describe('Order Validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('validateUserAddress', () => {
+    it('should accept valid 56-char address starting with G', () => {
+      expect(validateUserAddress(validAddress)).toBeNull();
+    });
+
+    it('should reject address that is too short', () => {
+      const shortAddress = 'GABCDEFGHIJK';
+      expect(validateUserAddress(shortAddress)).toBe('User address must be exactly 56 characters');
+    });
+
+    it('should reject address that is too long', () => {
+      const longAddress = 'G' + 'A'.repeat(60);
+      expect(validateUserAddress(longAddress)).toBe('User address must be exactly 56 characters');
+    });
+
+    it('should reject address that does not start with G', () => {
+      // Exactly 56 characters but starts with 'A' instead of 'G'
+      const invalidPrefix = 'AABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+      expect(validateUserAddress(invalidPrefix)).toBe('User address must start with G');
+    });
+
+    it('should reject empty string', () => {
+      expect(validateUserAddress('')).toBe('User address is required');
+    });
+
+    it('should reject null/undefined', () => {
+      expect(validateUserAddress(null as unknown as string)).toBe('User address must be a string');
+      expect(validateUserAddress(undefined as unknown as string)).toBe('User address must be a string');
+    });
+  });
+
+  describe('validateOrderSide', () => {
+    it('should accept BUY', () => {
+      expect(validateOrderSide('BUY')).toBeNull();
+    });
+
+    it('should accept SELL', () => {
+      expect(validateOrderSide('SELL')).toBeNull();
+    });
+
+    it('should reject other strings', () => {
+      expect(validateOrderSide('buy')).toBe("Order side must be 'BUY' or 'SELL'");
+      expect(validateOrderSide('HOLD')).toBe("Order side must be 'BUY' or 'SELL'");
+      expect(validateOrderSide('')).toBe("Order side must be 'BUY' or 'SELL'");
+    });
+
+    it('should reject null/undefined', () => {
+      expect(validateOrderSide(null)).toBe('Order side is required');
+      expect(validateOrderSide(undefined)).toBe('Order side is required');
+    });
+  });
+
+  describe('validateOutcome', () => {
+    it('should accept YES', () => {
+      expect(validateOutcome('YES')).toBeNull();
+    });
+
+    it('should accept NO', () => {
+      expect(validateOutcome('NO')).toBeNull();
+    });
+
+    it('should reject other strings', () => {
+      expect(validateOutcome('yes')).toBe("Outcome must be 'YES' or 'NO'");
+      expect(validateOutcome('MAYBE')).toBe("Outcome must be 'YES' or 'NO'");
+      expect(validateOutcome('')).toBe("Outcome must be 'YES' or 'NO'");
+    });
+
+    it('should reject null/undefined', () => {
+      expect(validateOutcome(null)).toBe('Outcome is required');
+      expect(validateOutcome(undefined)).toBe('Outcome is required');
+    });
+  });
+
+  describe('validatePrice', () => {
+    it('should accept 0.5', () => {
+      expect(validatePrice(0.5)).toBeNull();
+    });
+
+    it('should accept 0.01 (near min)', () => {
+      expect(validatePrice(0.01)).toBeNull();
+    });
+
+    it('should accept 0.99 (near max)', () => {
+      expect(validatePrice(0.99)).toBeNull();
+    });
+
+    it('should reject 0 (boundary)', () => {
+      expect(validatePrice(0)).toBe('Price must be between 0 and 1 (exclusive)');
+    });
+
+    it('should reject 1 (boundary)', () => {
+      expect(validatePrice(1)).toBe('Price must be between 0 and 1 (exclusive)');
+    });
+
+    it('should reject negative numbers', () => {
+      expect(validatePrice(-0.5)).toBe('Price must be between 0 and 1 (exclusive)');
+    });
+
+    it('should reject values greater than 1', () => {
+      expect(validatePrice(1.5)).toBe('Price must be between 0 and 1 (exclusive)');
+    });
+
+    it('should reject non-number values', () => {
+      expect(validatePrice('0.5')).toBe('Price must be a number');
+      expect(validatePrice({})).toBe('Price must be a number');
+    });
+
+    it('should reject NaN', () => {
+      expect(validatePrice(NaN)).toBe('Price must be a number');
+    });
+
+    it('should reject null/undefined', () => {
+      expect(validatePrice(null)).toBe('Price is required');
+      expect(validatePrice(undefined)).toBe('Price is required');
+    });
+  });
+
+  describe('validateQuantity', () => {
+    it('should accept 1', () => {
+      expect(validateQuantity(1)).toBeNull();
+    });
+
+    it('should accept 1000000', () => {
+      expect(validateQuantity(1000000)).toBeNull();
+    });
+
+    it('should reject 0', () => {
+      expect(validateQuantity(0)).toBe('Quantity must be positive');
+    });
+
+    it('should reject negative numbers', () => {
+      expect(validateQuantity(-5)).toBe('Quantity must be positive');
+    });
+
+    it('should reject decimals (1.5)', () => {
+      expect(validateQuantity(1.5)).toBe('Quantity must be an integer');
+    });
+
+    it('should reject non-number values', () => {
+      expect(validateQuantity('100')).toBe('Quantity must be a number');
+      expect(validateQuantity({})).toBe('Quantity must be a number');
+    });
+
+    it('should reject NaN', () => {
+      expect(validateQuantity(NaN)).toBe('Quantity must be a number');
+    });
+
+    it('should reject null/undefined', () => {
+      expect(validateQuantity(null)).toBe('Quantity is required');
+      expect(validateQuantity(undefined)).toBe('Quantity is required');
+    });
+  });
+
+  describe('validateOrderFields', () => {
+    it('should pass valid order', () => {
+      const result = validateOrderFields(validOrder);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual({});
+    });
+
+    it('should return all errors for multiple invalid fields', () => {
+      const invalidOrder: OrderInput = {
+        marketId: 'market-123',
+        userAddress: 'invalid',
+        side: 'INVALID' as 'BUY',
+        outcome: 'MAYBE' as 'YES',
+        price: 2,
+        quantity: -5,
+      };
+
+      const result = validateOrderFields(invalidOrder);
+      expect(result.valid).toBe(false);
+      expect(Object.keys(result.errors)).toHaveLength(5);
+      expect(result.errors.userAddress).toBeDefined();
+      expect(result.errors.side).toBeDefined();
+      expect(result.errors.outcome).toBeDefined();
+      expect(result.errors.price).toBeDefined();
+      expect(result.errors.quantity).toBeDefined();
+    });
+  });
+
+  describe('validateMarketState', () => {
+    it('should pass for active market with future end time', async () => {
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000); // 1 day in future
+      mockFindUnique.mockResolvedValue({
+        id: 'market-123',
+        status: 'ACTIVE',
+        endTime: futureDate,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await validateMarketState('market-123');
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual({});
+    });
+
+    it('should fail when market does not exist', async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const result = await validateMarketState('non-existent');
+      expect(result.valid).toBe(false);
+      expect(result.errors.marketId).toBe('Market not found');
+    });
+
+    it('should fail for RESOLVED market', async () => {
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      mockFindUnique.mockResolvedValue({
+        id: 'market-123',
+        status: 'RESOLVED',
+        endTime: futureDate,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await validateMarketState('market-123');
+      expect(result.valid).toBe(false);
+      expect(result.errors.marketId).toContain('resolved');
+    });
+
+    it('should fail for CANCELLED market', async () => {
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      mockFindUnique.mockResolvedValue({
+        id: 'market-123',
+        status: 'CANCELLED',
+        endTime: futureDate,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await validateMarketState('market-123');
+      expect(result.valid).toBe(false);
+      expect(result.errors.marketId).toContain('cancelled');
+    });
+
+    it('should fail for market with past endTime', async () => {
+      const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000); // 1 day in past
+      mockFindUnique.mockResolvedValue({
+        id: 'market-123',
+        status: 'ACTIVE',
+        endTime: pastDate,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await validateMarketState('market-123');
+      expect(result.valid).toBe(false);
+      expect(result.errors.marketId).toContain('ended');
+    });
+  });
+
+  describe('validateOrder', () => {
+    it('should pass valid order with active market', async () => {
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      mockFindUnique.mockResolvedValue({
+        id: 'market-123',
+        status: 'ACTIVE',
+        endTime: futureDate,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await validateOrder(validOrder);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual({});
+    });
+
+    it('should return field errors before DB check', async () => {
+      const invalidOrder: OrderInput = {
+        ...validOrder,
+        price: 2,
+      };
+
+      const result = await validateOrder(invalidOrder);
+      expect(result.valid).toBe(false);
+      expect(result.errors.price).toBeDefined();
+      // DB should not have been called
+      expect(mockFindUnique).not.toHaveBeenCalled();
+    });
+
+    it('should return market errors after field validation passes', async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const result = await validateOrder(validOrder);
+      expect(result.valid).toBe(false);
+      expect(result.errors.marketId).toBe('Market not found');
+    });
+  });
+
+  describe('assertValidOrder', () => {
+    it('should not throw for valid order', async () => {
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      mockFindUnique.mockResolvedValue({
+        id: 'market-123',
+        status: 'ACTIVE',
+        endTime: futureDate,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await expect(assertValidOrder(validOrder)).resolves.toBeUndefined();
+    });
+
+    it('should throw OrderValidationError for invalid order', async () => {
+      const invalidOrder: OrderInput = {
+        ...validOrder,
+        price: 2,
+      };
+
+      await expect(assertValidOrder(invalidOrder)).rejects.toThrow(OrderValidationError);
+    });
+
+    it('should include all validation failures in error', async () => {
+      const invalidOrder: OrderInput = {
+        marketId: 'market-123',
+        userAddress: 'invalid',
+        side: 'BUY',
+        outcome: 'YES',
+        price: 2,
+        quantity: 100,
+      };
+
+      try {
+        await assertValidOrder(invalidOrder);
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(OrderValidationError);
+        const validationError = error as OrderValidationError;
+        expect(validationError.fields?.userAddress).toBeDefined();
+        expect(validationError.fields?.price).toBeDefined();
+      }
+    });
+  });
+
+  describe('OrderValidationError', () => {
+    it('should have correct name', () => {
+      const error = new OrderValidationError({ field: 'error message' });
+      expect(error.name).toBe('OrderValidationError');
+    });
+
+    it('should concatenate error messages', () => {
+      const error = new OrderValidationError({
+        field1: 'Error 1',
+        field2: 'Error 2',
+      });
+      expect(error.message).toContain('Error 1');
+      expect(error.message).toContain('Error 2');
+    });
+
+    it('should expose fields object', () => {
+      const fields = { field: 'error message' };
+      const error = new OrderValidationError(fields);
+      expect(error.fields).toEqual(fields);
+    });
+  });
+});

--- a/src/matching/validation.ts
+++ b/src/matching/validation.ts
@@ -1,0 +1,235 @@
+import { ValidationError } from '../api/middleware/errors.js';
+import { getPrismaClient } from '../services/prisma.js';
+import type { OrderSide, Outcome } from '../types/index.js';
+
+// Input type for order validation (what the API receives)
+export interface OrderInput {
+  marketId: string;
+  userAddress: string;
+  side: OrderSide;
+  outcome: Outcome;
+  price: number;
+  quantity: number;
+}
+
+// Validation result structure
+export interface ValidationResult {
+  valid: boolean;
+  errors: Record<string, string>;
+}
+
+// Custom error type for order validation
+export class OrderValidationError extends ValidationError {
+  constructor(errors: Record<string, string>) {
+    const message = Object.values(errors).join('; ');
+    super(message, errors);
+    this.name = 'OrderValidationError';
+  }
+}
+
+/**
+ * Validates a Stellar user address format
+ * - Must be exactly 56 characters
+ * - Must start with 'G' (Stellar public key prefix)
+ */
+export function validateUserAddress(address: string): string | null {
+  if (typeof address !== 'string') {
+    return 'User address must be a string';
+  }
+
+  if (address.length === 0) {
+    return 'User address is required';
+  }
+
+  if (address.length !== 56) {
+    return 'User address must be exactly 56 characters';
+  }
+
+  if (!address.startsWith('G')) {
+    return 'User address must start with G';
+  }
+
+  return null;
+}
+
+/**
+ * Validates order side
+ * - Must be 'BUY' or 'SELL'
+ */
+export function validateOrderSide(side: unknown): string | null {
+  if (side === null || side === undefined) {
+    return 'Order side is required';
+  }
+
+  if (side !== 'BUY' && side !== 'SELL') {
+    return "Order side must be 'BUY' or 'SELL'";
+  }
+
+  return null;
+}
+
+/**
+ * Validates outcome
+ * - Must be 'YES' or 'NO'
+ */
+export function validateOutcome(outcome: unknown): string | null {
+  if (outcome === null || outcome === undefined) {
+    return 'Outcome is required';
+  }
+
+  if (outcome !== 'YES' && outcome !== 'NO') {
+    return "Outcome must be 'YES' or 'NO'";
+  }
+
+  return null;
+}
+
+/**
+ * Validates price
+ * - Must be a number
+ * - Must be > 0 and < 1 (exclusive range)
+ */
+export function validatePrice(price: unknown): string | null {
+  if (price === null || price === undefined) {
+    return 'Price is required';
+  }
+
+  if (typeof price !== 'number' || Number.isNaN(price)) {
+    return 'Price must be a number';
+  }
+
+  if (price <= 0 || price >= 1) {
+    return 'Price must be between 0 and 1 (exclusive)';
+  }
+
+  return null;
+}
+
+/**
+ * Validates quantity
+ * - Must be a positive integer
+ */
+export function validateQuantity(quantity: unknown): string | null {
+  if (quantity === null || quantity === undefined) {
+    return 'Quantity is required';
+  }
+
+  if (typeof quantity !== 'number' || Number.isNaN(quantity)) {
+    return 'Quantity must be a number';
+  }
+
+  if (!Number.isInteger(quantity)) {
+    return 'Quantity must be an integer';
+  }
+
+  if (quantity <= 0) {
+    return 'Quantity must be positive';
+  }
+
+  return null;
+}
+
+/**
+ * Validates all synchronous order fields
+ * Returns aggregated validation result with all errors
+ */
+export function validateOrderFields(order: OrderInput): ValidationResult {
+  const errors: Record<string, string> = {};
+
+  const userAddressError = validateUserAddress(order.userAddress);
+  if (userAddressError) {
+    errors.userAddress = userAddressError;
+  }
+
+  const sideError = validateOrderSide(order.side);
+  if (sideError) {
+    errors.side = sideError;
+  }
+
+  const outcomeError = validateOutcome(order.outcome);
+  if (outcomeError) {
+    errors.outcome = outcomeError;
+  }
+
+  const priceError = validatePrice(order.price);
+  if (priceError) {
+    errors.price = priceError;
+  }
+
+  const quantityError = validateQuantity(order.quantity);
+  if (quantityError) {
+    errors.quantity = quantityError;
+  }
+
+  return {
+    valid: Object.keys(errors).length === 0,
+    errors,
+  };
+}
+
+/**
+ * Validates market state from database
+ * - Market must exist
+ * - Market status must be 'ACTIVE'
+ * - Market endTime must be in the future
+ */
+export async function validateMarketState(marketId: string): Promise<ValidationResult> {
+  const errors: Record<string, string> = {};
+  const prisma = getPrismaClient();
+
+  const market = await prisma.market.findUnique({
+    where: { id: marketId },
+  });
+
+  if (!market) {
+    errors.marketId = 'Market not found';
+    return { valid: false, errors };
+  }
+
+  if (market.status !== 'ACTIVE') {
+    errors.marketId = `Market is ${market.status.toLowerCase()}, orders cannot be placed`;
+  }
+
+  if (market.endTime <= new Date()) {
+    errors.marketId = errors.marketId
+      ? `${errors.marketId}; market has ended`
+      : 'Market has ended';
+  }
+
+  return {
+    valid: Object.keys(errors).length === 0,
+    errors,
+  };
+}
+
+/**
+ * Main validation function
+ * - Runs synchronous field validations first (fast path)
+ * - If field validations pass, runs market state validation
+ * - Returns combined validation result
+ */
+export async function validateOrder(order: OrderInput): Promise<ValidationResult> {
+  // Run synchronous validations first (fast path)
+  const fieldResult = validateOrderFields(order);
+
+  if (!fieldResult.valid) {
+    return fieldResult;
+  }
+
+  // Only run database validation if field validation passes
+  const marketResult = await validateMarketState(order.marketId);
+
+  return marketResult;
+}
+
+/**
+ * Helper that throws OrderValidationError if validation fails
+ * Returns void if order is valid
+ */
+export async function assertValidOrder(order: OrderInput): Promise<void> {
+  const result = await validateOrder(order);
+
+  if (!result.valid) {
+    throw new OrderValidationError(result.errors);
+  }
+}


### PR DESCRIPTION
Add validation layer for incoming orders before they enter the order book:

- Create OrderInput and ValidationResult types
- Add OrderValidationError extending ValidationError
- Implement field validators:
  - validateUserAddress (56-char Stellar format)
  - validateOrderSide (BUY/SELL)
  - validateOutcome (YES/NO)
  - validatePrice (0-1 exclusive range)
  - validateQuantity (positive integer)
- Add validateOrderFields for sync validation
- Add validateMarketState for async DB checks
- Add validateOrder as main entry point (sync-first pattern)
- Add assertValidOrder helper that throws on failure
- Include comprehensive test suite with 48 tests

Closes #10