### PR TITLE
feat(db): add resolutions table migration for market settlement

### DIFF
--- a/RESOLUTION_MIGRATION_SUMMARY.md
+++ b/RESOLUTION_MIGRATION_SUMMARY.md
@@ -1,0 +1,194 @@
+# Resolution Migration - Implementation Summary
+
+## Assignment Completed ✓
+
+A migration for the `resolutions` table has been created to support finalized market resolutions for settlement and portfolio closeout.
+
+---
+
+## Files Created/Modified
+
+### 1. Migration File
+**Location**: `prisma/migrations/20260428000000_add_resolutions_table/migration.sql`
+
+**Contains**:
+- ✓ `ResolutionStatus` enum with values: `ACTIVE`, `CORRECTED`, `OVERRIDDEN`
+- ✓ `resolutions` table with:
+  - `id` (TEXT, PRIMARY KEY, UUID)
+  - `market_id` (TEXT, FOREIGN KEY → markets.id with CASCADE delete)
+  - `outcome` (BOOLEAN) - YES (true) or NO (false)
+  - `finalized_at` (TIMESTAMP) - When resolution was finalized
+  - `provenance` (TEXT) - Source attribution (e.g., CHAINLINK, PYTH, MANUAL)
+  - `status` (ResolutionStatus) - Tracks state transitions
+  - `correction_override_metadata` (JSONB) - Audit trail for corrections/overrides
+  - `created_at` (TIMESTAMP)
+  - `updated_at` (TIMESTAMP)
+- ✓ Enforces one ACTIVE resolution per market via partial unique index
+- ✓ 6 strategic indexes for query optimization
+
+### 2. Schema File
+**Location**: `prisma/schema.prisma`
+
+**Changes**:
+- ✓ Added `ResolutionStatus` enum (ACTIVE, CORRECTED, OVERRIDDEN)
+- ✓ Added `Resolution` model with:
+  - All required fields and relationships
+  - Unique constraint on `(marketId, ACTIVE status)`
+  - Proper field mappings to database column names
+  - Comprehensive indexes for performance
+  - Relationship to `Market` model with cascade delete
+- ✓ Updated `Market` model to include `resolutions` relationship
+
+### 3. Testing Guide
+**Location**: `RESOLUTION_MIGRATION_TESTING.md`
+
+**Includes**:
+- Migration overview and acceptance criteria verification
+- Step-by-step testing procedures
+- SQL verification queries
+- TypeScript/Prisma ORM usage examples
+- Rollback plan
+- Success criteria checklist
+
+---
+
+## Acceptance Criteria Met
+
+| Criterion | Status | Details |
+|-----------|--------|---------|
+| Resolution table keyed by market ID | ✓ | Primary key is UUID `id`, foreign key relationship with `Markets` |
+| Includes outcome field | ✓ | Boolean field: `true` = YES, `false` = NO |
+| Includes finalized_at field | ✓ | TIMESTAMP field for settlement cutoff |
+| Includes provenance field | ✓ | TEXT field for source attribution |
+| Enforces one active final resolution per market | ✓ | Partial unique index: `resolutions_market_id_active_idx` where status = 'ACTIVE' |
+| Correction/override metadata strategy | ✓ | JSONB field `correction_override_metadata` with ResolutionStatus enum (ACTIVE, CORRECTED, OVERRIDDEN) |
+
+---
+
+## Key Features
+
+### 1. Data Integrity
+- Foreign key constraint with cascade delete for data consistency
+- Unique partial index prevents multiple active resolutions per market
+- NOT NULL constraints on critical fields
+
+### 2. Audit Trail
+- `correctionOverrideMetadata` JSONB field tracks:
+  - When correction occurred
+  - Previous outcome value
+  - Reason for correction/override
+  - Who made the change
+- Status transitions (ACTIVE → CORRECTED/OVERRIDDEN)
+
+### 3. Performance
+- Market lookups: `resolutions_market_id_idx`
+- Status filtering: `resolutions_status_idx`
+- Temporal queries: `resolutions_finalized_at_idx`
+- Compound queries: `resolutions_market_id_status_idx`
+- Pagination: `resolutions_created_at_idx` (DESC)
+
+### 4. Settlement Support
+- `finalizedAt` timestamp for settlement window enforcement
+- `outcome` boolean for payout calculations
+- `status` field distinguishes between active and historical resolutions
+- Cascade delete ensures referential integrity when markets are archived
+
+---
+
+## How to Apply the Migration
+
+### Development
+```bash
+cd /workspaces/vatix-backend
+pnpm prisma:migrate dev --name "verify resolutions migration"
+```
+
+### Production
+```bash
+pnpm prisma:deploy
+```
+
+### Validation
+```bash
+pnpm prisma:generate  # Regenerate Prisma client
+pnpm test             # Run test suite
+```
+
+---
+
+## How to Verify Completion
+
+### 1. Check Migration Applied
+```sql
+SELECT * FROM "_prisma_migrations"
+WHERE migration = '20260428000000_add_resolutions_table';
+```
+
+### 2. Verify Table Structure
+```sql
+\d resolutions
+```
+
+### 3. Test One-Active-Per-Market Constraint
+```sql
+-- Insert first resolution (should succeed)
+INSERT INTO resolutions (id, market_id, outcome, finalized_at, provenance, status)
+VALUES ('res-1', 'market-1', true, NOW(), 'TEST', 'ACTIVE');
+
+-- Try inserting second ACTIVE resolution (should fail)
+INSERT INTO resolutions (id, market_id, outcome, finalized_at, provenance, status)
+VALUES ('res-2', 'market-1', false, NOW(), 'TEST', 'ACTIVE');
+-- Expected: Error: duplicate key violates unique constraint
+
+-- Insert with different status (should succeed)
+INSERT INTO resolutions (id, market_id, outcome, finalized_at, provenance, status)
+VALUES ('res-2', 'market-1', false, NOW(), 'TEST', 'CORRECTED');
+```
+
+### 4. Test Prisma ORM Integration
+```typescript
+import { prisma } from '@/services/prisma';
+
+// Query should work
+const activeResolution = await prisma.resolution.findFirst({
+  where: { status: 'ACTIVE' },
+});
+
+console.log('✓ Prisma client can access Resolution model');
+```
+
+---
+
+## Architecture Notes
+
+### Resolution Lifecycle
+1. **ACTIVE**: Current final resolution for the market
+2. **CORRECTED**: Previous ACTIVE resolution that was corrected (new one becomes ACTIVE)
+3. **OVERRIDDEN**: Previous ACTIVE resolution that was overridden (new one becomes ACTIVE)
+
+### Correction Strategy
+When a resolution needs to be corrected:
+1. Update existing ACTIVE resolution to CORRECTED/OVERRIDDEN status
+2. Store previous state in `correctionOverrideMetadata`
+3. Create new ACTIVE resolution with updated outcome
+4. Partial unique index prevents simultaneous active resolutions
+
+### Settlement Workflow
+1. Market reaches `endTime`
+2. Resolution consensus established (via resolution candidates)
+3. Final resolution created with `outcome` and `finalizedAt`
+4. Settlement engine uses `finalizedAt` for cutoff
+5. Portfolio closeout completed
+6. Historical resolutions preserved for audit
+
+---
+
+## Files to Review
+
+- [Migration SQL](prisma/migrations/20260428000000_add_resolutions_table/migration.sql)
+- [Schema Changes](prisma/schema.prisma) - Lines 43-47 (enum) and 168-188 (model)
+- [Testing Guide](RESOLUTION_MIGRATION_TESTING.md)
+
+---
+
+**Status**: ✅ COMPLETE - Ready for testing and deployment

