### PR TITLE
docs: add project map, scripts README, architecture doc, and workers …

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ docker compose up -d       # Start PostgreSQL + Redis
 docker compose down        # Stop containers
 ```
 
+## Project Map
+
+| Module | Directory | Purpose |
+|---|---|---|
+| **API** | [`src/`](src/) | Fastify HTTP server, CLOB matching engine, middleware |
+| **Indexer** | [`apps/indexer/`](apps/indexer/) | Polls Stellar for on-chain events and writes to PostgreSQL |
+| **Oracle** | [`apps/oracle/`](apps/oracle/) | Fetches external data, signs and submits resolution reports |
+| **Workers** | [`apps/workers/`](apps/workers/) | Queue consumers and scheduled jobs (settlement, expiry) |
+| **Shared DB** | [`packages/db/`](packages/db/) | Shared Prisma client and migration utilities |
+
+See [docs/architecture.md](docs/architecture.md) for service boundaries and data flow.
+
 ## Project Structure
 
 ```
@@ -94,9 +106,15 @@ scripts/
 ├── validate-migrations.ts  # Migration validation script
 └── generate-keypair.ts     # Stellar keypair generator
 
+apps/
+├── indexer/      # Stellar event indexer
+├── oracle/       # External data oracle
+└── workers/      # Queue consumers and scheduled jobs
+
 docs/
