### PR TITLE
feat: add GET /v1/health liveness endpoint

### DIFF
--- a/src/api/routes/health.ts
+++ b/src/api/routes/health.ts
@@ -1,0 +1,39 @@
+import type { FastifyInstance } from "fastify";
+import { getPrismaClient } from "../../services/prisma.js";
+
+interface HealthResponse {
+  status: "ok" | "degraded";
+  service: string;
+  version: string;
+  uptime: number;
+  timestamp: string;
+  dependencies: {
+    database: "ok" | "error";
+  };
+}
+
+export async function healthRoutes(fastify: FastifyInstance) {
+  fastify.get<{ Reply: HealthResponse }>("/v1/health", async (_request, reply) => {
+    let dbStatus: "ok" | "error" = "ok";
+
+    try {
+      const prisma = getPrismaClient();
+      await prisma.$queryRaw`SELECT 1`;
+    } catch {
+      dbStatus = "error";
+    }
+
+    const status = dbStatus === "ok" ? "ok" : "degraded";
+
+    return reply.status(200).send({
+      status,
+      service: "vatix-backend",
+      version: process.env.npm_package_version ?? "unknown",
+      uptime: Math.floor(process.uptime()),
+      timestamp: new Date().toISOString(),
+      dependencies: {
+        database: dbStatus,
+      },
+    });
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import "dotenv/config";
 import { marketsRoutes } from "./api/routes/markets.js";
 import { ordersRoutes } from "./api/routes/orders.js";
 import { adminRoutes } from "./api/routes/admin.js";
+import { healthRoutes } from "./api/routes/health.js";
 import { rateLimiter } from "./api/middleware/rateLimiter.js";
 import { requestLogger } from "./api/middleware/logger.js";
 
@@ -30,10 +31,7 @@ server.register(ordersRoutes);
 
 server.register(positionsRouter);
 server.register(adminRoutes);
-
-server.get("/health", async () => {
-  return { status: "ok", service: "vatix-backend" };
-});
+server.register(healthRoutes);
 
 // Test routes for error handling
 server.get("/test/validation-error", async () => {


### PR DESCRIPTION
- Registers healthRoutes on the Fastify instance
- Returns 200 with status, service name, version, uptime, timestamp
- Performs a lightweight SELECT 1 DB ping; reports 'degraded' if it fails
- Removes the old bare /health stub from index.ts
- No expensive downstream calls; safe for high-frequency uptime checks
closes #78