--- a/RESOLUTION_MIGRATION_TESTING.md
+++ b/RESOLUTION_MIGRATION_TESTING.md
@@ -1,0 +1,297 @@
+# Resolutions Table Migration - Testing & Verification Guide
+
+## Overview
+This migration adds the `resolutions` table to support finalized market resolutions. The table includes:
+- **Market ID keying**: Each resolution is linked to a market
+- **One active resolution per market**: Enforced via partial unique index on `market_id` WHERE `status = 'ACTIVE'`
+- **Outcome tracking**: Boolean field for YES/NO resolution
+- **Finalized timestamp**: When the resolution became final
+- **Provenance**: Source attribution (oracle, manual, override, etc.)
+- **Correction/Override metadata**: JSONB field for tracking historical corrections and overrides
+
+## Migration Details
+
+**Migration Name**: `20260428000000_add_resolutions_table`  
+**Location**: `prisma/migrations/20260428000000_add_resolutions_table/migration.sql`
+
+### Schema Changes
+
+#### New Enum: ResolutionStatus
+```
+ACTIVE       - Current active resolution
+CORRECTED    - Resolution that has been corrected (new one is ACTIVE)
+OVERRIDDEN   - Resolution that was overridden (new one is ACTIVE)
+```
+
+#### New Table: resolutions
+```sql
+CREATE TABLE "resolutions" (
+    "id" TEXT PRIMARY KEY,
+    "market_id" TEXT NOT NULL,           -- References markets.id (CASCADE delete)
+    "outcome" BOOLEAN NOT NULL,          -- YES (true) or NO (false)
+    "finalized_at" TIMESTAMP NOT NULL,   -- When resolution finalized
+    "provenance" TEXT NOT NULL,          -- Source (CHAINLINK, PYTH, MANUAL, etc.)
+    "status" ResolutionStatus DEFAULT 'ACTIVE',
+    "correction_override_metadata" JSONB, -- Correction/override history
+    "created_at" TIMESTAMP,
+    "updated_at" TIMESTAMP
+);
+```
+
+#### Indexes Created
+- `resolutions_market_id_active_idx` (unique, partial) - Enforces one ACTIVE resolution per market
+- `resolutions_market_id_idx` - Fast lookups by market
+- `resolutions_status_idx` - Filter by resolution status
+- `resolutions_finalized_at_idx` - Temporal queries
+- `resolutions_market_id_status_idx` - Compound filtering
+- `resolutions_created_at_idx` - Pagination/ordering
+
+## Testing Steps
+
+### 1. Apply Migration
+```bash
+# Development environment
+pnpm prisma:migrate dev --name "verify resolutions migration"
+
+# Production environment
+pnpm prisma:deploy
+```
+
+### 2. Verify Schema in Database
+```bash
+# Connect to database and check table structure
+pnpm prisma:studio
+
+# Or use SQL directly
+psql $DATABASE_URL -c "\d resolutions"
+```
+
+Expected output should show all columns with correct types.
+
+### 3. Test Acceptance Criteria
+
+#### A. Resolution Keyed by Market ID
+```sql
+-- Insert a market first
+INSERT INTO markets (id, question, end_time, resolution_time, oracle_address, status)
+VALUES (
+  'test-market-1',
+  'Will Bitcoin reach $100k?',
+  NOW() + INTERVAL '30 days',
+  NOW() + INTERVAL '31 days',
+  'GBXYZ...',
+  'ACTIVE'
+);
+
+-- Insert a resolution
+INSERT INTO resolutions (id, market_id, outcome, finalized_at, provenance, status)
+VALUES (
+  'res-1',
+  'test-market-1',
+  true,
+  NOW(),
+  'CHAINLINK',
+  'ACTIVE'
+);
+
+-- Verify retrieval by market_id
+SELECT * FROM resolutions WHERE market_id = 'test-market-1';
+```
+
+#### B. Outcome, Finalized At, and Provenance Fields
+```sql
+-- Verify all fields are populated correctly
+SELECT id, market_id, outcome, finalized_at, provenance, status
+FROM resolutions
+WHERE market_id = 'test-market-1';
+
+-- Expected: outcome=true, finalized_at=<timestamp>, provenance='CHAINLINK', status='ACTIVE'
+```
+
+#### C. One Active Resolution Per Market (Constraint)
+```sql
+-- This should FAIL (unique constraint violation)
+INSERT INTO resolutions (id, market_id, outcome, finalized_at, provenance, status)
+VALUES (
+  'res-2',
+  'test-market-1',
+  false,
+  NOW(),
+  'MANUAL',
+  'ACTIVE'
+);
+
+-- Expected Error: duplicate key value violates unique constraint "resolutions_market_id_active_idx"
+
+-- This should SUCCEED (different status)
+INSERT INTO resolutions (id, market_id, outcome, finalized_at, provenance, status)
+VALUES (
+  'res-2',
+  'test-market-1',
+  false,
+  NOW(),
+  'MANUAL',
+  'CORRECTED'
+);
+
+-- Verify only one ACTIVE per market
+SELECT status, COUNT(*) FROM resolutions GROUP BY market_id, status HAVING COUNT(*) > 1;
+-- Expected: (empty result)
+```
+
+#### D. Correction/Override Metadata Strategy
+```sql
+-- Test with correction metadata
+UPDATE resolutions
+SET status = 'CORRECTED',
+    correction_override_metadata = jsonb_build_object(
+      'corrected_at', NOW()::text,
+      'previous_outcome', false,
+      'reason', 'Data validation error in oracle source',
+      'corrected_by', 'oracle-ops'
+    )
+WHERE id = 'res-1';
+
+-- Verify metadata was stored
+SELECT id, status, correction_override_metadata
+FROM resolutions
+WHERE id = 'res-1';
+
+-- Example metadata structure
+-- {
+--   "corrected_at": "2026-04-28T14:30:00Z",
+--   "previous_outcome": false,
+--   "reason": "Data validation error in oracle source",
+--   "corrected_by": "oracle-ops"
+-- }
+```
+
+### 4. Integration with Prisma ORM
+
+#### Generate Prisma Client
+```bash
+pnpm prisma:generate
+```
+
+#### Usage Example (TypeScript)
+```typescript
+import { prisma } from '@/services/prisma';
+
+// Create a resolution
+const resolution = await prisma.resolution.create({
+  data: {
+    marketId: 'market-123',
+    outcome: true,
+    finalizedAt: new Date(),
+    provenance: 'CHAINLINK',
+    status: 'ACTIVE',
+  },
+});
+
+// Query active resolutions
+const activeResolutions = await prisma.resolution.findMany({
+  where: { status: 'ACTIVE' },
+  include: { market: true },
+});
+
+// Get resolution for specific market
+const marketResolution = await prisma.resolution.findUniqueOrThrow({
+  where: {
+    marketId_status: {
+      marketId: 'market-123',
+      status: 'ACTIVE',
+    },
+  },
+});
+
+// Update resolution to corrected with metadata
+const corrected = await prisma.resolution.update({
+  where: { id: 'res-123' },
+  data: {
+    status: 'CORRECTED',
+    correctionOverrideMetadata: {
+      corrected_at: new Date().toISOString(),
+      previous_outcome: false,
+      reason: 'Oracle data validation issue',
+    },
+  },
+});
+```
+
+### 5. Run Full Test Suite
+```bash
+# Run all tests including integration tests
+pnpm test
+
+# Run specific test file
+pnpm test tests/integration/
+
+# Check test coverage
+pnpm test:coverage
+```
+
+## Verification Queries
+
+### Check Migration Applied
+```sql
+SELECT * FROM "_prisma_migrations"
+WHERE migration = '20260428000000_add_resolutions_table'
+ORDER BY finished_at DESC LIMIT 1;
+```
+
+### View Table Structure
+```sql
+\d resolutions
+```
+
+### Verify Indexes
+```sql
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'resolutions';
+```
+
+### Test Constraint
+```sql
+-- Count ACTIVE resolutions per market (should be 0 or 1 for each)
+SELECT market_id, COUNT(*) as active_count
+FROM resolutions
+WHERE status = 'ACTIVE'
+GROUP BY market_id
+HAVING COUNT(*) > 1;
+-- Expected: (empty result - no violations)
+```
+
+## Rollback Plan
+
+If you need to rollback this migration:
+
+```bash
+# Development environment
+pnpm prisma:migrate resolve --rolled-back 20260428000000_add_resolutions_table
+
+# Production environment
+pnpm prisma:migrate resolve --rolled-back 20260428000000_add_resolutions_table --skip-generate
+```
+
+Manual SQL rollback (if needed):
+```sql
+DROP TABLE IF EXISTS resolutions CASCADE;
+DROP TYPE IF EXISTS "ResolutionStatus";
+```
+
+## Notes
+
+1. **Cascade Deletes**: When a market is deleted, all associated resolutions are automatically deleted
+2. **Corrected/Overridden Tracking**: Use `correctionOverrideMetadata` JSONB field to maintain audit trail
+3. **Partial Unique Index**: Only `ACTIVE` resolutions are enforced as unique per market, allowing historical tracking
+4. **Sentinel Provenance Values**: Use standardized provenance values (e.g., 'CHAINLINK', 'PYTH', 'MANUAL', 'OVERRIDE', 'API3', 'UMA')
+
+## Success Criteria
+✅ Migration applies without errors  
+✅ Table structure matches schema  
+✅ One ACTIVE resolution per market constraint enforced  
+✅ Correction metadata is stored and retrievable  
+✅ Foreign key cascades work correctly  
+✅ All indexes created successfully  
+✅ Prisma ORM client generates successfully  

