### PR TITLE
Closes #133 Add stricter limits for heavy endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,16 @@ STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 # Oracle signing keypair
 # Generate with: pnpm generate:keypair
 ORACLE_SECRET_KEY=SABC123...YOUR_SECRET_KEY_HERE
+
+# Rate limiting
+# Global baseline — applies to all routes
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX=100
+
+# Heavy read endpoints (GET /markets, GET /orders/user/:address, GET /positions/user/:address)
+RATE_LIMIT_HEAVY_WINDOW_MS=60000
+RATE_LIMIT_HEAVY_MAX=20
+
+# Write endpoints (POST /orders)
+RATE_LIMIT_WRITE_WINDOW_MS=60000
+RATE_LIMIT_WRITE_MAX=10

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,80 @@
+# Rate Limiting
+
+All API endpoints are protected by an in-memory, per-IP sliding-window rate
+limiter. Limits are tiered by endpoint cost so that expensive routes receive
+tighter controls without penalising cheap ones.
+
+## Tiers
+
+| Tier | Default limit | Env vars | Applies to |
+|------|--------------|----------|------------|
+| **Global** | 100 req / 60 s | `RATE_LIMIT_MAX`, `RATE_LIMIT_WINDOW_MS` | Every route (baseline) |
+| **Heavy read** | 20 req / 60 s | `RATE_LIMIT_HEAVY_MAX`, `RATE_LIMIT_HEAVY_WINDOW_MS` | Expensive read routes (see below) |
+| **Write** | 10 req / 60 s | `RATE_LIMIT_WRITE_MAX`, `RATE_LIMIT_WRITE_WINDOW_MS` | Mutation routes (see below) |
+
+Each tier maintains its own counter, so exhausting the heavy-read budget does
+not consume the global budget and vice versa.
+
+## Route classification
+
+### Heavy read endpoints
+
+These routes perform expensive database operations on every call:
+
+| Route | Reason |
+|-------|--------|
+| `GET /markets` | Full-table scan; no cursor-based pagination |
+| `GET /orders/user/:address` | Two parallel DB queries (`findMany` + `count`) |
+| `GET /positions/user/:address` | `findMany` with a `market` JOIN |
+
+Limit: **20 req / 60 s** per IP.
+
+### Write endpoints
+
+Mutation routes carry the highest per-request cost (input validation, DB
+write, and future matching-engine work):
+
+| Route | Reason |
+|-------|--------|
+| `POST /orders` | Validation + DB write + matching-engine integration |
+
+Limit: **10 req / 60 s** per IP.
+
+### Standard endpoints
+
+All other routes (e.g. `GET /health`, admin routes) are covered only by the
+global baseline.
+
+Limit: **100 req / 60 s** per IP.
+
+## Response format
+
+When a limit is exceeded the server responds with HTTP **429 Too Many Requests**:
+
+```json
+{
+  "error": "Too Many Requests",
+  "code": "RATE_LIMITED",
+  "statusCode": 429,
+  "retryAfter": 42
+}
+```
+
+The `Retry-After` response header is also set to the same value (seconds until
+the window resets).
+
+## Configuration
+
+All limits are configurable via environment variables (see `.env.example`).
+Changes take effect on the next server start. The in-memory store resets on
+restart; for distributed deployments consider replacing the store with a shared
+Redis backend.
+
+## Integrator notes
+
+- Clients should respect the `Retry-After` header and back off accordingly.
+- The `X-Forwarded-For` header is used for IP detection when the server sits
+  behind a proxy. Ensure your proxy sets this header correctly.
+- Heavy and write limits are intentionally lower than the global limit. If your
+  integration requires higher throughput on these routes, contact the platform
+  team to discuss dedicated rate-limit tiers.

--- a/src/api/middleware/rateLimiter.test.ts
+++ b/src/api/middleware/rateLimiter.test.ts
@@ -1,41 +1,67 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Fastify, { FastifyInstance } from "fastify";
-import { rateLimiter } from "./rateLimiter.js";
+import {
+  rateLimiter,
+  heavyReadLimiter,
+  writeLimiter,
+} from "./rateLimiter.js";
 