-├── testing.md    # Comprehensive testing guide
-└── migrations.md # Database migration guide
+├── architecture.md # Service boundaries and data flow
+├── testing.md      # Comprehensive testing guide
+└── migrations.md   # Database migration guide
 ```
 
 ## Environment Variables

--- a/apps/workers/README.md
+++ b/apps/workers/README.md
@@ -1,0 +1,40 @@
+# Workers
+
+Background execution module for queue consumers and scheduled jobs.
+
+Workers handle tasks that must run outside the HTTP request lifecycle: settlement sweeps, expiry processing, and any other async work enqueued by the API or Oracle.
+
+## Scope
+
+| Concern | Description |
+|---|---|
+| **Queue consumers** | Process jobs pushed to Redis by the API or Oracle (e.g. trade settlement) |
+| **Scheduled jobs** | Cron-style tasks such as market expiry sweeps and position reconciliation |
+
+## Status
+
+Module scaffolded. No queues or jobs are implemented yet.
+See [docs/architecture.md](../../docs/architecture.md) for how Workers fit into the overall system.
+
+## Structure (planned)
+
+```
+apps/workers/
+├── src/
+│   ├── consumers/   # One file per queue consumer
+│   ├── schedulers/  # Cron / interval jobs
+│   └── index.ts     # Entry point
+└── README.md
+```
+
+## Running
+
+```bash
+# Not yet available — implementation pending
+```
+
+## Adding a Worker
+
+1. Create a consumer in `src/consumers/<name>.ts` or a scheduler in `src/schedulers/<name>.ts`
+2. Register it in `src/index.ts`
+3. Document the queue name and payload shape in this README

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,72 @@
+# Architecture (Draft)
+
+> This is an early-stage draft. Details will evolve as the system matures.
+
+## System Overview
+
+Vatix Backend is a monorepo of services that together power the Vatix prediction market protocol on Stellar.
+
+```
+                        ┌─────────────┐
+  HTTP clients ────────▶│   API (src) │
+                        └──────┬──────┘
+                               │ reads/writes
+                        ┌──────▼──────┐
+                        │  PostgreSQL │◀──────────────────┐
+                        └──────▲──────┘                   │
+                               │ writes                   │ writes
+                        ┌──────┴──────┐          ┌────────┴───────┐
+                        │   Indexer   │          │    Workers     │
+                        │(apps/indexer│          │(apps/workers)  │
+                        └──────┬──────┘          └────────┬───────┘
+                               │ polls                    │ consumes
+                        ┌──────▼──────┐          ┌────────▼───────┐
+                        │  Stellar    │          │     Redis      │
+                        │  Network   │          │  (job queues)  │
+                        └─────────────┘          └────────────────┘
+                                                          ▲
+                        ┌─────────────┐                   │ enqueues
+                        │   Oracle   │───────────────────▶│
+                        │(apps/oracle)│
+                        └─────────────┘
+```
+
+## Service Boundaries
+
+| Module | Directory | Responsibility |
+|---|---|---|
+| **API** | `src/` | HTTP server (Fastify). Handles order placement, market queries, position reads. Owns the CLOB matching engine. |
+| **Indexer** | `apps/indexer/` | Polls Stellar network for on-chain events, parses them, and writes canonical records to PostgreSQL. |
+| **Oracle** | `apps/oracle/` | Fetches external price/resolution data, signs reports, and submits them on-chain via the Stellar SDK. |
+| **Workers** | `apps/workers/` | Queue consumers and scheduled jobs (e.g. settlement, expiry sweeps). Decoupled from the HTTP request lifecycle. |
+| **Shared DB** | `packages/db/` | Shared Prisma client and migration utilities used by all services. |
+
+## Major Data Flows
+
+### Order placement
+1. Client `POST /v1/orders` → API validates and writes order to PostgreSQL
+2. CLOB matching engine runs synchronously; fills are written in the same transaction
+3. Matched fills are enqueued to Redis for downstream settlement by Workers
+
+### Market resolution
+1. Oracle fetches external outcome data and signs a resolution report
+2. Oracle submits the report on-chain (Stellar)
+3. Indexer detects the on-chain event and writes a `ResolutionCandidate` to PostgreSQL
+4. Workers pick up the candidate, apply the challenge window, and settle positions
+
+### Indexer cursor
+- The Indexer stores a `ledger_cursor` in PostgreSQL (`IndexerCursor` table) to resume from the last processed ledger after restarts.
+
+## Open Decisions
+
+- [ ] **Queue technology**: Redis (BullMQ) is assumed for Workers but not yet implemented. Evaluate whether a managed queue (SQS, etc.) is preferable before first production deploy.
+- [ ] **Oracle multi-provider strategy**: `fallback-adapter.ts` exists but the failover policy (timeout, retry count) is not finalised.
+- [ ] **Monorepo build tooling**: Services currently share `tsconfig.json` at the root. Evaluate per-package tsconfigs as the repo grows.
+- [ ] **Authentication**: Admin routes use a static key guard (`adminGuard.ts`). A proper auth layer is needed before public launch.
+- [ ] **Workers deployment**: No Dockerfile or process manager config exists for Workers yet.
+
+## Assumptions
+
+- All services share a single PostgreSQL instance (separate schemas are not used)
+- Redis is used exclusively for caching and job queues (no persistence guarantees relied upon)
+- Stellar Horizon is the only chain data source; no EVM chains are in scope

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,35 @@
+# Scripts
+
+Dev utilities for bootstrapping, database management, and maintenance tasks.
+
+## Conventions
+
+- Scripts are TypeScript, executed via `tsx` (no compile step needed)
+- Add new scripts here rather than documenting one-off shell commands in chat
+- Prefer shell-agnostic implementations; avoid bash-only syntax
+- Scripts must be safe to run locally and in CI
+
+## Execution
+
+Run any script with:
+
+```bash
+npx tsx scripts/<script-name>.ts
+# or via pnpm if a package.json script alias exists
+pnpm <alias>
+```
+
+Scripts that require environment variables will fail fast with a clear error if they are missing. Copy `.env.example` to `.env` before running locally.
+
+## Available Scripts
+
+| Script | pnpm alias | Purpose |
+|---|---|---|
+| `generate-keypair.ts` | `pnpm generate:keypair` | Generate a Stellar keypair for oracle signing |
+| `validate-migrations.ts` | `pnpm prisma:validate` | Validate Prisma migration files against the schema |
+
+## Adding a Script
+
+1. Create `scripts/<your-script>.ts`
+2. Add a `pnpm` alias in `package.json` under `scripts` if it will be run frequently
+3. Add a row to the table above


### PR DESCRIPTION
…module

This commit resolves 4 orientation issues for new contributors.

---

Issue 1 — Add Project Map to root README
- The root README already contained a Project Map table (API, Indexer, Oracle, Workers, Shared DB) with one-line purpose descriptions and links to each module directory.
- Updated the Project Structure code block to include apps/workers/ and docs/architecture.md so the directory tree matches the actual repo.
- The section links to docs/architecture.md for deeper reading. Closes #1
Closes #62 
---

Issue 2 — Add scripts/README.md
- Created scripts/README.md documenting the conventions for all scripts in the scripts/ directory.
- Explains how to execute scripts via 'npx tsx' or pnpm aliases.
- Lists the two existing scripts (generate-keypair.ts, validate-migrations.ts) with their pnpm aliases and purpose.
- Includes a guide for adding new scripts. Closes #2
Closes #64 
---

Issue 3 — Create docs/architecture.md
- Created docs/architecture.md as a clearly labelled draft.
- Contains an ASCII diagram showing data flow between API, Indexer, Oracle, Workers, PostgreSQL, Redis, and the Stellar network.
- Defines service boundaries for all 5 modules in a table.
- Documents the three major data flows: order placement, market resolution, and indexer cursor management.
- Lists open decisions (queue technology, oracle failover policy, monorepo build tooling, authentication, workers deployment).
- Lists key assumptions (single PostgreSQL instance, Redis for queues only, Stellar Horizon as sole chain source). Closes #3
closes #63 
---

Issue 4 — Create apps/workers module
- Created apps/workers/README.md defining the scope of the Workers module: queue consumers and scheduled jobs.
- Documents the planned directory structure (src/consumers/, src/schedulers/, src/index.ts).
- Clearly states that no queues are implemented yet (module scaffold only).
- Links back to docs/architecture.md to show how Workers fits into the overall system. Closes #4
closes #61 