### PR TITLE
ci: add unit/integration test steps with artifact retention (#155)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, dev]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test
@@ -82,21 +86,44 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/vatix
 
-      - name: Run tests
-        run: pnpm test
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/vatix
-          REDIS_URL: redis://localhost:6379
-          NODE_ENV: development
-
-      - name: Run tests with coverage
-        run: pnpm test:coverage
+      - name: Run unit tests
+        run: pnpm test:run
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/vatix
           REDIS_URL: redis://localhost:6379
           NODE_ENV: test
 
+      - name: Run integration tests
+        run: pnpm test:integration
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/vatix
+          REDIS_URL: redis://localhost:6379
+          NODE_ENV: test
+
+      - name: Run tests with coverage
+        run: pnpm test:coverage --reporter=verbose --outputFile=test-results/results.json
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/vatix
+          REDIS_URL: redis://localhost:6379
+          NODE_ENV: test
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 7
+
       - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
+
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         if: always()
         with:


### PR DESCRIPTION
## Summary

Closes #155

Fixes and extends the CI `test` job to properly run unit and integration tests as separate steps, retain test artifacts for debugging, and cancel stale runs on the same PR.

## Changes to `.github/workflows/ci.yml`

- **Concurrency group**: cancels in-progress runs for the same ref, preventing stale CI from blocking PRs
- **Unit tests**: `pnpm test:run` (non-watch, exits with code on failure — blocks merge)
- **Integration tests**: `pnpm test:integration` as a separate step
- **Coverage**: `pnpm test:coverage` with JSON reporter output to `test-results/`
- **Upload test results artifact**: retained 7 days (`if: always()` so logs are available even on failure)
- **Upload coverage artifact**: retained 7 days
- Removed the old `pnpm test` (watch mode) step that would hang in CI

## Acceptance Criteria Met

- ✅ CI runs test suite on pull requests (triggers on `pull_request` to `main`/`dev`)
- ✅ Failing tests block merge (job exits non-zero on test failure)
- ✅ Test artifacts/logs retained for debugging (7-day artifact retention via `upload-artifact@v4`)