-describe("rateLimiter middleware", () => {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildServer(
+  hook: typeof rateLimiter,
+  route = "/test"
+): FastifyInstance {
+  const server = Fastify({ logger: false });
+  server.get(route, { onRequest: [hook] }, async () => ({ ok: true }));
+  server.post(route, { onRequest: [hook] }, async () => ({ ok: true }));
+  return server;
+}
+
+async function exhaust(
+  server: FastifyInstance,
+  n: number,
+  method: "GET" | "POST" = "GET",
+  url = "/test"
+): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await server.inject({ method, url });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Global rate limiter
+// ---------------------------------------------------------------------------
+
+describe("rateLimiter (global)", () => {
   let server: FastifyInstance;
 
   beforeEach(() => {
-    server = Fastify({ logger: false });
-    server.addHook("onRequest", rateLimiter);
-    server.get("/test", async () => ({ ok: true }));
+    vi.stubEnv("RATE_LIMIT_MAX", "5");
+    vi.stubEnv("RATE_LIMIT_WINDOW_MS", "60000");
+    server = buildServer(rateLimiter);
   });
 
-  afterEach(() => {
-    server.close();
+  afterEach(async () => {
+    await server.close();
     vi.unstubAllEnvs();
   });
 
   it("allows requests under the limit", async () => {
-    vi.stubEnv("RATE_LIMIT_MAX", "5");
-    vi.stubEnv("RATE_LIMIT_WINDOW_MS", "60000");
-
     const res = await server.inject({ method: "GET", url: "/test" });
     expect(res.statusCode).toBe(200);
   });
 
   it("returns 429 when limit is exceeded", async () => {
+    const s = Fastify({ logger: false });
+    s.get("/t", { onRequest: [rateLimiter] }, async () => ({ ok: true }));
+
     vi.stubEnv("RATE_LIMIT_MAX", "2");
     vi.stubEnv("RATE_LIMIT_WINDOW_MS", "60000");
 
-    // Need a fresh server so env vars are picked up per-request
-    // rateLimiter reads env at call time, so we can exhaust via same IP
-    const s = Fastify({ logger: false });
-    s.addHook("onRequest", rateLimiter);
-    s.get("/t", async () => ({ ok: true }));
-
-    await s.inject({ method: "GET", url: "/t" });
-    await s.inject({ method: "GET", url: "/t" });
+    await exhaust(s, 2, "GET", "/t");
     const res = await s.inject({ method: "GET", url: "/t" });
 
     expect(res.statusCode).toBe(429);
@@ -47,15 +73,211 @@ describe("rateLimiter middleware", () => {
 
   it("includes Retry-After header on 429", async () => {
     const s = Fastify({ logger: false });
-    s.addHook("onRequest", rateLimiter);
-    s.get("/t", async () => ({ ok: true }));
+    s.get("/t", { onRequest: [rateLimiter] }, async () => ({ ok: true }));
 
     vi.stubEnv("RATE_LIMIT_MAX", "1");
+
     await s.inject({ method: "GET", url: "/t" });
     const res = await s.inject({ method: "GET", url: "/t" });
 
     expect(res.statusCode).toBe(429);
     expect(res.headers["retry-after"]).toBeDefined();
+    await s.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heavy-read rate limiter
+// ---------------------------------------------------------------------------
+
+describe("heavyReadLimiter", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("allows requests under the heavy limit", async () => {
+    vi.stubEnv("RATE_LIMIT_HEAVY_MAX", "5");
+    vi.stubEnv("RATE_LIMIT_HEAVY_WINDOW_MS", "60000");
+
+    const s = buildServer(heavyReadLimiter);
+    const res = await s.inject({ method: "GET", url: "/test" });
+    expect(res.statusCode).toBe(200);
+    await s.close();
+  });
+
+  it("enforces a lower threshold than the global limiter", async () => {
+    // Heavy limit set to 3; global would be 100 — heavy fires first.
+    vi.stubEnv("RATE_LIMIT_HEAVY_MAX", "3");
+    vi.stubEnv("RATE_LIMIT_HEAVY_WINDOW_MS", "60000");
+    vi.stubEnv("RATE_LIMIT_MAX", "100");
+
+    const s = Fastify({ logger: false });
+    s.get(
+      "/markets",
+      { onRequest: [heavyReadLimiter] },
+      async () => ({ ok: true })
+    );
+
+    await exhaust(s, 3, "GET", "/markets");
+    const res = await s.inject({ method: "GET", url: "/markets" });
+
+    expect(res.statusCode).toBe(429);
+    const body = JSON.parse(res.body);
+    expect(body.code).toBe("RATE_LIMITED");
+    await s.close();
+  });
+
+  it("returns 429 with Retry-After header", async () => {
+    vi.stubEnv("RATE_LIMIT_HEAVY_MAX", "1");
+    vi.stubEnv("RATE_LIMIT_HEAVY_WINDOW_MS", "60000");
+
+    const s = buildServer(heavyReadLimiter);
+    await s.inject({ method: "GET", url: "/test" });
+    const res = await s.inject({ method: "GET", url: "/test" });
+
+    expect(res.statusCode).toBe(429);
+    expect(res.headers["retry-after"]).toBeDefined();
+    await s.close();
+  });
+
+  it("uses RATE_LIMIT_HEAVY_MAX env var", async () => {
+    vi.stubEnv("RATE_LIMIT_HEAVY_MAX", "2");
+    vi.stubEnv("RATE_LIMIT_HEAVY_WINDOW_MS", "60000");
+
+    const s = buildServer(heavyReadLimiter);
+    await exhaust(s, 2);
+    const res = await s.inject({ method: "GET", url: "/test" });
+    expect(res.statusCode).toBe(429);
+    await s.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Write rate limiter
+// ---------------------------------------------------------------------------
+
+describe("writeLimiter", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("allows requests under the write limit", async () => {
+    vi.stubEnv("RATE_LIMIT_WRITE_MAX", "5");
+    vi.stubEnv("RATE_LIMIT_WRITE_WINDOW_MS", "60000");
+
+    const s = buildServer(writeLimiter);
+    const res = await s.inject({ method: "POST", url: "/test" });
+    expect(res.statusCode).toBe(200);
+    await s.close();
+  });
+
+  it("enforces the strictest threshold for write endpoints", async () => {
+    vi.stubEnv("RATE_LIMIT_WRITE_MAX", "2");
+    vi.stubEnv("RATE_LIMIT_WRITE_WINDOW_MS", "60000");
+
+    const s = Fastify({ logger: false });
+    s.post(
+      "/orders",
+      { onRequest: [writeLimiter] },
+      async () => ({ ok: true })
+    );
+
+    await exhaust(s, 2, "POST", "/orders");
+    const res = await s.inject({ method: "POST", url: "/orders" });
+
+    expect(res.statusCode).toBe(429);
+    const body = JSON.parse(res.body);
+    expect(body.code).toBe("RATE_LIMITED");
+    await s.close();
+  });
+
+  it("returns 429 with Retry-After header on write overflow", async () => {
+    vi.stubEnv("RATE_LIMIT_WRITE_MAX", "1");
+    vi.stubEnv("RATE_LIMIT_WRITE_WINDOW_MS", "60000");
+
+    const s = buildServer(writeLimiter);
+    await s.inject({ method: "POST", url: "/test" });
+    const res = await s.inject({ method: "POST", url: "/test" });
+
+    expect(res.statusCode).toBe(429);
+    expect(res.headers["retry-after"]).toBeDefined();
+    await s.close();
+  });
+
+  it("uses RATE_LIMIT_WRITE_MAX env var", async () => {
+    vi.stubEnv("RATE_LIMIT_WRITE_MAX", "3");
+    vi.stubEnv("RATE_LIMIT_WRITE_WINDOW_MS", "60000");
+
+    const s = buildServer(writeLimiter);
+    await exhaust(s, 3, "POST");
+    const res = await s.inject({ method: "POST", url: "/test" });
+    expect(res.statusCode).toBe(429);
+    await s.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier isolation — heavy and write counters are independent of global
+// ---------------------------------------------------------------------------
+
+describe("tier isolation", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("heavy-read counter does not affect global counter", async () => {
+    vi.stubEnv("RATE_LIMIT_HEAVY_MAX", "1");
+    vi.stubEnv("RATE_LIMIT_HEAVY_WINDOW_MS", "60000");
+    vi.stubEnv("RATE_LIMIT_MAX", "100");
+
+    const s = Fastify({ logger: false });
+    // /heavy uses heavyReadLimiter; /light uses global rateLimiter
+    s.get(
+      "/heavy",
+      { onRequest: [heavyReadLimiter] },
+      async () => ({ ok: true })
+    );
+    s.get("/light", { onRequest: [rateLimiter] }, async () => ({ ok: true }));
+
+    // Exhaust the heavy tier
+    await s.inject({ method: "GET", url: "/heavy" });
+    const heavyRes = await s.inject({ method: "GET", url: "/heavy" });
+    expect(heavyRes.statusCode).toBe(429);
+
+    // Global tier should still be fine
+    const lightRes = await s.inject({ method: "GET", url: "/light" });
+    expect(lightRes.statusCode).toBe(200);
+
+    await s.close();
+  });
+
+  it("write counter does not affect heavy-read counter", async () => {
+    vi.stubEnv("RATE_LIMIT_WRITE_MAX", "1");
+    vi.stubEnv("RATE_LIMIT_WRITE_WINDOW_MS", "60000");
+    vi.stubEnv("RATE_LIMIT_HEAVY_MAX", "10");
+    vi.stubEnv("RATE_LIMIT_HEAVY_WINDOW_MS", "60000");
+
+    const s = Fastify({ logger: false });
+    s.post(
+      "/orders",
+      { onRequest: [writeLimiter] },
+      async () => ({ ok: true })
+    );
+    s.get(
+      "/markets",
+      { onRequest: [heavyReadLimiter] },
+      async () => ({ ok: true })
+    );
+
+    // Exhaust write tier
+    await s.inject({ method: "POST", url: "/orders" });
+    const writeRes = await s.inject({ method: "POST", url: "/orders" });
+    expect(writeRes.statusCode).toBe(429);
+
+    // Heavy-read tier should still be fine
+    const readRes = await s.inject({ method: "GET", url: "/markets" });
+    expect(readRes.statusCode).toBe(200);
+
     await s.close();
   });
 });

--- a/src/api/middleware/rateLimiter.ts
+++ b/src/api/middleware/rateLimiter.ts
@@ -5,34 +5,87 @@ interface WindowEntry {
   resetAt: number;
 }
 
-const store = new Map<string, WindowEntry>();
+// Separate stores per limit tier so heavy-endpoint counters don't bleed into
+// the global counter for the same IP.
+const stores = new Map<string, Map<string, WindowEntry>>();
 
-// Defaults: 100 requests per 60 seconds per IP
+function getStore(tier: string): Map<string, WindowEntry> {
+  let store = stores.get(tier);
+  if (!store) {
+    store = new Map();
+    stores.set(tier, store);
+  }
+  return store;
+}
+
+// ---------------------------------------------------------------------------
+// Limit tiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Global defaults: 100 req / 60 s per IP.
+ * Override via RATE_LIMIT_WINDOW_MS and RATE_LIMIT_MAX.
+ */
 const WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS) || 60_000;
 const MAX_REQUESTS = Number(process.env.RATE_LIMIT_MAX) || 100;
 
-export function rateLimiter(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  done: () => void
-): void {
-  const key =
+/**
+ * Heavy-endpoint defaults: 20 req / 60 s per IP.
+ * These routes perform expensive DB queries (full-table scans, multi-join
+ * reads, or write + matching-engine work) and need tighter controls to
+ * prevent overload.
+ *
+ * Override via RATE_LIMIT_HEAVY_WINDOW_MS and RATE_LIMIT_HEAVY_MAX.
+ */
+const HEAVY_WINDOW_MS =
+  Number(process.env.RATE_LIMIT_HEAVY_WINDOW_MS) || 60_000;
+const HEAVY_MAX_REQUESTS = Number(process.env.RATE_LIMIT_HEAVY_MAX) || 20;
+
+/**
+ * Write-endpoint defaults: 10 req / 60 s per IP.
+ * Mutation routes (order creation) carry the highest per-request cost
+ * (validation, DB write, future matching-engine work).
+ *
+ * Override via RATE_LIMIT_WRITE_WINDOW_MS and RATE_LIMIT_WRITE_MAX.
+ */
+const WRITE_WINDOW_MS =
+  Number(process.env.RATE_LIMIT_WRITE_WINDOW_MS) || 60_000;
+const WRITE_MAX_REQUESTS = Number(process.env.RATE_LIMIT_WRITE_MAX) || 10;
+
+// ---------------------------------------------------------------------------
+// Core implementation
+// ---------------------------------------------------------------------------
+
+function extractIp(request: FastifyRequest): string {
+  return (
     (request.headers["x-forwarded-for"] as string)?.split(",")[0].trim() ||
     request.socket.remoteAddress ||
-    "unknown";
+    "unknown"
+  );
+}
 
+function applyLimit(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  done: () => void,
+  tier: string,
+  windowMs: number,
+  maxRequests: number
+): void {
+  const key = extractIp(request);
+  const store = getStore(tier);
   const now = Date.now();
   const entry = store.get(key);
 
   if (!entry || now >= entry.resetAt) {
-    store.set(key, { count: 1, resetAt: now + WINDOW_MS });
+    store.set(key, { count: 1, resetAt: now + windowMs });
     done();
     return;
   }
 
   entry.count += 1;
 
-  if (entry.count > MAX_REQUESTS) {
+  if (entry.count > maxRequests) {
     const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
     reply
       .status(429)
@@ -47,4 +100,68 @@ export function rateLimiter(
   }
 
   done();
+}
+
+// ---------------------------------------------------------------------------
+// Exported middleware hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * Global rate limiter — applied to all routes as a baseline.
+ * Limit: 100 req / 60 s (configurable via RATE_LIMIT_MAX / RATE_LIMIT_WINDOW_MS).
+ */
+export function rateLimiter(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  done: () => void
+): void {
+  applyLimit(request, reply, done, "global", WINDOW_MS, MAX_REQUESTS);
+}
+
+/**
+ * Heavy-endpoint rate limiter — apply to routes that perform expensive reads.
+ *
+ * Affected routes:
+ *   GET /markets                  — full-table scan, no cursor-based pagination
+ *   GET /orders/user/:address     — paginated but requires two DB queries (findMany + count)
+ *   GET /positions/user/:address  — findMany with market JOIN
+ *
+ * Limit: 20 req / 60 s (configurable via RATE_LIMIT_HEAVY_MAX / RATE_LIMIT_HEAVY_WINDOW_MS).
+ */
+export function heavyReadLimiter(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  done: () => void
+): void {
+  applyLimit(
+    request,
+    reply,
+    done,
+    "heavy-read",
+    HEAVY_WINDOW_MS,
+    HEAVY_MAX_REQUESTS
+  );
+}
+
+/**
+ * Write-endpoint rate limiter — apply to mutation routes.
+ *
+ * Affected routes:
+ *   POST /orders  — input validation, DB write, future matching-engine work
+ *
+ * Limit: 10 req / 60 s (configurable via RATE_LIMIT_WRITE_MAX / RATE_LIMIT_WRITE_WINDOW_MS).
+ */
+export function writeLimiter(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  done: () => void
+): void {
+  applyLimit(
+    request,
+    reply,
+    done,
+    "write",
+    WRITE_WINDOW_MS,
+    WRITE_MAX_REQUESTS
+  );
 }

--- a/src/api/routes/markets.ts
+++ b/src/api/routes/markets.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { getPrismaClient } from "../../services/prisma.js";
 import type { Market, MarketStatus } from "../../types/index.js";
+import { heavyReadLimiter } from "../middleware/rateLimiter.js";
 
 interface GetMarketsQueryParams {
   status?: MarketStatus;
@@ -14,9 +15,11 @@ interface GetMarketsResponse {
 export async function marketsRoutes(fastify: FastifyInstance) {
   const prisma = getPrismaClient();
 
+  // Heavy read: full-table scan with optional status filter — apply stricter limit.
   fastify.get<{ Querystring: GetMarketsQueryParams }>(
     "/markets",
     {
+      onRequest: [heavyReadLimiter],
       schema: {
         querystring: {
           type: "object",

--- a/src/api/routes/orders.ts
+++ b/src/api/routes/orders.ts
@@ -7,6 +7,10 @@ import {
   assertValidOrder,
   type OrderInput,
 } from "../../matching/validation.js";
+import {
+  heavyReadLimiter,
+  writeLimiter,
+} from "../middleware/rateLimiter.js";
 
 interface GetUserOrdersParams {
   address: string;
@@ -30,12 +34,14 @@ interface CreateOrderBody {
 export async function ordersRoutes(fastify: FastifyInstance) {
   const prisma = getPrismaClient();
 
+  // Heavy read: two DB queries (findMany + count) per request — apply stricter limit.
   fastify.get<{
     Params: GetUserOrdersParams;
     Querystring: GetUserOrdersQuery;
   }>(
     "/orders/user/:address",
     {
+      onRequest: [heavyReadLimiter],
       schema: {
         params: {
           type: "object",
@@ -137,10 +143,11 @@ export async function ordersRoutes(fastify: FastifyInstance) {
     }
   );
 
-  // POST /orders
+  // Write endpoint: validation + DB write + future matching-engine work — apply strictest limit.
   fastify.post<{ Body: CreateOrderBody }>(
     "/orders",
     {
+      onRequest: [writeLimiter],
       schema: {
         body: {
           type: "object",

--- a/src/api/routes/positions.ts
+++ b/src/api/routes/positions.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from "fastify";
 import { getPrismaClient } from "../../services/prisma.js";
 import { validateUserAddress } from "../../matching/validation.js";
 import { ValidationError } from "../middleware/errors.js";
+import { heavyReadLimiter } from "../middleware/rateLimiter.js";
 
 interface PositionResult {
   yesShares: number;
@@ -10,7 +11,8 @@ interface PositionResult {
 }
 
 export default async function positionsRouter(server: FastifyInstance) {
-  server.get("/positions/user/:address", async (request, reply) => {
+  // Heavy read: findMany with market JOIN — apply stricter limit.
+  server.get("/positions/user/:address", { onRequest: [heavyReadLimiter] }, async (request, reply) => {
     const { address } = request.params as { address: string };
     const prisma = getPrismaClient();
 


### PR DESCRIPTION
<html><head></head><body>
<h2>Issue #133 — Route-specific rate limits for heavy endpoints</h2>
<h3>What changed</h3>
<p><strong><code>src/api/middleware/rateLimiter.ts</code></strong> — refactored into three exported middleware functions:</p>

Middleware | Limit | Tier key
-- | -- | --
rateLimiter | 100 req / 60 s | global
heavyReadLimiter | 20 req / 60 s | heavy-read
writeLimiter | 10 req / 60 s | write


<p><strong><code>src/api/middleware/rateLimiter.test.ts</code></strong> — expanded with tests for all three tiers plus a tier-isolation suite that confirms counters don't bleed across tiers.</p>
<p><strong><code>.env.example</code></strong> — documents the six new env vars (<code>RATE_LIMIT_HEAVY_MAX</code>, <code>RATE_LIMIT_HEAVY_WINDOW_MS</code>, <code>RATE_LIMIT_WRITE_MAX</code>, <code>RATE_LIMIT_WRITE_WINDOW_MS</code>).</p>
<p><strong><code>docs/rate-limiting.md</code></strong> — new doc covering tier definitions, route classification rationale, response format, and integrator notes.</p>
</body></html>