### PR TITLE
feat: add source attribution field to resolution_candidates (#124)

### DIFF
--- a/prisma/migrations/20260427000003_add_source_attribution/migration.sql
+++ b/prisma/migrations/20260427000003_add_source_attribution/migration.sql
@@ -1,0 +1,58 @@
+-- Source attribution for oracle data providers (#124)
+-- Adds OracleSource enum, ResolutionCandidateStatus enum, resolution_candidates table,
+-- and oracle_source_aliases mapping table for provider alias normalisation.
+
+-- CreateEnum
+CREATE TYPE "ResolutionCandidateStatus" AS ENUM ('PROPOSED', 'CHALLENGED', 'ACCEPTED', 'REJECTED');
+
+-- CreateEnum: standardized oracle provider identifiers
+CREATE TYPE "OracleSource" AS ENUM ('CHAINLINK', 'PYTH', 'UMA', 'API3', 'INTERNAL', 'MANUAL');
+
+-- CreateTable
+CREATE TABLE "resolution_candidates" (
+    "id" TEXT NOT NULL,
+    "market_id" TEXT NOT NULL,
+    "proposed_outcome" BOOLEAN NOT NULL,
+    "source" "OracleSource" NOT NULL,
+    "status" "ResolutionCandidateStatus" NOT NULL DEFAULT 'PROPOSED',
+    "confidence_score" DECIMAL(5,4),
+    "operator_address" VARCHAR(56) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "resolution_candidates_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "resolution_candidates_confidence_score_check"
+        CHECK ("confidence_score" IS NULL OR ("confidence_score" >= 0.0 AND "confidence_score" <= 1.0))
+);
+
+-- CreateTable: provider alias mapping
+CREATE TABLE "oracle_source_aliases" (
+    "id" SERIAL NOT NULL,
+    "alias" TEXT NOT NULL,
+    "canonical_source" "OracleSource" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "oracle_source_aliases_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "resolution_candidates_market_id_idx" ON "resolution_candidates"("market_id");
+
+-- CreateIndex
+CREATE INDEX "resolution_candidates_status_idx" ON "resolution_candidates"("status");
+
+-- CreateIndex
+CREATE INDEX "resolution_candidates_source_idx" ON "resolution_candidates"("source");
+
+-- CreateIndex
+CREATE INDEX "resolution_candidates_market_id_status_idx" ON "resolution_candidates"("market_id", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "oracle_source_aliases_alias_key" ON "oracle_source_aliases"("alias");
+
+-- CreateIndex
+CREATE INDEX "oracle_source_aliases_canonical_source_idx" ON "oracle_source_aliases"("canonical_source");
+
+-- AddForeignKey
+ALTER TABLE "resolution_candidates" ADD CONSTRAINT "resolution_candidates_market_id_fkey"
+    FOREIGN KEY ("market_id") REFERENCES "markets"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,24 @@ enum Outcome {
   NO
 }
 
+enum ResolutionCandidateStatus {
+  PROPOSED
+  CHALLENGED
+  ACCEPTED
+  REJECTED
+}
+
+/// Standardized identifiers for oracle data providers.
+/// Add new providers here; use OracleSourceAlias for raw/legacy name mapping.
+enum OracleSource {
+  CHAINLINK
+  PYTH
+  UMA
+  API3
+  INTERNAL
+  MANUAL
+}
+
 model Market {
   id             String       @id @default(uuid())
   question       String
@@ -49,6 +67,7 @@ model Market {
 
   orders    Order[]
   positions UserPosition[]
+  resolutionCandidates ResolutionCandidate[]
 
   @@index([status])
   @@index([endTime])
@@ -94,4 +113,39 @@ model UserPosition {
   @@index([marketId])
   @@index([userAddress])
   @@map("user_positions")
+}
+
+model ResolutionCandidate {
+  id              String                    @id @default(uuid())
+  marketId        String                    @map("market_id")
+  proposedOutcome Boolean                   @map("proposed_outcome")
+  /// Standardized oracle provider identifier. See OracleSource enum.
+  source          OracleSource
+  status          ResolutionCandidateStatus @default(PROPOSED)
+  /// Confidence score in the range 0.0 (no confidence) to 1.0 (full confidence).
+  /// Null if the source did not report a confidence value.
+  confidenceScore Decimal?                  @map("confidence_score") @db.Decimal(5, 4)
+  operatorAddress String                    @map("operator_address") @db.VarChar(56)
+  createdAt       DateTime                  @default(now()) @map("created_at")
+  updatedAt       DateTime                  @default(now()) @updatedAt @map("updated_at")
+
+  market Market @relation(fields: [marketId], references: [id], onDelete: Cascade)
+
+  @@index([marketId])
+  @@index([status])
+  @@index([source])
+  @@index([marketId, status])
+  @@map("resolution_candidates")
+}
+
+/// Maps raw/legacy provider names or aliases to their canonical OracleSource value.
+/// Used for normalising source attribution from external feeds.
+model OracleSourceAlias {
+  id           Int          @id @default(autoincrement())
+  alias        String       @unique
+  canonicalSource OracleSource @map("canonical_source")
+  createdAt    DateTime     @default(now()) @map("created_at")
+
+  @@index([canonicalSource])
+  @@map("oracle_source_aliases")
 }


### PR DESCRIPTION
Track which oracle provider produced each resolution candidate with a standardized OracleSource enum and an alias mapping table.

- Add OracleSource enum (CHAINLINK, PYTH, UMA, API3, INTERNAL, MANUAL)
- Add ResolutionCandidateStatus enum (PROPOSED, CHALLENGED, ACCEPTED, REJECTED)
- Add resolution_candidates table with typed source column (OracleSource)
- Add oracle_source_aliases table for mapping raw/legacy provider names to their canonical OracleSource value
- Add index on source column for metrics and audit queries
- Add migration 20260427000003_add_source_attribution
closes #124