### PR TITLE
feat: add resolution_candidates table (#122)

### DIFF
--- a/prisma/migrations/20260427000001_add_resolution_candidates/migration.sql
+++ b/prisma/migrations/20260427000001_add_resolution_candidates/migration.sql
@@ -1,0 +1,28 @@
+-- CreateEnum
+CREATE TYPE "ResolutionCandidateStatus" AS ENUM ('PROPOSED', 'CHALLENGED', 'ACCEPTED', 'REJECTED');
+
+-- CreateTable
+CREATE TABLE "resolution_candidates" (
+    "id" TEXT NOT NULL,
+    "market_id" TEXT NOT NULL,
+    "proposed_outcome" BOOLEAN NOT NULL,
+    "source" TEXT NOT NULL,
+    "status" "ResolutionCandidateStatus" NOT NULL DEFAULT 'PROPOSED',
+    "operator_address" VARCHAR(56) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "resolution_candidates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "resolution_candidates_market_id_idx" ON "resolution_candidates"("market_id");
+
+-- CreateIndex
+CREATE INDEX "resolution_candidates_status_idx" ON "resolution_candidates"("status");
+
+-- CreateIndex
+CREATE INDEX "resolution_candidates_market_id_status_idx" ON "resolution_candidates"("market_id", "status");
+
+-- AddForeignKey
+ALTER TABLE "resolution_candidates" ADD CONSTRAINT "resolution_candidates_market_id_fkey" FOREIGN KEY ("market_id") REFERENCES "markets"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,13 @@ enum Outcome {
   NO
 }
 
+enum ResolutionCandidateStatus {
+  PROPOSED
+  CHALLENGED
+  ACCEPTED
+  REJECTED
+}
+
 model Market {
   id             String       @id @default(uuid())
   question       String
@@ -47,8 +54,9 @@ model Market {
   createdAt      DateTime     @default(now()) @map("created_at")
   updatedAt      DateTime     @default(now()) @updatedAt @map("updated_at")
 
-  orders    Order[]
-  positions UserPosition[]
+  orders               Order[]
+  positions            UserPosition[]
+  resolutionCandidates ResolutionCandidate[]
 
   @@index([status])
   @@index([endTime])
@@ -94,4 +102,22 @@ model UserPosition {
   @@index([marketId])
   @@index([userAddress])
   @@map("user_positions")
+}
+
+model ResolutionCandidate {
+  id              String                    @id @default(uuid())
+  marketId        String                    @map("market_id")
+  proposedOutcome Boolean                   @map("proposed_outcome")
+  source          String
+  status          ResolutionCandidateStatus @default(PROPOSED)
+  operatorAddress String                    @map("operator_address") @db.VarChar(56)
+  createdAt       DateTime                  @default(now()) @map("created_at")
+  updatedAt       DateTime                  @default(now()) @updatedAt @map("updated_at")
+
+  market Market @relation(fields: [marketId], references: [id], onDelete: Cascade)
+
+  @@index([marketId])
+  @@index([status])
+  @@index([marketId, status])
+  @@map("resolution_candidates")
 }


### PR DESCRIPTION
Add ResolutionCandidate model and migration for storing proposed market resolutions before finalization.

- Add ResolutionCandidateStatus enum (PROPOSED, CHALLENGED, ACCEPTED, REJECTED)
- Add ResolutionCandidate model with marketId, proposedOutcome, source, status, operatorAddress, and immutable audit timestamps (createdAt/updatedAt)
- Add FK relation from Market to ResolutionCandidate (cascade delete)
- Add indexes on marketId, status, and composite marketId+status
- Add migration 20260427000001_add_resolution_candidates
closes #122