### PR TITLE
chore: add tmp/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ yarn.lock
 # Test coverage
 coverage/
 
+# Temporary files
+/tmp/
+
 #Issues descriptions
 vrickish_issues.md


### PR DESCRIPTION
Adds `/tmp/` to `.gitignore` to prevent temporary files generated during local development and debugging from being tracked.\n\nCloses #65