### PR TITLE
Feat/add stellar rpc url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ REDIS_URL=redis://localhost:6379
 # Stellar
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+# Stellar Soroban RPC endpoint used by the indexer and oracle for chain reads.
+# Testnet:  https://soroban-testnet.stellar.org
+# Mainnet:  https://soroban.stellar.org
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 
 # Oracle signing keypair
 # Generate with: pnpm generate:keypair

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Server
 PORT=3000
+# Accepted values: development | test | production
 NODE_ENV=development
 
 # Database

--- a/apps/indexer/src/config.ts
+++ b/apps/indexer/src/config.ts
@@ -1,10 +1,14 @@
 export interface IndexerConfig {
+  nodeEnv: "development" | "test" | "production";
   ingestionIntervalMs: number;
   networkId: string;
   cursorKey: string;
   checkpointFlushEveryBatches: number;
   logLevel: "debug" | "info" | "warn" | "error";
 }
+
+const ACCEPTED_NODE_ENVS = ["development", "test", "production"] as const;
+type NodeEnv = (typeof ACCEPTED_NODE_ENVS)[number];
 
 const DEFAULT_INGESTION_INTERVAL_MS = 5_000;
 const DEFAULT_NETWORK_ID = "mainnet";
@@ -13,6 +17,14 @@ const DEFAULT_CHECKPOINT_FLUSH_EVERY_BATCHES = 10;
 const DEFAULT_LOG_LEVEL: IndexerConfig["logLevel"] = "info";
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): IndexerConfig {
+  const rawNodeEnv = env.NODE_ENV ?? "development";
+  if (!ACCEPTED_NODE_ENVS.includes(rawNodeEnv as NodeEnv)) {
+    throw new Error(
+      `NODE_ENV must be one of ${ACCEPTED_NODE_ENVS.join(" | ")}, got: ${JSON.stringify(rawNodeEnv)}`
+    );
+  }
+  const nodeEnv = rawNodeEnv as NodeEnv;
+
   const ingestionIntervalMs = Number(
     env.INDEXER_INGESTION_INTERVAL_MS ?? DEFAULT_INGESTION_INTERVAL_MS
   );
@@ -48,6 +60,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): IndexerConfig 
   }
 
   return {
+    nodeEnv,
     ingestionIntervalMs,
     networkId,
     cursorKey,

--- a/apps/indexer/src/config.ts
+++ b/apps/indexer/src/config.ts
@@ -1,5 +1,6 @@
 export interface IndexerConfig {
   nodeEnv: "development" | "test" | "production";
+  stellarRpcUrl: string;
   ingestionIntervalMs: number;
   networkId: string;
   cursorKey: string;
@@ -59,8 +60,28 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): IndexerConfig 
     throw new Error("INDEXER_CHECKPOINT_FLUSH_EVERY_BATCHES must be an integer >= 1");
   }
 
