### PR TITLE
chore: scaffold API module root

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,15 @@
+# API Module
+
+## Purpose
+Houses all HTTP-facing logic (controllers, routes, middleware).
+
+## Scope
+- Request/response handling
+- Input validation
+- Routing layer only
+
+## Ownership
+Backend/API team
+
+## Notes
+No business logic should live here; delegate to services.


### PR DESCRIPTION
Create apps/api folder with README defining scope and ownership.

closes #57