--- a/prisma/migrations/20260428000000_add_resolutions_table/migration.sql
+++ b/prisma/migrations/20260428000000_add_resolutions_table/migration.sql
@@ -1,0 +1,42 @@
+-- Create resolutions table for finalized market resolutions
+-- Keyed by market ID with enforcement of one active final resolution per market
+-- Includes outcome, finalized_at, and provenance (source attribution) fields
+-- correction_override_metadata captures history of corrections and overrides
+
+-- CreateEnum for resolution status states
+CREATE TYPE "ResolutionStatus" AS ENUM ('ACTIVE', 'CORRECTED', 'OVERRIDDEN');
+
+-- CreateTable: market resolutions
+CREATE TABLE "resolutions" (
+    "id" TEXT NOT NULL,
+    "market_id" TEXT NOT NULL,
+    "outcome" BOOLEAN NOT NULL,
+    "finalized_at" TIMESTAMP(3) NOT NULL,
+    "provenance" TEXT NOT NULL,
+    "status" "ResolutionStatus" NOT NULL DEFAULT 'ACTIVE',
+    "correction_override_metadata" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "resolutions_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "resolutions_market_id_fkey" FOREIGN KEY ("market_id") REFERENCES "markets"("id") ON DELETE CASCADE
+);
+
+-- Enforce one active final resolution per market
+-- Partial unique index on market_id where status = 'ACTIVE'
+CREATE UNIQUE INDEX "resolutions_market_id_active_idx" ON "resolutions"("market_id") WHERE "status" = 'ACTIVE';
+
+-- CreateIndex for efficient lookups by market
+CREATE INDEX "resolutions_market_id_idx" ON "resolutions"("market_id");
+
+-- CreateIndex for querying by status
+CREATE INDEX "resolutions_status_idx" ON "resolutions"("status");
+
+-- CreateIndex for temporal queries
+CREATE INDEX "resolutions_finalized_at_idx" ON "resolutions"("finalized_at");
+
+-- CreateIndex for compound lookups
+CREATE INDEX "resolutions_market_id_status_idx" ON "resolutions"("market_id", "status");
+
+-- CreateIndex for efficient ordering/pagination
+CREATE INDEX "resolutions_created_at_idx" ON "resolutions"("created_at" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,12 @@ enum ResolutionCandidateStatus {
   REJECTED
 }
 
+enum ResolutionStatus {
+  ACTIVE
+  CORRECTED
+  OVERRIDDEN
+}
+
 model Market {
   id             String       @id @default(uuid())
   question       String
@@ -58,6 +64,7 @@ model Market {
   positions            UserPosition[]
   oracleReports        OracleReport[]
   resolutionCandidates ResolutionCandidate[]
+  resolutions          Resolution[]
 
   @@index([status])
   @@index([endTime])
@@ -143,4 +150,28 @@ model ResolutionCandidate {
   @@index([status])
   @@index([marketId, status])
   @@map("resolution_candidates")
+}
+
+model Resolution {
+  id                           String           @id @default(uuid())
+  marketId                     String           @map("market_id")
+  outcome                      Boolean
+  finalizedAt                  DateTime         @map("finalized_at")
+  provenance                   String
+  status                       ResolutionStatus @default(ACTIVE)
+  /// JSONB field tracking correction and override history
+  /// Example: { "corrected_at": "2026-04-28T00:00:00Z", "previous_outcome": false, "reason": "..." }
+  correctionOverrideMetadata   Json?            @map("correction_override_metadata")
+  createdAt                    DateTime         @default(now()) @map("created_at")
+  updatedAt                    DateTime         @default(now()) @updatedAt @map("updated_at")
+
+  market Market @relation(fields: [marketId], references: [id], onDelete: Cascade)
+
+  @@unique([marketId], where: { status : ACTIVE })
+  @@index([marketId])
+  @@index([status])
+  @@index([finalizedAt])
+  @@index([marketId, status])
+  @@index([createdAt(sort: Desc)])
+  @@map("resolutions")
 }


### PR DESCRIPTION
Close #143 


## 📋 PULL REQUEST DOCUMENT


# Add Migration: Resolutions Table for Finalized Market Resolutions

## Description

Create database schema migration for finalized market resolutions to support settlement and portfolio closeout workflows. The migration introduces a `resolutions` table with comprehensive tracking of resolution state, outcome, and correction/override metadata.

## Type of Change

- [x] Database migration (new table)
- [x] Schema update (new enum and model)
- [ ] Breaking change
- [ ] New feature
- [ ] Bug fix




**New Enum**: `ResolutionStatus`
- `ACTIVE` - Current final resolution for market
- `CORRECTED` - Previous resolution that was corrected
- `OVERRIDDEN` - Previous resolution that was overridden

**New Table**: `resolutions`
- `id` (UUID, PRIMARY KEY)
- `market_id` (TEXT, FOREIGN KEY → markets.id, CASCADE)
- `outcome` (BOOLEAN) - YES (true) or NO (false)
- `finalized_at` (TIMESTAMP) - When resolution finalized
- `provenance` (TEXT) - Source: CHAINLINK, PYTH, MANUAL, etc.
- `status` (ResolutionStatus) - State: ACTIVE, CORRECTED, OVERRIDDEN
- `correction_override_metadata` (JSONB) - Audit trail
- `created_at`, `updated_at` (TIMESTAMP)

### Key Features

1. **Data Integrity**
   - Foreign key constraint with cascade delete
   - Partial unique index on `(market_id)` WHERE `status = 'ACTIVE'`
   - Enforces maximum one active resolution per market

2. **Audit Trail**
   - `correctionOverrideMetadata` JSONB field tracks:
     - Correction timestamp
     - Previous outcome
     - Reason for change
     - Who made the change

3. **Performance**
   - 6 strategic indexes for efficient queries:
     - `resolutions_market_id_active_idx` (partial unique)
     - `resolutions_market_id_idx`
     - `resolutions_status_idx`
     - `resolutions_finalized_at_idx`
     - `resolutions_market_id_status_idx`
     - `resolutions_created_at_idx` (DESC)

4. **Settlement Support**
   - Precise `finalizedAt` timestamp for settlement window
   - Cascade deletes ensure referential integrity

### Schema Changes

**File**: `prisma/schema.prisma`
- Added `ResolutionStatus` enum (ACTIVE, CORRECTED, OVERRIDDEN)
- Added `Resolution` model with complete field mappings
- Updated `Market` model with `resolutions` relationship

**File**: `prisma/migrations/20260428000000_add_resolutions_table/migration.sql`
- DDL for `resolutions` table creation
- Enum type definition
- Index creation with strategic coverage

## How to Test

### Apply Migration
```bash
pnpm prisma:migrate dev --name "verify resolutions migration"
pnpm prisma:generate
```

### Verify One-Active-Per-Market Constraint
```sql
-- Should succeed
INSERT INTO resolutions (id, market_id, outcome, finalized_at, provenance, status)
VALUES ('res-1', 'market-1', true, NOW(), 'TEST', 'ACTIVE');

-- Should fail (duplicate ACTIVE)
INSERT INTO resolutions (id, market_id, outcome, finalized_at, provenance, status)
VALUES ('res-2', 'market-1', false, NOW(), 'TEST', 'ACTIVE');

-- Should succeed (different status)
INSERT INTO resolutions (id, market_id, outcome, finalized_at, provenance, status)
VALUES ('res-2', 'market-1', false, NOW(), 'TEST', 'CORRECTED');
```

### Verify with Prisma ORM
```typescript
import { prisma } from '@/services/prisma';

const activeResolution = await prisma.resolution.findFirst({
  where: { status: 'ACTIVE' },
});
```

### Run Test Suite
```bash
pnpm test
```

## Checklist

- [x] Migration file created with proper naming convention
- [x] Schema updated with Resolution model and ResolutionStatus enum
- [x] Foreign key relationships configured with CASCADE delete
- [x] Partial unique index enforces one ACTIVE per market
- [x] Indexes created for optimal query performance
- [x] Documentation provided (testing guide, summary)
- [x] Meets all acceptance criteria
- [x] Follows project conventions and patterns

## Rollback Plan

If rollback is needed:

```bash
# Development
pnpm prisma:migrate resolve --rolled-back 20260428000000_add_resolutions_table

# Manual SQL (if needed)
DROP TABLE IF EXISTS resolutions CASCADE;
DROP TYPE IF EXISTS "ResolutionStatus";
```

## Additional Notes

- The migration uses PostgreSQL partial unique indexes, ensuring compatibility with the project's tech stack
- JSONB field allows flexible schema for correction metadata without schema migrations
- Cascade delete from markets ensures data integrity during market archival
- Status enum approach enables clean state machine for resolution lifecycle

---

## Files Changed

- migration.sql (new)
- schema.prisma (updated: added enum and model)
```

---

## Changes

- Create 'resolutions' table keyed by market ID with foreign key relationship
- Add ResolutionStatus enum: ACTIVE, CORRECTED, OVERRIDDEN
- Enforce one active final resolution per market via partial unique index
- Include outcome (boolean YES/NO) field for settlement payout
- Include finalized_at timestamp for settlement window enforcement
- Include provenance field for source attribution (oracle type)
- Include correction_override_metadata JSONB for audit trail tracking

## Acceptance Criteria

- [x] Resolution table keyed by market ID
- [x] Includes outcome, finalized_at, and provenance fields
- [x] Enforces one active final resolution per market
- [x] Includes correction/override metadata strategy

## Technical Details

- Migration: 20260428000000_add_resolutions_table
- Partial unique index: resolutions_market_id_active_idx (status='ACTIVE')
- 6 strategic indexes for query optimization
- Foreign key with CASCADE delete for referential integrity
- JSONB field for flexible correction/override history

## Testing

- Verify one ACTIVE resolution per market constraint
- Test correction_override_metadata JSONB storage
- Regenerate Prisma client with updated schema
- Run full test suite
