### PR TITLE
drips

### DIFF
--- a/src/api/middleware/responses.test.ts
+++ b/src/api/middleware/responses.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Fastify, { FastifyInstance } from "fastify";
-import { unauthorized, forbidden } from "./responses.js";
+import { unauthorized, forbidden, success } from "./responses.js";
 
 describe("Auth response helpers", () => {
   let server: FastifyInstance;
@@ -11,6 +11,9 @@ describe("Auth response helpers", () => {
     server.get("/test-401-msg", async (_, reply) => { unauthorized(reply, "Token expired"); });
     server.get("/test-403", async (_, reply) => { forbidden(reply); });
     server.get("/test-403-msg", async (_, reply) => { forbidden(reply, "Admin only"); });
+    server.get("/test-200", async (_, reply) => {
+      success(reply, { message: "ok" });
+    });
   });
 
   afterEach(() => server.close());
@@ -47,5 +50,15 @@ describe("Auth response helpers", () => {
     const r401 = await server.inject({ method: "GET", url: "/test-401" });
     const r403 = await server.inject({ method: "GET", url: "/test-403" });
     expect(r401.statusCode).not.toBe(r403.statusCode);
+  });
+
+  it("success helper returns standardized success envelope", async () => {
+    const res = await server.inject({ method: "GET", url: "/test-200" });
+    const body = JSON.parse(res.body);
+    expect(res.statusCode).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      data: { message: "ok" },
+    });
   });
 });

--- a/src/api/middleware/responses.ts
+++ b/src/api/middleware/responses.ts
@@ -6,6 +6,19 @@ export interface AuthErrorResponse {
   statusCode: number;
 }
 
