### PR TITLE
refactor: remove try-catch blocks from API routes

### DIFF
--- a/src/api/routes/markets.ts
+++ b/src/api/routes/markets.ts
@@ -55,32 +55,23 @@ export async function marketsRoutes(fastify: FastifyInstance) {
       },
     },
     async (request: FastifyRequest<{ Querystring: GetMarketsQueryParams }>) => {
-      try {
-        const { status } = request.query;
+      const { status } = request.query;
 
-        const whereClause = status ? { status } : {};
+      const whereClause = status ? { status } : {};
 
-        const markets = await prisma.market.findMany({
-          where: whereClause,
-          orderBy: {
-            createdAt: "desc",
-          },
-        });
+      const markets = await prisma.market.findMany({
+        where: whereClause,
+        orderBy: {
+          createdAt: "desc",
+        },
+      });
 
-        const response: GetMarketsResponse = {
-          markets,
-          count: markets.length,
-        };
+      const response: GetMarketsResponse = {
+        markets,
+        count: markets.length,
+      };
 
-        return response;
-      } catch (error) {
-        request.log.error(
-          { error, query: request.query },
-          "Failed to fetch markets",
-        );
-
-        throw new Error("Failed to fetch markets from database");
-      }
+      return response;
     },
   );
 }

--- a/src/api/routes/orders.test.ts
+++ b/src/api/routes/orders.test.ts
@@ -120,4 +120,28 @@ describe("GET /orders/user/:address", () => {
 
     expect(response.statusCode).toBe(400);
   });
+
+  it("should reject invalid status value", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/orders/user/${validAddress}?status=INVALID`,
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("should return 500 when database error occurs", async () => {
+    (mockPrismaClient.order.findMany as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Database connection failed"),
+    );
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/orders/user/${validAddress}`,
+    });
+
+    expect(response.statusCode).toBe(500);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveProperty("error");
+  });
 });

--- a/src/api/routes/orders.ts
+++ b/src/api/routes/orders.ts
@@ -81,30 +81,22 @@ export async function ordersRoutes(fastify: FastifyInstance) {
         throw new ValidationError(addressError);
       }
 
-      try {
-        const whereClause = {
-          userAddress: address,
-          ...(status ? { status } : {}),
-        };
+      const whereClause = {
+        userAddress: address,
+        ...(status ? { status } : {}),
+      };
 
-        const orders = await prisma.order.findMany({
-          where: whereClause,
-          orderBy: {
-            createdAt: "desc",
-          },
-        });
+      const orders = await prisma.order.findMany({
+        where: whereClause,
+        orderBy: {
+          createdAt: "desc",
+        },
+      });
 
-        return {
-          orders,
-          count: orders.length,
-        };
-      } catch (error) {
-        request.log.error(
-          { error, address, status },
-          "Failed to fetch user orders",
-        );
-        throw new Error("Failed to fetch user orders");
-      }
+      return {
+        orders,
+        count: orders.length,
+      };
     },
   );
 }


### PR DESCRIPTION
Let global error handler manage all errors for consistency.
- Removed try-catch from GET /markets
- Removed try-catch from GET /orders/user/:address
- Errors now bubble up to errorHandler middleware