### PR TITLE
feat: add migration for oracle_reports table (#142)

### DIFF
--- a/prisma/migrations/20260427000001_add_oracle_reports/migration.sql
+++ b/prisma/migrations/20260427000001_add_oracle_reports/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "oracle_reports" (
+    "id" TEXT NOT NULL,
+    "source" VARCHAR(256) NOT NULL,
+    "payload_hash" VARCHAR(64) NOT NULL,
+    "confidence" DECIMAL(5,4) NOT NULL,
+    "market_id" TEXT,
+    "candidate_resolution" BOOLEAN,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "oracle_reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "oracle_reports_market_id_idx" ON "oracle_reports"("market_id");
+
+-- CreateIndex
+CREATE INDEX "oracle_reports_source_idx" ON "oracle_reports"("source");
+
+-- CreateIndex
+CREATE INDEX "oracle_reports_created_at_idx" ON "oracle_reports"("created_at");
+
+-- AddForeignKey
+ALTER TABLE "oracle_reports" ADD CONSTRAINT "oracle_reports_market_id_fkey" FOREIGN KEY ("market_id") REFERENCES "markets"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,8 +47,9 @@ model Market {
   createdAt      DateTime     @default(now()) @map("created_at")
   updatedAt      DateTime     @default(now()) @updatedAt @map("updated_at")
 
-  orders    Order[]
-  positions UserPosition[]
+  orders        Order[]
+  positions     UserPosition[]
+  oracleReports OracleReport[]
 
   @@index([status])
   @@index([endTime])
@@ -76,6 +77,23 @@ model Order {
   @@index([status])
   @@index([marketId, outcome, price, createdAt])
   @@map("orders")
+}
+
+model OracleReport {
+  id                   String    @id @default(uuid())
+  source               String    @db.VarChar(256)
+  payloadHash          String    @map("payload_hash") @db.VarChar(64)
+  confidence           Decimal   @db.Decimal(5, 4)
+  marketId             String?   @map("market_id")
+  candidateResolution  Boolean?  @map("candidate_resolution")
+  createdAt            DateTime  @default(now()) @map("created_at")
+
+  market Market? @relation(fields: [marketId], references: [id], onDelete: SetNull)
+
+  @@index([marketId])
+  @@index([source])
+  @@index([createdAt])
+  @@map("oracle_reports")
 }
 
 model UserPosition {


### PR DESCRIPTION
## Summary

Closes #142

Adds the `oracle_reports` table to support raw oracle provider report history for auditing and dispute investigations.

## Changes

- **`prisma/schema.prisma`**: Added `OracleReport` model with `source`, `payload_hash`, `confidence`, nullable `market_id` FK, nullable `candidate_resolution`, and `created_at`. Added `oracleReports` back-relation on `Market`.
- **`prisma/migrations/20260427000001_add_oracle_reports/migration.sql`**: Migration SQL creating the table, indexes on `market_id`, `source`, and `created_at`, and the FK constraint with `ON DELETE SET NULL`.

## Acceptance Criteria Met

- ✅ Stores source, payload hash, confidence, and timestamps
- ✅ Links to market and candidate resolution (both nullable)
- ✅ Write path supports immutable inserts (no update columns)