+export interface SuccessResponse<T> {
+  success: true;
+  data: T;
+}
+
+export function success<T>(reply: FastifyReply, data: T, statusCode = 200): void {
+  const body: SuccessResponse<T> = {
+    success: true,
+    data,
+  };
+  reply.status(statusCode).send(body);
+}
+
 export function unauthorized(reply: FastifyReply, message = "Unauthorized"): void {
   const body: AuthErrorResponse = {
     error: message,

--- a/src/api/routes/orders.test.ts
+++ b/src/api/routes/orders.test.ts
@@ -4,6 +4,10 @@ import { ordersRoutes } from "./orders.js";
 import { errorHandler } from "../middleware/errorHandler.js";
 import type { PrismaClient } from "../../generated/prisma/client";
 
+const mockAuditService = {
+  getWalletTradeHistory: vi.fn(),
+};
+
 const mockPrismaClient = {
   order: {
     findMany: vi.fn(),
@@ -18,6 +22,162 @@ const mockPrismaClient = {
 vi.mock("../../services/prisma.js", () => ({
   getPrismaClient: () => mockPrismaClient,
 }));
+
+vi.mock("../../services/audit.js", () => ({
+  auditService: mockAuditService,
+}));
+
+describe("GET /trades/user/:address", () => {
+  let app: FastifyInstance;
+  const validAddress =
+    "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    app.setErrorHandler(errorHandler);
+    await app.register(ordersRoutes);
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("should return wallet trades latest-first with pagination metadata", async () => {
+    (
+      mockAuditService.getWalletTradeHistory as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      trades: [
+        {
+          id: "1714170000002-0",
+          trade: {
+            id: "trade-2",
+            marketId: "market-2",
+            outcome: "NO",
+            buyerAddress: validAddress,
+            sellerAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            buyOrderId: "buy-2",
+            sellOrderId: "sell-2",
+            price: 0.67,
+            quantity: 12,
+            timestamp: 1714170000002,
+          },
+          loggedAt: "2026-04-27T14:00:02.000Z",
+        },
+        {
+          id: "1714170000001-0",
+          trade: {
+            id: "trade-1",
+            marketId: "market-1",
+            outcome: "YES",
+            buyerAddress: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+            sellerAddress: validAddress,
+            buyOrderId: "buy-1",
+            sellOrderId: "sell-1",
+            price: 0.51,
+            quantity: 20,
+            timestamp: 1714170000001,
+          },
+          loggedAt: "2026-04-27T14:00:01.000Z",
+        },
+      ],
+      total: 2,
+      hasNext: false,
+      page: 1,
+      limit: 20,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/trades/user/${validAddress}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.trades).toHaveLength(2);
+    expect(body.trades[0].id).toBe("trade-2");
+    expect(body.trades[0].marketId).toBe("market-2");
+    expect(body.trades[1].id).toBe("trade-1");
+    expect(body.total).toBe(2);
+    expect(body.hasNext).toBe(false);
+    expect(body.page).toBe(1);
+    expect(body.limit).toBe(20);
+  });
+
+  it("should pass pagination args to wallet trade history lookup", async () => {
+    (
+      mockAuditService.getWalletTradeHistory as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      trades: [],
+      total: 3,
+      hasNext: true,
+      page: 2,
+      limit: 1,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/trades/user/${validAddress}?page=2&limit=1`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mockAuditService.getWalletTradeHistory).toHaveBeenCalledWith(
+      validAddress,
+      2,
+      1,
+      undefined,
+      undefined
+    );
+  });
+
+  it("should pass from/to UTC filters to wallet trade history lookup", async () => {
+    (
+      mockAuditService.getWalletTradeHistory as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      trades: [],
+      total: 0,
+      hasNext: false,
+      page: 1,
+      limit: 20,
+    });
+
+    const from = "2026-04-27T00:00:00.000Z";
+    const to = "2026-04-27T23:59:59.999Z";
+    const response = await app.inject({
+      method: "GET",
+      url: `/trades/user/${validAddress}?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mockAuditService.getWalletTradeHistory).toHaveBeenCalledWith(
+      validAddress,
+      1,
+      20,
+      Date.parse(from),
+      Date.parse(to)
+    );
+  });
+
+  it("should return 400 when from is after to", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/trades/user/${validAddress}?from=2026-04-28T00:00:00.000Z&to=2026-04-27T00:00:00.000Z`,
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain("Invalid date range");
+  });
+
+  it("should return 400 for invalid wallet address", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/trades/user/not-a-wallet",
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});
 
 describe("GET /orders/user/:address", () => {
   let app: FastifyInstance;

--- a/src/api/routes/orders.ts
+++ b/src/api/routes/orders.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyRequest } from "fastify";
 import { getPrismaClient } from "../../services/prisma.js";
 import { ValidationError } from "../middleware/errors.js";
 import type { OrderSide, Outcome, OrderStatus } from "../../types/index.js";
+import { auditService } from "../../services/audit.js";
 import {
   validateUserAddress,
   assertValidOrder,
@@ -18,6 +19,13 @@ interface GetUserOrdersQuery {
   limit?: number;
 }
 
+interface GetWalletTradesQuery {
+  page?: number;
+  limit?: number;
+  from?: string;
+  to?: string;
+}
+
 interface CreateOrderBody {
   marketId: string;
   userAddress: string;
@@ -29,6 +37,115 @@ interface CreateOrderBody {
 
 export async function ordersRoutes(fastify: FastifyInstance) {
   const prisma = getPrismaClient();
+
+  fastify.get<{
+    Params: GetUserOrdersParams;
+    Querystring: GetWalletTradesQuery;
+  }>(
+    "/trades/user/:address",
+    {
+      schema: {
+        params: {
+          type: "object",
+          required: ["address"],
+          properties: {
+            address: { type: "string" },
+          },
+        },
+        querystring: {
+          type: "object",
+          properties: {
+            page: {
+              type: "integer",
+              minimum: 1,
+            },
+            limit: {
+              type: "integer",
+              minimum: 1,
+              maximum: 100,
+            },
+            from: {
+              type: "string",
+              format: "date-time",
+              description:
+                "Inclusive UTC start timestamp (ISO-8601), e.g. 2026-04-27T00:00:00.000Z",
+            },
+            to: {
+              type: "string",
+              format: "date-time",
+              description:
+                "Inclusive UTC end timestamp (ISO-8601), e.g. 2026-04-27T23:59:59.999Z",
+            },
+          },
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{
+        Params: GetUserOrdersParams;
+        Querystring: GetWalletTradesQuery;
+      }>
+    ) => {
+      const { address } = request.params;
+      const { page = 1, limit = 20, from, to } = request.query;
+
+      const addressError = validateUserAddress(address);
+      if (addressError) {
+        throw new ValidationError(addressError);
+      }
+
+      let fromMs: number | undefined;
+      let toMs: number | undefined;
+
+      if (from !== undefined) {
+        fromMs = Date.parse(from);
+        if (Number.isNaN(fromMs)) {
+          throw new ValidationError("from must be a valid UTC ISO-8601 timestamp");
+        }
+      }
+
+      if (to !== undefined) {
+        toMs = Date.parse(to);
+        if (Number.isNaN(toMs)) {
+          throw new ValidationError("to must be a valid UTC ISO-8601 timestamp");
+        }
+      }
+
+      if (fromMs !== undefined && toMs !== undefined && fromMs > toMs) {
+        throw new ValidationError(
+          "Invalid date range: from must be earlier than or equal to to"
+        );
+      }
+
+      const { trades, total, hasNext } = await auditService.getWalletTradeHistory(
+        address,
+        page,
+        limit,
+        fromMs,
+        toMs
+      );
+
+      return {
+        trades: trades.map((entry) => ({
+          id: entry.trade.id,
+          marketId: entry.trade.marketId,
+          outcome: entry.trade.outcome,
+          buyerAddress: entry.trade.buyerAddress,
+          sellerAddress: entry.trade.sellerAddress,
+          buyOrderId: entry.trade.buyOrderId,
+          sellOrderId: entry.trade.sellOrderId,
+          price: entry.trade.price,
+          quantity: entry.trade.quantity,
+          timestamp: entry.trade.timestamp,
+          loggedAt: entry.loggedAt,
+        })),
+        total,
+        hasNext,
+        page,
+        limit,
+      };
+    }
+  );
 
   fastify.get<{
     Params: GetUserOrdersParams;

--- a/src/api/routes/positions.test.ts
+++ b/src/api/routes/positions.test.ts
@@ -11,8 +11,12 @@ vi.mock("../../services/prisma", () => ({
           id: "test-pos-1",
           userAddress:
             "GBAHUIO7S6NXF2654321098765432109876543210987654321098765",
+          marketId: "market-1",
           yesShares: 50,
           noShares: 10,
+          lockedCollateral: { toString: () => "25.50000000" },
+          isSettled: false,
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
           market: {
             id: "market-1",
             question: "Will it rain?",
@@ -27,7 +31,8 @@ vi.mock("../../services/prisma", () => ({
 
 vi.mock("../../matching/validation", () => ({
   validateUserAddress: (addr: string) =>
-    /^G[A-Z0-9]{55}$/.test(addr) ? null : "Invalid Stellar address",
+    /^G[A-Z2-7]{55}$/.test(addr) ? null : "Invalid Stellar address",
+  STELLAR_PUBLIC_KEY_REGEX: /^G[A-Z2-7]{55}$/,
 }));
 
 describe("Positions Route", () => {
@@ -70,5 +75,58 @@ describe("Positions Route", () => {
     expect(body[0].potentialPayoutIfNo).toBe(10);
     expect(body[0].netPosition).toBe(40); // 50 - 10
     expect(body[0].market.question).toBe("Will it rain?");
+  });
+
+  it("should return wallet exposure rows with standardized success response", async () => {
+    const app = await createTestServer();
+    const wallet =
+      "GBAHUIO7S6NXF2654321098765432109876543210987654321098765";
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/wallets/${wallet}/positions`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.success).toBe(true);
+    expect(body.data.wallet).toBe(wallet);
+    expect(body.data.count).toBe(1);
+    expect(body.data.exposures[0]).toMatchObject({
+      marketId: "market-1",
+      marketQuestion: "Will it rain?",
+      yesShares: 50,
+      noShares: 10,
+      netExposure: 40,
+      lockedCollateral: "25.50000000",
+      isSettled: false,
+    });
+  });
+
+  it("should return 400 for invalid wallet identifier on wallet exposure endpoint", async () => {
+    const app = await createTestServer();
+    const response = await app.inject({
+      method: "GET",
+      url: "/wallets/0xInvalidAddress/positions",
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain("params/wallet");
+  });
+
+  it("should return 400 for wallet with non-Stellar base32 characters", async () => {
+    const app = await createTestServer();
+    const invalidWallet =
+      "G1BCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/wallets/${invalidWallet}/positions`,
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain("params/wallet");
   });
 });

--- a/src/api/routes/positions.ts
+++ b/src/api/routes/positions.ts
@@ -1,7 +1,11 @@
 import { FastifyInstance } from "fastify";
 import { getPrismaClient } from "../../services/prisma.js";
-import { validateUserAddress } from "../../matching/validation.js";
+import {
+  STELLAR_PUBLIC_KEY_REGEX,
+  validateUserAddress,
+} from "../../matching/validation.js";
 import { ValidationError } from "../middleware/errors.js";
+import { success } from "../middleware/responses.js";
 
 interface PositionResult {
   yesShares: number;
@@ -9,7 +13,79 @@ interface PositionResult {
   [key: string]: any;
 }
 
+interface WalletExposureRow {
+  marketId: string;
+  marketQuestion: string;
+  yesShares: number;
+  noShares: number;
+  netExposure: number;
+  lockedCollateral: string;
+  isSettled: boolean;
+  updatedAt: Date;
+}
+
 export default async function positionsRouter(server: FastifyInstance) {
+  server.get(
+    "/wallets/:wallet/positions",
+    {
+      schema: {
+        params: {
+          type: "object",
+          required: ["wallet"],
+          properties: {
+            wallet: {
+              type: "string",
+              pattern: STELLAR_PUBLIC_KEY_REGEX.source,
+              description:
+                "Stellar public key (StrKey): starts with G and is 56 chars using [A-Z2-7]",
+            },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+    const { wallet } = request.params as { wallet: string };
+    const prisma = getPrismaClient();
+
+    const addressError = validateUserAddress(wallet);
+    if (addressError) {
+      throw new ValidationError(addressError);
+    }
+
+    const positions = await prisma.userPosition.findMany({
+      where: { userAddress: wallet },
+      include: {
+        market: {
+          select: {
+            id: true,
+            question: true,
+          },
+        },
+      },
+      orderBy: {
+        updatedAt: "desc",
+      },
+    });
+
+    const exposures: WalletExposureRow[] = positions.map((position) => ({
+      marketId: position.market.id,
+      marketQuestion: position.market.question,
+      yesShares: position.yesShares,
+      noShares: position.noShares,
+      netExposure: position.yesShares - position.noShares,
+      lockedCollateral: position.lockedCollateral.toString(),
+      isSettled: position.isSettled,
+      updatedAt: position.updatedAt,
+    }));
+
+    success(reply, {
+      wallet,
+      exposures,
+      count: exposures.length,
+    });
+    }
+  );
+
   server.get("/positions/user/:address", async (request, reply) => {
     const { address } = request.params as { address: string };
     const prisma = getPrismaClient();

--- a/src/matching/validation.test.ts
+++ b/src/matching/validation.test.ts
@@ -71,6 +71,14 @@ describe("Order Validation", () => {
       expect(validateUserAddress("")).toBe("User address is required");
     });
 
+    it("should reject non-base32 characters in Stellar address", () => {
+      const invalidCharsetAddress =
+        "G1BCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+      expect(validateUserAddress(invalidCharsetAddress)).toBe(
+        "User address must be a valid Stellar public key (G + 55 base32 chars)"
+      );
+    });
+
     it("should reject null/undefined", () => {
       expect(validateUserAddress(null as unknown as string)).toBe(
         "User address must be a string"

--- a/src/matching/validation.ts
+++ b/src/matching/validation.ts
@@ -31,7 +31,10 @@ export class OrderValidationError extends ValidationError {
  * Validates a Stellar user address format
  * - Must be exactly 56 characters
  * - Must start with 'G' (Stellar public key prefix)
+ * - Remaining characters must be Stellar StrKey base32 charset [A-Z2-7]
  */
+export const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+
 export function validateUserAddress(address: string): string | null {
   if (typeof address !== "string") {
     return "User address must be a string";
@@ -47,6 +50,10 @@ export function validateUserAddress(address: string): string | null {
 
   if (!address.startsWith("G")) {
     return "User address must start with G";
+  }
+
+  if (!STELLAR_PUBLIC_KEY_REGEX.test(address)) {
+    return "User address must be a valid Stellar public key (G + 55 base32 chars)";
   }
 
   return null;

--- a/src/services/audit.ts
+++ b/src/services/audit.ts
@@ -189,6 +189,58 @@ export class AuditService {
   }
 
   /**
+   * Get paginated trade history for a wallet address across all markets.
+   * Ordering is deterministic and latest-first based on Redis stream IDs.
+   */
+  async getWalletTradeHistory(
+    wallet: string,
+    page: number = 1,
+    limit: number = 20,
+    fromMs?: number,
+    toMs?: number
+  ): Promise<{
+    trades: AuditLogEntry[];
+    total: number;
+    hasNext: boolean;
+    page: number;
+    limit: number;
+  }> {
+    const startId =
+      toMs !== undefined ? `${toMs}-${Number.MAX_SAFE_INTEGER}` : "+";
+    const endId = fromMs !== undefined ? `${fromMs}-0` : "-";
+
+    // Redis stream range query (xrevrange) uses stream IDs efficiently for time windows.
+    const entries = await redis.xrevrange(this.globalStream, startId, endId);
+    if (entries.length === 0) {
+      return {
+        trades: [],
+        total: 0,
+        hasNext: false,
+        page,
+        limit,
+      };
+    }
+
+    const walletTrades = entries
+      .map(([id, fields]) => this.parseStreamEntry(id, fields))
+      .filter(
+        (entry) =>
+          entry.trade.buyerAddress === wallet || entry.trade.sellerAddress === wallet
+      );
+
+    const skip = (page - 1) * limit;
+    const trades = walletTrades.slice(skip, skip + limit);
+
+    return {
+      trades,
+      total: walletTrades.length,
+      hasNext: skip + trades.length < walletTrades.length,
+      page,
+      limit,
+    };
+  }
+
+  /**
    * Get audit log entries within a time range
    *
    * @param marketId - Market ID to query


### PR DESCRIPTION
## Summary
- Add `GET /wallets/:wallet/positions` to return per-market wallet exposure rows (`marketId`, `marketQuestion`, shares, net exposure, collateral, settlement status, `updatedAt`) using a standardized success envelope.
- Add `GET /trades/user/:address` to return wallet trade history with deterministic latest-first ordering, market identifiers, and pagination metadata (`total`, `hasNext`, `page`, `limit`).
- Add wallet validation hardening for Stellar addresses (`G` + 55 chars in `[A-Z2-7]`) and support `from`/`to` UTC ISO-8601 filters for trade history with `400` on invalid date ranges.

## Why
- Provide portfolio visibility for decision-making via current exposure by market.
- Enable analytics/export workflows through wallet-level historical trade queries and time-window filtering.
- Reject malformed wallet/date inputs early to reduce unnecessary storage load and improve API safety.

## Test Plan
- [x] Added tests for wallet positions response shape and standardized success helper.
- [x] Added tests for wallet path validation failures (invalid format/non-base32).
- [x] Added tests for trade history ordering, pagination metadata, and `from`/`to` propagation.
- [x] Added test for invalid date range (`from > to`) returning `400`.

closes #97 
closes #98 
closes #99 
closes #100 