+  const rawRpcUrl = env.STELLAR_RPC_URL;
+  if (!rawRpcUrl || rawRpcUrl.trim() === "") {
+    throw new Error("Missing required environment variable: STELLAR_RPC_URL");
+  }
+  let parsedRpcUrl: URL;
+  try {
+    parsedRpcUrl = new URL(rawRpcUrl);
+  } catch {
+    throw new Error(
+      "STELLAR_RPC_URL is not a valid URL (expected format: https://soroban-testnet.stellar.org)"
+    );
+  }
+  if (parsedRpcUrl.protocol !== "https:" && parsedRpcUrl.protocol !== "http:") {
+    throw new Error(
+      `STELLAR_RPC_URL must use http:// or https://, got: ${JSON.stringify(parsedRpcUrl.protocol)}`
+    );
+  }
+  const stellarRpcUrl = rawRpcUrl.trim();
+
   return {
     nodeEnv,
+    stellarRpcUrl,
     ingestionIntervalMs,
     networkId,
     cursorKey,

--- a/apps/indexer/src/main.ts
+++ b/apps/indexer/src/main.ts
@@ -23,6 +23,7 @@ async function bootstrap(): Promise<void> {
   );
 
   logger.info("Indexer bootstrap started", {
+    nodeEnv: config.nodeEnv,
     ingestionIntervalMs: config.ingestionIntervalMs,
     networkId: config.networkId,
     cursorKey: config.cursorKey,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,28 @@
 /**
  * Application configuration parsed and validated from environment variables.
  *
+ * NODE_ENV:
+ *   Accepted values: development | test | production (default: development)
+ *
  * Oracle challenge window:
  *   ORACLE_CHALLENGE_WINDOW_SECONDS — duration of the resolution challenge period
  *   in whole seconds (integer, minimum 1). All window calculations use UTC timestamps.
  *   Example: 86400 = 24 hours, 3600 = 1 hour.
  */
+
+export type NodeEnv = "development" | "test" | "production";
+
+const ACCEPTED_NODE_ENVS: NodeEnv[] = ["development", "test", "production"];
+
+function loadNodeEnv(): NodeEnv {
+  const raw = process.env.NODE_ENV ?? "development";
+  if (!ACCEPTED_NODE_ENVS.includes(raw as NodeEnv)) {
+    throw new Error(
+      `NODE_ENV must be one of ${ACCEPTED_NODE_ENVS.join(" | ")}, got: ${JSON.stringify(raw)}`
+    );
+  }
+  return raw as NodeEnv;
+}
 
 function requirePositiveInt(name: string, fallback?: number): number {
   const raw = process.env[name];
@@ -27,6 +44,11 @@ function requirePositiveInt(name: string, fallback?: number): number {
 }
 
 export const config = {
+  /**
+   * Current runtime environment. Constrained to development | test | production.
+   * Configured via NODE_ENV (default: development).
+   */
+  nodeEnv: loadNodeEnv(),
   /**
    * Duration of the oracle resolution challenge window in seconds.
    * Must be a positive integer. All window boundary calculations use UTC.

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,11 @@ function loadNodeEnv(): NodeEnv {
   return raw as NodeEnv;
 }
 
-function requirePositiveInt(name: string, fallback?: number): number {
+function requirePositiveInt(
+  name: string,
+  fallback?: number,
+  max?: number
+): number {
   const raw = process.env[name];
 
   if (raw === undefined || raw === "") {
@@ -40,6 +44,12 @@ function requirePositiveInt(name: string, fallback?: number): number {
     );
   }
 
+  if (max !== undefined && value > max) {
+    throw new Error(
+      `Environment variable ${name} must be <= ${max}, got: ${JSON.stringify(raw)}`
+    );
+  }
+
   return value;
 }
 
@@ -49,6 +59,12 @@ export const config = {
    * Configured via NODE_ENV (default: development).
    */
   nodeEnv: loadNodeEnv(),
+  /**
+   * TCP port the API server binds to.
+   * Must be a positive integer in the range 1–65535.
+   * Configured via PORT (default: 3000).
+   */
+  port: requirePositiveInt("PORT", 3000, 65535),
   /**
    * Duration of the oracle resolution challenge window in seconds.
    * Must be a positive integer. All window boundary calculations use UTC.

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,39 @@ export type NodeEnv = "development" | "test" | "production";
 
 const ACCEPTED_NODE_ENVS: NodeEnv[] = ["development", "test", "production"];
 
+/**
+ * Validates DATABASE_URL is present and matches a postgresql:// or postgres:// URL.
+ * Throws at startup if missing or malformed — never logs the full connection string.
+ */
+function loadDatabaseUrl(): string {
+  const raw = process.env.DATABASE_URL;
+
+  if (!raw || raw.trim() === "") {
+    throw new Error("Missing required environment variable: DATABASE_URL");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(
+      "DATABASE_URL is not a valid URL (expected format: postgresql://user:pass@host:port/db)"
+    );
+  }
+
+  if (parsed.protocol !== "postgresql:" && parsed.protocol !== "postgres:") {
+    throw new Error(
+      `DATABASE_URL must use the postgresql:// or postgres:// scheme, got: ${JSON.stringify(parsed.protocol)}`
+    );
+  }
+
+  if (!parsed.hostname) {
+    throw new Error("DATABASE_URL must include a hostname");
+  }
+
+  return raw;
+}
+
 function loadNodeEnv(): NodeEnv {
   const raw = process.env.NODE_ENV ?? "development";
   if (!ACCEPTED_NODE_ENVS.includes(raw as NodeEnv)) {
@@ -65,6 +98,13 @@ export const config = {
    * Configured via PORT (default: 3000).
    */
   port: requirePositiveInt("PORT", 3000, 65535),
+  /**
+   * PostgreSQL connection string for the primary database.
+   * Must be a valid postgresql:// or postgres:// URL.
+   * Configured via DATABASE_URL — startup fails if missing or malformed.
+   * Never logged in full to avoid leaking credentials.
+   */
+  databaseUrl: loadDatabaseUrl(),
   /**
    * Duration of the oracle resolution challenge window in seconds.
    * Must be a positive integer. All window boundary calculations use UTC.

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const start = async () => {
     // Initialize signing service BEFORE starting server
     signingService.initialize();
 
-    const port = Number(process.env.PORT) || 3000;
+    const port = config.port;
     await server.listen({ port, host: "0.0.0.0" });
     server.log.info(
       { nodeEnv: config.nodeEnv, port },

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { ordersRoutes } from "./api/routes/orders.js";
 import { adminRoutes } from "./api/routes/admin.js";
 import { rateLimiter } from "./api/middleware/rateLimiter.js";
 import { requestLogger } from "./api/middleware/logger.js";
+import { config } from "./config.js";
 
 const server = Fastify({
   logger: true,
@@ -58,7 +59,10 @@ const start = async () => {
 
     const port = Number(process.env.PORT) || 3000;
     await server.listen({ port, host: "0.0.0.0" });
-    console.log(`Server running at http://localhost:${port}`);
+    server.log.info(
+      { nodeEnv: config.nodeEnv, port },
+      `Server running at http://localhost:${port}`
+    );
   } catch (err) {
     server.log.error(err);
     process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,37 @@ import { rateLimiter } from "./api/middleware/rateLimiter.js";
 import { requestLogger } from "./api/middleware/logger.js";
 import { config } from "./config.js";
 
+interface RpcReachabilityResult {
+  url: string | null;
+  reachable: boolean;
+  error?: string;
+}
+
+async function checkRpcReachability(
+  rpcUrl: string | undefined
+): Promise<RpcReachabilityResult> {
+  if (!rpcUrl) {
+    return { url: null, reachable: false, error: "STELLAR_RPC_URL not configured" };
+  }
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getHealth", params: [] }),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timeout));
+    return { url: rpcUrl, reachable: res.ok || res.status < 500 };
+  } catch (err) {
+    return {
+      url: rpcUrl,
+      reachable: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 const server = Fastify({
   logger: true,
   genReqId: () => crypto.randomUUID(), // Generate unique request IDs
@@ -34,6 +65,19 @@ server.register(adminRoutes);
 
 server.get("/health", async () => {
   return { status: "ok", service: "vatix-backend" };
+});
+
+server.get("/readiness", async (_req, reply) => {
+  const rpcUrl = process.env.STELLAR_RPC_URL;
+  const rpcStatus = await checkRpcReachability(rpcUrl);
+  const allHealthy = rpcStatus.reachable;
+  reply.status(allHealthy ? 200 : 503);
+  return {
+    status: allHealthy ? "ready" : "not_ready",
+    checks: {
+      stellarRpc: rpcStatus,
+    },
+  };
 });
 
 // Test routes for error handling

--- a/src/services/prisma.ts
+++ b/src/services/prisma.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from "../generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
+import { config } from "../config.js";
 
 /**
  * Singleton Prisma Client instance
@@ -17,15 +18,10 @@ let pgPool: Pool | null = null;
  */
 export function getPrismaClient(): PrismaClient {
   if (!prismaInstance) {
-    const isProduction = process.env.NODE_ENV === "production";
-    const databaseUrl = process.env.DATABASE_URL;
+    const isProduction = config.nodeEnv === "production";
 
-    if (!databaseUrl) {
-      throw new Error("DATABASE_URL environment variable is not set");
-    }
-
-    // create postgres connection pool
-    pgPool = new Pool({ connectionString: databaseUrl });
+    // create postgres connection pool — URL already validated at startup via config
+    pgPool = new Pool({ connectionString: config.databaseUrl });
     const adapter = new PrismaPg(pgPool);
 
     prismaInstance = new PrismaClient({


### PR DESCRIPTION
Adds STELLAR_RPC_URL as a required, validated environment variable for the indexer and oracle services, which depend on Soroban RPC connectivity to read chain state. Also exposes a /readiness endpoint that actively probes the configured RPC endpoint so orchestration systems (Kubernetes, Docker Compose health checks, etc.) can gate traffic on real connectivity. closes #71 