### PR TITLE
feat: add composite wallet+market indexes for portfolio queries (#145)

### DIFF
--- a/prisma/migrations/20260427000002_add_wallet_lookup_indexes/migration.sql
+++ b/prisma/migrations/20260427000002_add_wallet_lookup_indexes/migration.sql
@@ -1,0 +1,7 @@
+-- Add composite indexes for wallet + market lookups to support low-latency portfolio queries
+
+-- CreateIndex: orders by wallet address + market (covers wallet-scoped trade history per market)
+CREATE INDEX "orders_user_address_market_id_idx" ON "orders"("user_address", "market_id");
+
+-- CreateIndex: positions by wallet address + market (covers wallet-scoped position lookups per market)
+CREATE INDEX "user_positions_user_address_market_id_idx" ON "user_positions"("user_address", "market_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,7 @@ model Order {
 
   @@index([marketId])
   @@index([userAddress])
+  @@index([userAddress, marketId])
   @@index([status])
   @@index([marketId, outcome, price, createdAt])
   @@map("orders")
@@ -93,5 +94,6 @@ model UserPosition {
   @@unique([marketId, userAddress])
   @@index([marketId])
   @@index([userAddress])
+  @@index([userAddress, marketId])
   @@map("user_positions")
 }


### PR DESCRIPTION
## Summary

Closes #145

Adds composite `(user_address, market_id)` indexes to `orders` and `user_positions` to support low-latency wallet portfolio queries.

## Changes

- **`prisma/schema.prisma`**: Added `@@index([userAddress, marketId])` to both `Order` and `UserPosition` models.
- **`prisma/migrations/20260427000002_add_wallet_lookup_indexes/migration.sql`**: Creates `orders_user_address_market_id_idx` and `user_positions_user_address_market_id_idx`.

## Acceptance Criteria Met

- ✅ Wallet indexes added to relevant tables (`orders`, `user_positions`)
- ✅ Composite indexes cover wallet + market filter pattern
- ✅ Index definitions documented in migration SQL comments

## Notes

Existing single-column `user_address` indexes are retained for queries that filter by wallet only. The new composite indexes cover the more selective wallet + market pattern used by portfolio endpoints.