### PR TITLE
feat: build the market route

### DIFF
--- a/src/api/routes/markets.test.ts
+++ b/src/api/routes/markets.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify, { FastifyInstance } from "fastify";
+import { marketsRoutes } from "./markets.js";
+import { errorHandler } from "../middleware/errorHandler.js";
+import type { PrismaClient } from "../../generated/prisma/client";
+
+const mockPrismaClient = {
+  market: {
+    findMany: vi.fn(),
+  },
+} as unknown as PrismaClient;
+
+vi.mock("../../services/prisma.js", () => ({
+  getPrismaClient: () => mockPrismaClient,
+}));
+
+describe("GET /markets", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    app.setErrorHandler(errorHandler);
+    await app.register(marketsRoutes);
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe("successful responses", () => {
+    it("should return all markets when they exist", async () => {
+      const mockMarkets = [
+        {
+          id: "market-1",
+          question: "Will it rain tomorrow?",
+          endTime: new Date("2026-02-01T00:00:00Z"),
+          resolutionTime: null,
+          oracleAddress: "GABC123...",
+          status: "ACTIVE",
+          outcome: null,
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+          updatedAt: new Date("2026-01-01T00:00:00Z"),
+        },
+        {
+          id: "market-2",
+          question: "Will the price go up?",
+          endTime: new Date("2026-03-01T00:00:00Z"),
+          resolutionTime: null,
+          oracleAddress: "GDEF456...",
+          status: "ACTIVE",
+          outcome: null,
+          createdAt: new Date("2026-01-02T00:00:00Z"),
+          updatedAt: new Date("2026-01-02T00:00:00Z"),
+        },
+      ];
+
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(mockMarkets);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("markets");
+      expect(body).toHaveProperty("count");
+      expect(body.markets).toHaveLength(2);
+      expect(body.count).toBe(2);
+      expect(body.markets[0].id).toBe("market-1");
+      expect(body.markets[1].id).toBe("market-2");
+
+      expect(mockPrismaClient.market.findMany).toHaveBeenCalledWith({
+        where: {},
+        orderBy: { createdAt: "desc" },
+      });
+    });
+
+    it("should return empty array when no markets exist", async () => {
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.markets).toEqual([]);
+      expect(body.count).toBe(0);
+    });
+  });
+
+  describe("status filter", () => {
+    it("should filter markets by ACTIVE status", async () => {
+      const mockActiveMarkets = [
+        {
+          id: "market-1",
+          question: "Active market",
+          endTime: new Date("2026-02-01T00:00:00Z"),
+          resolutionTime: null,
+          oracleAddress: "GABC123...",
+          status: "ACTIVE",
+          outcome: null,
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+          updatedAt: new Date("2026-01-01T00:00:00Z"),
+        },
+      ];
+
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(mockActiveMarkets);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets?status=ACTIVE",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.markets).toHaveLength(1);
+      expect(body.markets[0].status).toBe("ACTIVE");
+
+      expect(mockPrismaClient.market.findMany).toHaveBeenCalledWith({
+        where: { status: "ACTIVE" },
+        orderBy: { createdAt: "desc" },
+      });
+    });
+
+    it("should filter markets by RESOLVED status", async () => {
+      const mockResolvedMarkets = [
+        {
+          id: "market-2",
+          question: "Resolved market",
+          endTime: new Date("2026-01-15T00:00:00Z"),
+          resolutionTime: new Date("2026-01-16T00:00:00Z"),
+          oracleAddress: "GDEF456...",
+          status: "RESOLVED",
+          outcome: true,
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+          updatedAt: new Date("2026-01-16T00:00:00Z"),
+        },
+      ];
+
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(mockResolvedMarkets);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets?status=RESOLVED",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.markets).toHaveLength(1);
+      expect(body.markets[0].status).toBe("RESOLVED");
+
+      expect(mockPrismaClient.market.findMany).toHaveBeenCalledWith({
+        where: { status: "RESOLVED" },
+        orderBy: { createdAt: "desc" },
+      });
+    });
+
+    it("should filter markets by CANCELLED status", async () => {
+      const mockCancelledMarkets = [
+        {
+          id: "market-3",
+          question: "Cancelled market",
+          endTime: new Date("2026-01-20T00:00:00Z"),
+          resolutionTime: null,
+          oracleAddress: "GHIJ789...",
+          status: "CANCELLED",
+          outcome: null,
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+          updatedAt: new Date("2026-01-15T00:00:00Z"),
+        },
+      ];
+
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(mockCancelledMarkets);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets?status=CANCELLED",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.markets).toHaveLength(1);
+      expect(body.markets[0].status).toBe("CANCELLED");
+
+      expect(mockPrismaClient.market.findMany).toHaveBeenCalledWith({
+        where: { status: "CANCELLED" },
+        orderBy: { createdAt: "desc" },
+      });
+    });
+
+    it("should reject invalid status values", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets?status=INVALID",
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("should return empty array when no markets match filter", async () => {
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets?status=CANCELLED",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.markets).toEqual([]);
+      expect(body.count).toBe(0);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should return 500 when database error occurs", async () => {
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockRejectedValue(new Error("Database connection failed"));
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets",
+      });
+
+      expect(response.statusCode).toBe(500);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("error");
+      expect(body).toHaveProperty("statusCode", 500);
+      expect(body).toHaveProperty("requestId");
+    });
+
+    it("should handle Prisma query timeout", async () => {
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockRejectedValue(new Error("Query timeout"));
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets",
+      });
+
+      expect(response.statusCode).toBe(500);
+    });
+  });
+
+  describe("response format validation", () => {
+    it("should return all market fields in correct format", async () => {
+      const mockMarket = {
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        question: "Will Bitcoin reach $100k in 2026?",
+        endTime: new Date("2026-12-31T23:59:59Z"),
+        resolutionTime: null,
+        oracleAddress:
+          "GABC123XYZ456DEF789GHI012JKL345MNO678PQR901STU234VWX567YZA890",
+        status: "ACTIVE",
+        outcome: null,
+        createdAt: new Date("2026-01-25T10:00:00Z"),
+        updatedAt: new Date("2026-01-25T10:00:00Z"),
+      };
+
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([mockMarket]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body.markets[0]).toMatchObject({
+        id: mockMarket.id,
+        question: mockMarket.question,
+        endTime: mockMarket.endTime.toISOString(),
+        resolutionTime: null,
+        oracleAddress: mockMarket.oracleAddress,
+        status: mockMarket.status,
+        outcome: null,
+        createdAt: mockMarket.createdAt.toISOString(),
+        updatedAt: mockMarket.updatedAt.toISOString(),
+      });
+    });
+
+    it("should handle resolved markets with outcome", async () => {
+      const mockResolvedMarket = {
+        id: "market-id",
+        question: "Test question",
+        endTime: new Date("2026-01-20T00:00:00Z"),
+        resolutionTime: new Date("2026-01-21T00:00:00Z"),
+        oracleAddress: "GABC123...",
+        status: "RESOLVED",
+        outcome: true,
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-21T00:00:00Z"),
+      };
+
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([mockResolvedMarket]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.markets[0].outcome).toBe(true);
+      expect(body.markets[0].resolutionTime).toBe(
+        mockResolvedMarket.resolutionTime.toISOString(),
+      );
+    });
+  });
+
+  describe("ordering", () => {
+    it("should return markets ordered by createdAt descending (newest first)", async () => {
+      const mockMarkets = [
+        {
+          id: "market-3",
+          question: "Newest market",
+          endTime: new Date("2026-02-01T00:00:00Z"),
+          resolutionTime: null,
+          oracleAddress: "GABC123...",
+          status: "ACTIVE",
+          outcome: null,
+          createdAt: new Date("2026-01-25T00:00:00Z"),
+          updatedAt: new Date("2026-01-25T00:00:00Z"),
+        },
+        {
+          id: "market-2",
+          question: "Middle market",
+          endTime: new Date("2026-02-01T00:00:00Z"),
+          resolutionTime: null,
+          oracleAddress: "GDEF456...",
+          status: "ACTIVE",
+          outcome: null,
+          createdAt: new Date("2026-01-20T00:00:00Z"),
+          updatedAt: new Date("2026-01-20T00:00:00Z"),
+        },
+        {
+          id: "market-1",
+          question: "Oldest market",
+          endTime: new Date("2026-02-01T00:00:00Z"),
+          resolutionTime: null,
+          oracleAddress: "GHIJ789...",
+          status: "ACTIVE",
+          outcome: null,
+          createdAt: new Date("2026-01-15T00:00:00Z"),
+          updatedAt: new Date("2026-01-15T00:00:00Z"),
+        },
+      ];
+
+      (
+        mockPrismaClient.market.findMany as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(mockMarkets);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/markets",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.markets[0].id).toBe("market-3"); // Newest
+      expect(body.markets[1].id).toBe("market-2"); // Middle
+      expect(body.markets[2].id).toBe("market-1"); // Oldest
+    });
+  });
+});

