### PR TITLE
feat: add shared typed config loader

### DIFF
--- a/apps/indexer/src/config.ts
+++ b/apps/indexer/src/config.ts
@@ -1,0 +1,10 @@
+/**
+ * Indexer config — thin wrapper around the shared typed config loader.
+ */
+import { loadConfig as loadSharedConfig } from "../../../packages/shared/src/config.js";
+
+export type { AppConfig as IndexerConfig } from "../../../packages/shared/src/config.js";
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env) {
+  return loadSharedConfig(env).indexer;
+}

--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { loadConfig, getConfig, resetConfig } from "./config.js";
+
+const BASE_ENV: NodeJS.ProcessEnv = {
+  DATABASE_URL: "postgresql://postgres:postgres@localhost:5433/vatix",
+  ORACLE_SECRET_KEY: "SABC123",
+};
+
+describe("loadConfig", () => {
+  it("returns defaults for optional vars", () => {
+    const cfg = loadConfig(BASE_ENV);
+    expect(cfg.server.port).toBe(3000);
+    expect(cfg.server.nodeEnv).toBe("development");
+    expect(cfg.redis.url).toBe("redis://localhost:6379");
+    expect(cfg.stellar.network).toBe("testnet");
+    expect(cfg.oracle.challengeWindowSeconds).toBe(86400);
+    expect(cfg.rateLimit.max).toBe(100);
+    expect(cfg.indexer.logLevel).toBe("info");
+    expect(cfg.indexer.networkId).toBe("mainnet");
+  });
+
+  it("reads overridden values from env", () => {
+    const cfg = loadConfig({
+      ...BASE_ENV,
+      PORT: "4000",
+      NODE_ENV: "production",
+      REDIS_URL: "redis://redis:6380",
+      ORACLE_CHALLENGE_WINDOW_SECONDS: "3600",
+      RATE_LIMIT_MAX: "50",
+      INDEXER_LOG_LEVEL: "debug",
+      INDEXER_NETWORK_ID: "testnet",
+    });
+    expect(cfg.server.port).toBe(4000);
+    expect(cfg.server.nodeEnv).toBe("production");
+    expect(cfg.redis.url).toBe("redis://redis:6380");
+    expect(cfg.oracle.challengeWindowSeconds).toBe(3600);
+    expect(cfg.rateLimit.max).toBe(50);
+    expect(cfg.indexer.logLevel).toBe("debug");
+    expect(cfg.indexer.networkId).toBe("testnet");
+  });
+
+  it("throws when DATABASE_URL is missing", () => {
+    expect(() => loadConfig({})).toThrow("DATABASE_URL");
+  });
+
+  it("throws on invalid PORT", () => {
+    expect(() => loadConfig({ ...BASE_ENV, PORT: "abc" })).toThrow("PORT");
+  });
+
+  it("throws on invalid NODE_ENV", () => {
+    expect(() =>
+      loadConfig({ ...BASE_ENV, NODE_ENV: "staging" })
+    ).toThrow("NODE_ENV");
+  });
+
+  it("throws on invalid INDEXER_LOG_LEVEL", () => {
+    expect(() =>
+      loadConfig({ ...BASE_ENV, INDEXER_LOG_LEVEL: "verbose" })
+    ).toThrow("INDEXER_LOG_LEVEL");
+  });
+
+  it("throws when INDEXER_INGESTION_INTERVAL_MS is zero", () => {
+    expect(() =>
+      loadConfig({ ...BASE_ENV, INDEXER_INGESTION_INTERVAL_MS: "0" })
+    ).toThrow("INDEXER_INGESTION_INTERVAL_MS");
+  });
+});
+
+describe("getConfig / resetConfig", () => {
+  beforeEach(() => resetConfig());
+
+  it("returns the same instance on repeated calls", () => {
+    process.env.DATABASE_URL = BASE_ENV.DATABASE_URL!;
+    process.env.ORACLE_SECRET_KEY = BASE_ENV.ORACLE_SECRET_KEY!;
+    const a = getConfig();
+    const b = getConfig();
+    expect(a).toBe(b);
+    delete process.env.DATABASE_URL;
+    delete process.env.ORACLE_SECRET_KEY;
+  });
+});

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -1,0 +1,205 @@
+/**
+ * Shared typed config loader.
+ *
+ * Reads and validates environment variables once. All services should import
+ * `loadConfig` (or the pre-built `config` singleton) from this module instead
+ * of reading `process.env` directly.
+ *
+ * This module is side-effect free: nothing runs at import time.
+ * Call `loadConfig()` explicitly (or use the exported `config` singleton).
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function requireString(name: string, fallback?: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    if (fallback !== undefined) return fallback;
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function requirePositiveInt(name: string, fallback?: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    if (fallback !== undefined) return fallback;
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(
+      `Environment variable ${name} must be a positive integer, got: ${JSON.stringify(raw)}`
+    );
+  }
+  return value;
+}
+
+function requirePositiveNumber(name: string, fallback?: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    if (fallback !== undefined) return fallback;
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(
+      `Environment variable ${name} must be a positive number, got: ${JSON.stringify(raw)}`
+    );
+  }
+  return value;
+}
+
+function requireEnum<T extends string>(
+  name: string,
+  allowed: readonly T[],
+  fallback?: T
+): T {
+  const raw = (process.env[name] ?? fallback) as T | undefined;
+  if (raw === undefined) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  if (!allowed.includes(raw)) {
+    throw new Error(
+      `Environment variable ${name} must be one of ${allowed.join("|")}, got: ${JSON.stringify(raw)}`
+    );
+  }
+  return raw;
+}
+
+// ---------------------------------------------------------------------------
+// Config shape
+// ---------------------------------------------------------------------------
+
+export interface AppConfig {
+  server: {
+    port: number;
+    nodeEnv: "development" | "production" | "test";
+  };
+  database: {
+    url: string;
+  };
+  redis: {
+    url: string;
+  };
+  stellar: {
+    network: string;
+    horizonUrl: string;
+  };
+  oracle: {
+    secretKey: string;
+    challengeWindowSeconds: number;
+  };
+  rateLimit: {
+    windowMs: number;
+    max: number;
+    heavyWindowMs: number;
+    heavyMax: number;
+    writeWindowMs: number;
+    writeMax: number;
+  };
+  indexer: {
+    ingestionIntervalMs: number;
+    networkId: string;
+    cursorKey: string;
+    checkpointFlushEveryBatches: number;
+    logLevel: "debug" | "info" | "warn" | "error";
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
+const NODE_ENVS = ["development", "production", "test"] as const;
+
+/**
+ * Parse and validate all environment variables.
+ * Throws a descriptive error on the first missing or invalid value.
+ */
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
+  // Temporarily swap process.env so helpers pick up the provided env map.
+  const original = process.env;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process as any).env = env;
+
+  try {
+    return {
+      server: {
+        port: requirePositiveInt("PORT", 3000),
+        nodeEnv: requireEnum("NODE_ENV", NODE_ENVS, "development"),
+      },
+      database: {
+        url: requireString("DATABASE_URL"),
+      },
+      redis: {
+        url: requireString("REDIS_URL", "redis://localhost:6379"),
+      },
+      stellar: {
+        network: requireString("STELLAR_NETWORK", "testnet"),
+        horizonUrl: requireString(
+          "STELLAR_HORIZON_URL",
+          "https://horizon-testnet.stellar.org"
+        ),
+      },
+      oracle: {
+        secretKey: requireString("ORACLE_SECRET_KEY", ""),
+        challengeWindowSeconds: requirePositiveInt(
+          "ORACLE_CHALLENGE_WINDOW_SECONDS",
+          86400
+        ),
+      },
+      rateLimit: {
+        windowMs: requirePositiveNumber("RATE_LIMIT_WINDOW_MS", 60_000),
+        max: requirePositiveInt("RATE_LIMIT_MAX", 100),
+        heavyWindowMs: requirePositiveNumber(
+          "RATE_LIMIT_HEAVY_WINDOW_MS",
+          60_000
+        ),
+        heavyMax: requirePositiveInt("RATE_LIMIT_HEAVY_MAX", 20),
+        writeWindowMs: requirePositiveNumber(
+          "RATE_LIMIT_WRITE_WINDOW_MS",
+          60_000
+        ),
+        writeMax: requirePositiveInt("RATE_LIMIT_WRITE_MAX", 10),
+      },
+      indexer: {
+        ingestionIntervalMs: requirePositiveNumber(
+          "INDEXER_INGESTION_INTERVAL_MS",
+          5_000
+        ),
+        networkId: requireString("INDEXER_NETWORK_ID", "mainnet"),
+        cursorKey: requireString("INDEXER_CURSOR_KEY", "ingestion"),
+        checkpointFlushEveryBatches: requirePositiveInt(
+          "INDEXER_CHECKPOINT_FLUSH_EVERY_BATCHES",
+          10
+        ),
+        logLevel: requireEnum("INDEXER_LOG_LEVEL", LOG_LEVELS, "info"),
+      },
+    };
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process as any).env = original;
+  }
+}
+
+/**
+ * Pre-built singleton for services that don't need a custom env map.
+ * Evaluated lazily on first access so tests can set env vars before import.
+ */
+let _config: AppConfig | undefined;
+
+export function getConfig(): AppConfig {
+  if (!_config) {
+    _config = loadConfig();
+  }
+  return _config;
+}
+
+/** Reset the singleton (useful in tests). */
+export function resetConfig(): void {
+  _config = undefined;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,15 @@
+/**
+ * API config — re-exports the shared typed config loader.
+ * Import `getConfig()` or `loadConfig()` from here for API-layer use.
+ */
+export { loadConfig, getConfig, resetConfig } from "../../packages/shared/src/config.js";
+export type { AppConfig } from "../../packages/shared/src/config.js";
+
+// Convenience accessor kept for backwards compatibility.
+import { getConfig } from "../../packages/shared/src/config.js";
+
+export const config = {
+  get oracle() {
+    return getConfig().oracle;
+  },
+} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Fastify from "fastify";
+import { getConfig } from "./config.js";
 
 const server = Fastify({
   logger: true,
@@ -10,7 +11,7 @@ server.get("/health", async () => {
 
 const start = async () => {
   try {
-    const port = Number(process.env.PORT) || 3000;
+    const port = getConfig().server.port;
     await server.listen({ port, host: "0.0.0.0" });
     console.log(`Server running at http://localhost:${port}`);
   } catch (err) {


### PR DESCRIPTION
Implements a single typed config loader consumed by all services.\n\n## Changes\n- **`packages/shared/src/config.ts`** — `loadConfig(env?)` parses and validates all env vars (server, database, redis, stellar, oracle, rate-limit, indexer) with helpful error messages. `getConfig()` / `resetConfig()` provide a lazy singleton.\n- **`src/config.ts`** — re-exports from shared module; keeps backwards-compatible `config.oracle` accessor.\n- **`apps/indexer/src/config.ts`** — thin wrapper that returns `loadSharedConfig(env).indexer`.\n- **`src/index.ts`** — reads port via `getConfig().server.port` instead of raw `process.env`.\n- **`packages/shared/src/config.test.ts`** — 8 unit tests covering defaults, overrides, and validation errors.\n\n## Notes\n- Module is side-effect free; nothing runs at import time.\n- `loadConfig` accepts an optional `env` map for easy testing without mutating `process.env`.\n\nCloses #75