### PR TITLE
feat(orders): add GET /orders/user/:address endpoint

### DIFF
--- a/src/api/routes/orders.test.ts
+++ b/src/api/routes/orders.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify, { FastifyInstance } from "fastify";
+import { ordersRoutes } from "./orders.js";
+import { errorHandler } from "../middleware/errorHandler.js";
+import type { PrismaClient } from "../../generated/prisma/client";
+
+const mockPrismaClient = {
+  order: {
+    findMany: vi.fn(),
+  },
+} as unknown as PrismaClient;
+
+vi.mock("../../services/prisma.js", () => ({
+  getPrismaClient: () => mockPrismaClient,
+}));
+
+describe("GET /orders/user/:address", () => {
+  let app: FastifyInstance;
+
+  const validAddress =
+    "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    app.setErrorHandler(errorHandler);
+    await app.register(ordersRoutes);
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("should return user orders sorted by newest first", async () => {
+    const mockOrders = [
+      {
+        id: "order-2",
+        marketId: "market-1",
+        userAddress: validAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: "0.6",
+        quantity: 100,
+        filledQuantity: 0,
+        status: "OPEN",
+        createdAt: new Date("2026-01-20T00:00:00Z"),
+      },
+      {
+        id: "order-1",
+        marketId: "market-1",
+        userAddress: validAddress,
+        side: "SELL",
+        outcome: "NO",
+        price: "0.5",
+        quantity: 50,
+        filledQuantity: 50,
+        status: "FILLED",
+        createdAt: new Date("2026-01-10T00:00:00Z"),
+      },
+    ];
+
+    (
+      mockPrismaClient.order.findMany as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(mockOrders);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/orders/user/${validAddress}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const body = JSON.parse(response.body);
+    expect(body.orders).toHaveLength(2);
+    expect(body.count).toBe(2);
+    expect(body.orders[0].id).toBe("order-2");
+  });
+
+  it("should filter orders by status", async () => {
+    (
+      mockPrismaClient.order.findMany as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/orders/user/${validAddress}?status=OPEN`,
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    expect(mockPrismaClient.order.findMany).toHaveBeenCalledWith({
+      where: {
+        userAddress: validAddress,
+        status: "OPEN",
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  });
+
+  it("should return empty array when user has no orders", async () => {
+    (
+      mockPrismaClient.order.findMany as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/orders/user/${validAddress}`,
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body.orders).toEqual([]);
+    expect(body.count).toBe(0);
+  });
+
+  it("should reject invalid Stellar address", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/orders/user/invalid-address`,
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});

--- a/src/api/routes/orders.ts
+++ b/src/api/routes/orders.ts
@@ -1,0 +1,110 @@
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { getPrismaClient } from "../../services/prisma.js";
+import { ValidationError } from "../middleware/errors.js";
+import type { OrderStatus } from "../../types/index.js";
+import { validateUserAddress } from "../../matching/validation.js";
+
+interface GetUserOrdersParams {
+  address: string;
+}
+
+interface GetUserOrdersQuery {
+  status?: OrderStatus;
+}
+
+export async function ordersRoutes(fastify: FastifyInstance) {
+  const prisma = getPrismaClient();
+
+  fastify.get<{
+    Params: GetUserOrdersParams;
+    Querystring: GetUserOrdersQuery;
+  }>(
+    "/orders/user/:address",
+    {
+      schema: {
+        params: {
+          type: "object",
+          required: ["address"],
+          properties: {
+            address: { type: "string" },
+          },
+        },
+        querystring: {
+          type: "object",
+          properties: {
+            status: {
+              type: "string",
+              enum: ["OPEN", "FILLED", "CANCELLED", "PARTIALLY_FILLED"],
+            },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              orders: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    marketId: { type: "string" },
+                    userAddress: { type: "string" },
+                    side: { type: "string" },
+                    outcome: { type: "string" },
+                    price: { type: "string" },
+                    quantity: { type: "number" },
+                    filledQuantity: { type: "number" },
+                    status: { type: "string" },
+                    createdAt: { type: "string" },
+                  },
+                },
+              },
+              count: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{
+        Params: GetUserOrdersParams;
+        Querystring: GetUserOrdersQuery;
+      }>,
+    ) => {
+      const { address } = request.params;
+      const { status } = request.query;
+
+      // Validate Stellar address
+      const addressError = validateUserAddress(address);
+      if (addressError) {
+        throw new ValidationError(addressError);
+      }
+
+      try {
+        const whereClause = {
+          userAddress: address,
+          ...(status ? { status } : {}),
+        };
+
+        const orders = await prisma.order.findMany({
+          where: whereClause,
+          orderBy: {
+            createdAt: "desc",
+          },
+        });
+
+        return {
+          orders,
+          count: orders.length,
+        };
+      } catch (error) {
+        request.log.error(
+          { error, address, status },
+          "Failed to fetch user orders",
+        );
+        throw new Error("Failed to fetch user orders");
+      }
+    },
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { NotFoundError, ValidationError } from "./api/middleware/errors.js";
 import { signingService } from "./services/signing.js";
 import "dotenv/config";
 import { marketsRoutes } from "./api/routes/markets.js";
+import { ordersRoutes } from "./api/routes/orders.js";
 
 const server = Fastify({
 	logger: true,
@@ -15,6 +16,7 @@ server.setErrorHandler(errorHandler);
 
 // Register API routes
 server.register(marketsRoutes);
+server.register(ordersRoutes);
 
 server.get("/health", async () => {
 	return { status: "ok", service: "vatix-backend" };


### PR DESCRIPTION
Closes #17

- Added GET /orders/user/:address endpoint
- Supports optional status filter (?status=OPEN)
- Orders are sorted by newest first
- Validates Stellar address format
- Returns empty array when user has no orders
- Added route-level tests covering all acceptance criteria