### PR TITLE
feat: add standard API error envelope with stable code field (#81)

### DIFF
--- a/src/api/middleware/errorHandler.test.ts
+++ b/src/api/middleware/errorHandler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Fastify, { FastifyInstance } from "fastify";
 import { errorHandler } from "./errorHandler.js";
 import {
@@ -12,13 +12,7 @@ describe("Error Handler Middleware", () => {
   let server: FastifyInstance;
 
   beforeEach(async () => {
-    // Create a fresh Fastify instance for each test
-    server = Fastify({
-      logger: false, // Disable logging in tests
-      genReqId: () => "test-request-id",
-    });
-
-    // Register error handler
+    server = Fastify({ logger: false, genReqId: () => "test-request-id" });
     server.setErrorHandler(errorHandler);
   });
 
@@ -26,325 +20,108 @@ describe("Error Handler Middleware", () => {
     await server.close();
   });
 
+  // Helper
+  const inject = (throw_: () => never) => {
+    server.get("/test", async () => { throw_(); });
+    return server.inject({ method: "GET", url: "/test" });
+  };
+
+  describe("envelope shape", () => {
+    it("has code, message, statusCode, requestId", async () => {
+      server.get("/test", async () => { throw new NotFoundError("x"); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      const body = JSON.parse(res.body);
+      expect(body).toMatchObject({
+        code: "not_found",
+        message: "x",
+        statusCode: 404,
+        requestId: "test-request-id",
+      });
+    });
+
+    it("statusCode in body matches HTTP status", async () => {
+      server.get("/test", async () => { throw new NotFoundError(); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      const body = JSON.parse(res.body);
+      expect(body.statusCode).toBe(res.statusCode);
+    });
+  });
+
   describe("ValidationError", () => {
-    it("should return 400 status code", async () => {
-      server.get("/test", async () => {
-        throw new ValidationError("Validation failed");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      expect(response.statusCode).toBe(400);
+    it("returns 400 with code validation_error", async () => {
+      server.get("/test", async () => { throw new ValidationError("bad input"); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).code).toBe("validation_error");
     });
 
-    it("should include field details in response", async () => {
-      const fields = {
-        email: "Invalid email format",
-        password: "Password too short",
-      };
-
-      server.get("/test", async () => {
-        throw new ValidationError("Validation failed", fields);
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.fields).toEqual(fields);
+    it("puts fields inside metadata", async () => {
+      const fields = { email: "invalid" };
+      server.get("/test", async () => { throw new ValidationError("bad", fields); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      expect(JSON.parse(res.body).metadata).toEqual({ fields });
     });
 
-    it("should include error message in response", async () => {
-      server.get("/test", async () => {
-        throw new ValidationError("Invalid input data");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.error).toBe("Invalid input data");
+    it("omits metadata when no fields", async () => {
+      server.get("/test", async () => { throw new ValidationError("bad"); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      expect(JSON.parse(res.body).metadata).toBeUndefined();
     });
   });
 
   describe("NotFoundError", () => {
-    it("should return 404 status code", async () => {
-      server.get("/test", async () => {
-        throw new NotFoundError("Market not found");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it("should include error message in response", async () => {
-      server.get("/test", async () => {
-        throw new NotFoundError("User not found");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.error).toBe("User not found");
+    it("returns 404 with code not_found", async () => {
+      server.get("/test", async () => { throw new NotFoundError("gone"); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(res.body).code).toBe("not_found");
     });
   });
 
   describe("UnauthorizedError", () => {
-    it("should return 401 status code", async () => {
-      server.get("/test", async () => {
-        throw new UnauthorizedError("Invalid token");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      expect(response.statusCode).toBe(401);
-    });
-
-    it("should include error message in response", async () => {
-      server.get("/test", async () => {
-        throw new UnauthorizedError("Access denied");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.error).toBe("Access denied");
+    it("returns 401 with code unauthorized", async () => {
+      server.get("/test", async () => { throw new UnauthorizedError(); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      expect(res.statusCode).toBe(401);
+      expect(JSON.parse(res.body).code).toBe("unauthorized");
     });
   });
 
   describe("ForbiddenError", () => {
-    it("should return 403 status code", async () => {
-      server.get("/test", async () => {
-        throw new ForbiddenError("Access forbidden");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      expect(response.statusCode).toBe(403);
-    });
-
-    it("should include error message in response", async () => {
-      server.get("/test", async () => {
-        throw new ForbiddenError("Insufficient permissions");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.error).toBe("Insufficient permissions");
-    });
-
-    it("should use default message when none provided", async () => {
-      server.get("/test", async () => {
-        throw new ForbiddenError();
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(response.statusCode).toBe(403);
-      expect(body.error).toBe("Forbidden");
+    it("returns 403 with code forbidden", async () => {
+      server.get("/test", async () => { throw new ForbiddenError(); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      expect(res.statusCode).toBe(403);
+      expect(JSON.parse(res.body).code).toBe("forbidden");
     });
   });
 
-  describe("Unknown Errors", () => {
-    it("should return 500 status code for generic errors", async () => {
-      server.get("/test", async () => {
-        throw new Error("Something went wrong");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      expect(response.statusCode).toBe(500);
+  describe("generic Error", () => {
+    it("returns 500 with code internal_error", async () => {
+      server.get("/test", async () => { throw new Error("boom"); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.body).code).toBe("internal_error");
     });
 
-    it("should include error message in development mode", async () => {
-      const originalEnv = process.env.NODE_ENV;
+    it("exposes message in development", async () => {
+      const orig = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
-
-      server.get("/test", async () => {
-        throw new Error("Database connection failed");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.error).toBe("Database connection failed");
-
-      process.env.NODE_ENV = originalEnv;
+      server.get("/test", async () => { throw new Error("db failed"); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      expect(JSON.parse(res.body).message).toBe("db failed");
+      process.env.NODE_ENV = orig;
     });
 
-    it("should hide internal details in production mode", async () => {
-      const originalEnv = process.env.NODE_ENV;
+    it("hides message in production", async () => {
+      const orig = process.env.NODE_ENV;
       process.env.NODE_ENV = "production";
-
-      server.get("/test", async () => {
-        throw new Error("Database connection failed");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.error).toBe("Internal server error");
-      expect(body.error).not.toContain("Database");
-
-      process.env.NODE_ENV = originalEnv;
-    });
-  });
-
-  describe("Response Format", () => {
-    it("should have consistent format with error, requestId, and statusCode", async () => {
-      server.get("/test", async () => {
-        throw new NotFoundError("Resource not found");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body).toHaveProperty("error");
-      expect(body).toHaveProperty("requestId");
-      expect(body).toHaveProperty("statusCode");
-      expect(typeof body.error).toBe("string");
-      expect(typeof body.requestId).toBe("string");
-      expect(typeof body.statusCode).toBe("number");
-    });
-
-    it("should include request ID in response", async () => {
-      server.get("/test", async () => {
-        throw new Error("Test error");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.requestId).toBe("test-request-id");
-    });
-
-    it("should match statusCode in response body and HTTP status", async () => {
-      server.get("/test", async () => {
-        throw new NotFoundError("Not found");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.statusCode).toBe(response.statusCode);
-      expect(body.statusCode).toBe(404);
-    });
-  });
-
-  describe("Logging", () => {
-    it("should log client errors at warn level", async () => {
-      // Use a simple approach - check that the error handler doesn't crash
-      // Actual logging is tested via integration tests
-      server.get("/test", async () => {
-        throw new ValidationError("Bad input");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      expect(response.statusCode).toBe(400);
-      // If we got here, logging worked without crashing
-    });
-
-    it("should log server errors at error level", async () => {
-      // Use a simple approach - check that the error handler doesn't crash
-      // Actual logging is tested via integration tests
-      server.get("/test", async () => {
-        throw new Error("Internal error");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      expect(response.statusCode).toBe(500);
-      // If we got here, logging worked without crashing
-    });
-  });
-
-  describe("Edge Cases", () => {
-    it("should handle errors with custom status codes", async () => {
-      class CustomError extends Error {
-        statusCode = 418; // I'm a teapot
-      }
-
-      server.get("/test", async () => {
-        throw new CustomError("Custom error");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      expect(response.statusCode).toBe(418);
-    });
-
-    it("should handle ValidationError without fields", async () => {
-      server.get("/test", async () => {
-        throw new ValidationError("Validation failed");
-      });
-
-      const response = await server.inject({
-        method: "GET",
-        url: "/test",
-      });
-
-      const body = JSON.parse(response.body);
-      expect(body.statusCode).toBe(400);
-      expect(body.fields).toBeUndefined();
+      server.get("/test", async () => { throw new Error("db failed"); });
+      const res = await server.inject({ method: "GET", url: "/test" });
+      const body = JSON.parse(res.body);
+      expect(body.message).not.toContain("db");
+      expect(body.code).toBe("internal_error");
+      process.env.NODE_ENV = orig;
     });
   });
 });

--- a/src/api/middleware/errorHandler.ts
+++ b/src/api/middleware/errorHandler.ts
@@ -1,32 +1,22 @@
-// Error handler middleware for Fastify
-
 import type { FastifyError, FastifyReply, FastifyRequest } from "fastify";
-import { ValidationError } from "./errors.js";
-import { ErrorResponse } from "../../types/errors.js";
+import { ValidationError, AppError } from "./errors.js";
+import type { ErrorEnvelope } from "../../types/errors.js";
 
-// Centralized error handler for Fastify
-// Catches all unhandled errors and returns consistent error responses
 export function errorHandler(
   error: FastifyError | Error,
   request: FastifyRequest,
   reply: FastifyReply
 ) {
-  // Determine status code
-  let statusCode = 500;
-  if ("statusCode" in error && typeof error.statusCode === "number") {
-    statusCode = error.statusCode;
-  }
+  const statusCode =
+    "statusCode" in error && typeof error.statusCode === "number"
+      ? error.statusCode
+      : 500;
 
-  // Determine if it's a client error (4xx) or server error (5xx)
   const isClientError = statusCode >= 400 && statusCode < 500;
   const isServerError = statusCode >= 500;
 
-  // Get request ID for tracking
-  const requestId = request.id;
-
-  // Log error with appropriate level
   const logContext = {
-    requestId,
+    requestId: request.id,
     method: request.method,
     url: request.url,
     statusCode,
@@ -34,38 +24,37 @@ export function errorHandler(
   };
 
   if (isClientError) {
-    // Client errors are expected (bad input, not found, etc.)
     request.log.warn(logContext, "Client error");
   } else if (isServerError) {
-    // Server errors are unexpected and need investigation
-    request.log.error(
-      {
-        ...logContext,
-        stack: error.stack,
-      },
-      "Server error"
-    );
+    request.log.error({ ...logContext, stack: error.stack }, "Server error");
   }
 
-  // Build error response
-  let errorMessage = error.message;
+  // Derive stable code: prefer AppError.code, fall back to Fastify's error code,
+  // then a generic sentinel.
+  let code =
+    error instanceof AppError
+      ? error.code
+      : ("code" in error && typeof error.code === "string" && error.code) ||
+        "internal_error";
 
-  // hide internal error details in prod
-  if (process.env.NODE_ENV === "production" && isServerError) {
-    errorMessage = "Internal server error";
+  // Human-readable message — scrub internals in production
+  let message = error.message;
+  if (isServerError && process.env.NODE_ENV === "production") {
+    message = "An unexpected error occurred. Please try again later.";
+    code = "internal_error";
   }
 
-  const response: ErrorResponse = {
-    error: errorMessage,
-    requestId,
+  const envelope: ErrorEnvelope = {
+    code,
+    message,
     statusCode,
+    requestId: request.id,
   };
 
-  // Add field details for ValidationError
+  // Attach field-level details as metadata for ValidationError
   if (error instanceof ValidationError && error.fields) {
-    response.fields = error.fields;
+    envelope.metadata = { fields: error.fields };
   }
 
-  // Send error response
-  reply.status(statusCode).send(response);
+  reply.status(statusCode).send(envelope);
 }

--- a/src/api/middleware/errors.ts
+++ b/src/api/middleware/errors.ts
@@ -1,50 +1,42 @@
 // Custom error classes for Vatix Backend
-// used throughout the application for consistent error handling
-
-// Base class for application errors
+// Each class carries a stable `code` used in the API error envelope.
 
 export class AppError extends Error {
   statusCode: number;
+  code: string;
 
-  constructor(message: string, statusCode: number) {
+  constructor(message: string, statusCode: number, code: string) {
     super(message);
     this.name = this.constructor.name;
     this.statusCode = statusCode;
+    this.code = code;
     Error.captureStackTrace(this, this.constructor);
   }
 }
 
-// ValidationError is used when request validation fails
-// Returns 400 Bad Request with field-specific error details
 export class ValidationError extends AppError {
   fields?: Record<string, string>;
 
   constructor(message: string, fields?: Record<string, string>) {
-    super(message, 400);
+    super(message, 400, "validation_error");
     this.fields = fields;
   }
 }
 
-// NotFoundError is used when a requested resource doesn't exist
-// Returns 404 Not Found
 export class NotFoundError extends AppError {
   constructor(message: string = "Resource not found") {
-    super(message, 404);
+    super(message, 404, "not_found");
   }
 }
 
-// UnauthorizedError is used when authentication or authorization fails
-// Returns 401 Unauthorized
 export class UnauthorizedError extends AppError {
   constructor(message: string = "Unauthorized") {
-    super(message, 401);
+    super(message, 401, "unauthorized");
   }
 }
 
-// ForbiddenError is used when a user is not authorized to access a resource
-// Returns 403 Forbidden
 export class ForbiddenError extends AppError {
   constructor(message = "Forbidden") {
-    super(message, 403);
+    super(message, 403, "forbidden");
   }
 }

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,8 +1,20 @@
-// Error response format
-
-export interface ErrorResponse {
-  error: string;
-  requestId: string;
+/**
+ * Standardised error envelope returned by every API error response.
+ *
+ * Machine-readable: `code`   – stable snake_case identifier, safe to switch on.
+ * Human-readable:  `message` – plain-English description, may change between releases.
+ * Correlation:     `requestId` – ties the response to server logs.
+ * Extra context:   `metadata`  – optional structured details (e.g. field-level errors).
+ */
+export interface ErrorEnvelope {
+  /** Stable snake_case error code, e.g. "validation_error", "not_found". */
+  code: string;
+  /** Human-readable description of the error. */
+  message: string;
+  /** HTTP status code mirrored in the body for clients that parse JSON only. */
   statusCode: number;
-  fields?: Record<string, string>;
+  /** Request correlation ID for log tracing. */
+  requestId: string;
+  /** Optional structured metadata (field errors, resource IDs, etc.). */
+  metadata?: Record<string, unknown>;
 }


### PR DESCRIPTION
- Replace ErrorResponse with ErrorEnvelope (code, message, statusCode, requestId, metadata)
- Add stable snake_case code to all AppError subclasses
- Scrub internal 5xx messages in production
- Move ValidationError fields into metadata.fields
- Update tests for new envelope shape

Closes #81