--- a/src/api/routes/markets.ts
+++ b/src/api/routes/markets.ts
@@ -1,0 +1,86 @@
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { getPrismaClient } from "../../services/prisma.js";
+import type { Market, MarketStatus } from "../../types/index.js";
+
+interface GetMarketsQueryParams {
+  status?: MarketStatus;
+}
+
+interface GetMarketsResponse {
+  markets: Market[];
+  count: number;
+}
+
+export async function marketsRoutes(fastify: FastifyInstance) {
+  const prisma = getPrismaClient();
+
+  fastify.get<{ Querystring: GetMarketsQueryParams }>(
+    "/markets",
+    {
+      schema: {
+        querystring: {
+          type: "object",
+          properties: {
+            status: {
+              type: "string",
+              enum: ["ACTIVE", "RESOLVED", "CANCELLED"],
+            },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              markets: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    question: { type: "string" },
+                    endTime: { type: "string" },
+                    resolutionTime: { type: ["string", "null"] },
+                    oracleAddress: { type: "string" },
+                    status: { type: "string" },
+                    outcome: { type: ["boolean", "null"] },
+                    createdAt: { type: "string" },
+                    updatedAt: { type: "string" },
+                  },
+                },
+              },
+              count: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+    async (request: FastifyRequest<{ Querystring: GetMarketsQueryParams }>) => {
+      try {
+        const { status } = request.query;
+
+        const whereClause = status ? { status } : {};
+
+        const markets = await prisma.market.findMany({
+          where: whereClause,
+          orderBy: {
+            createdAt: "desc",
+          },
+        });
+
+        const response: GetMarketsResponse = {
+          markets,
+          count: markets.length,
+        };
+
+        return response;
+      } catch (error) {
+        request.log.error(
+          { error, query: request.query },
+          "Failed to fetch markets",
+        );
+
+        throw new Error("Failed to fetch markets from database");
+      }
+    },
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import Fastify from "fastify";
 import { errorHandler } from "./api/middleware/errorHandler.js";
 import { NotFoundError, ValidationError } from "./api/middleware/errors.js";
+import { marketsRoutes } from "./api/routes/markets.js";
 
 const server = Fastify({
   logger: true,
@@ -9,6 +10,9 @@ const server = Fastify({
 
 // Register error handler (must be before routes)
 server.setErrorHandler(errorHandler);
+
+// Register API routes
+server.register(marketsRoutes);
 
 server.get("/health", async () => {
   return { status: "ok", service: "vatix-backend" };


### PR DESCRIPTION
### Description
This pull request introduces a comprehensive suite of tests for the `/markets` API endpoint and registers the `marketsRoutes` in the main server. It also adds the implementation for the `GET /markets` endpoint, supporting filtering, ordering, and error handling. The main areas of change are the addition of endpoint implementation, test coverage, and route registration.

### Related Issue
- Closes #14 

### Changes Made
**New endpoint implementation and registration:**

- Implemented the `GET /markets` endpoint in `marketsRoutes`, supporting optional filtering by market status, returning results ordered by creation date, and providing a consistent response format. Includes input validation and error handling for database failures.
- Registered the `marketsRoutes` with the Fastify server in `src/index.ts` to make the endpoint available in the API. 

**Test coverage for `/markets` endpoint:**

- Added a comprehensive test suite in `markets.test.ts` that verifies:
  - Successful retrieval of all markets, empty results, and correct response formatting.
  - Filtering by status (`ACTIVE`, `RESOLVED`, `CANCELLED`), including handling of invalid status values and empty filter results.
  - Error handling for database failures and query timeouts.
  - Correct ordering of results by `createdAt` descending.
  - Proper serialization of market fields, including date formatting and outcome handling.
  
  @manlikeHB 
  Please review. If there are changes to be made, tell me. Thanks