### PR TITLE
feat(oracle): add configurable ORACLE_POLL_INTERVAL_MS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,12 @@ RATE_LIMIT_WRITE_MAX=10
 FINALIZATION_INTERVAL_MS=60000
 FINALIZATION_CHALLENGE_WINDOW_SECONDS=3600
 FINALIZATION_LOG_LEVEL=info
+
+# -----------------------------------------------------------------------------
+# Oracle
+# -----------------------------------------------------------------------------
+# How often the oracle scheduler polls for ingestion and resolution checks (ms).
+# Recommended default: 30000 (30 seconds).
+# Lower bound: 5000 ms  — prevents runaway polling under misconfiguration.
+# Upper bound: 3600000 ms (1 hour) — ensures checks are not indefinitely delayed.
+ORACLE_POLL_INTERVAL_MS=30000

--- a/apps/oracle/oracle-scheduler.ts
+++ b/apps/oracle/oracle-scheduler.ts
@@ -1,0 +1,58 @@
+/**
+ * Oracle Scheduler
+ *
+ * Provides the configurable polling interval for oracle ingestion and
+ * resolution checks. The interval is read from ORACLE_POLL_INTERVAL_MS
+ * with lower and upper safety bounds enforced at startup.
+ *
+ * Recommended default : 30 000 ms (30 seconds)
+ * Lower bound         : 5 000 ms  — prevents runaway polling under misconfiguration
+ * Upper bound         : 3 600 000 ms (1 hour) — ensures checks are not indefinitely delayed
+ *
+ * @module apps/oracle/oracle-scheduler
+ */
+
+/** Minimum allowed polling interval (5 seconds). */
+export const MIN_POLL_INTERVAL_MS = 5_000;
+
+/** Maximum allowed polling interval (1 hour). */
+export const MAX_POLL_INTERVAL_MS = 3_600_000;
+
+/** Recommended default polling interval (30 seconds). */
+export const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Read and validate ORACLE_POLL_INTERVAL_MS from the environment.
+ *
+ * @returns Validated polling interval in milliseconds.
+ * @throws {Error} If the value is present but outside the allowed bounds or not a positive integer.
+ */
+export function getOraclePollIntervalMs(): number {
+  const raw = process.env["ORACLE_POLL_INTERVAL_MS"];
+
+  if (raw === undefined || raw === "") {
+    return DEFAULT_POLL_INTERVAL_MS;
+  }
+
+  const value = Number(raw);
+
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(
+      `ORACLE_POLL_INTERVAL_MS must be a positive integer, got: ${JSON.stringify(raw)}`
+    );
+  }
+
+  if (value < MIN_POLL_INTERVAL_MS) {
+    throw new Error(
+      `ORACLE_POLL_INTERVAL_MS must be >= ${MIN_POLL_INTERVAL_MS} ms (lower safety bound), got: ${value}`
+    );
+  }
+
+  if (value > MAX_POLL_INTERVAL_MS) {
+    throw new Error(
+      `ORACLE_POLL_INTERVAL_MS must be <= ${MAX_POLL_INTERVAL_MS} ms (upper safety bound), got: ${value}`
+    );
+  }
+
+  return value;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,46 @@ function requirePositiveInt(
   return value;
 }
 
+/**
+ * Loads ORACLE_POLL_INTERVAL_MS with lower and upper safety bounds.
+ * Lower bound: 5 000 ms — prevents runaway polling under misconfiguration.
+ * Upper bound: 3 600 000 ms (1 hour) — ensures checks are not indefinitely delayed.
+ * Default: 30 000 ms (30 seconds).
+ */
+function loadOraclePollIntervalMs(): number {
+  const MIN_POLL_INTERVAL_MS = 5_000;
+  const MAX_POLL_INTERVAL_MS = 3_600_000;
+  const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+  const raw = process.env["ORACLE_POLL_INTERVAL_MS"];
+
+  if (raw === undefined || raw === "") {
+    return DEFAULT_POLL_INTERVAL_MS;
+  }
+
+  const value = Number(raw);
+
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(
+      `Environment variable ORACLE_POLL_INTERVAL_MS must be a positive integer, got: ${JSON.stringify(raw)}`
+    );
+  }
+
+  if (value < MIN_POLL_INTERVAL_MS) {
+    throw new Error(
+      `ORACLE_POLL_INTERVAL_MS must be >= ${MIN_POLL_INTERVAL_MS} ms, got: ${JSON.stringify(raw)}`
+    );
+  }
+
+  if (value > MAX_POLL_INTERVAL_MS) {
+    throw new Error(
+      `ORACLE_POLL_INTERVAL_MS must be <= ${MAX_POLL_INTERVAL_MS} ms, got: ${JSON.stringify(raw)}`
+    );
+  }
+
+  return value;
+}
+
 export const config = {
   /**
    * Current runtime environment. Constrained to development | test | production.
@@ -115,5 +155,13 @@ export const config = {
       "ORACLE_CHALLENGE_WINDOW_SECONDS",
       86400
     ),
+    /**
+     * How often the oracle scheduler polls for ingestion and resolution checks (ms).
+     * Recommended default: 30 000 ms (30 seconds).
+     * Lower bound: 5 000 ms — prevents runaway polling under misconfiguration.
+     * Upper bound: 3 600 000 ms (1 hour) — ensures checks are not indefinitely delayed.
+     * Configured via ORACLE_POLL_INTERVAL_MS.
+     */
+    pollIntervalMs: loadOraclePollIntervalMs(),
   },
 } as const;


### PR DESCRIPTION
- Add ORACLE_POLL_INTERVAL_MS to .env.example with recommended default of 30 000 ms, documented lower bound (5 000 ms) and upper bound (3 600 000 ms / 1 hour)
- Add loadOraclePollIntervalMs() to src/config.ts with strict lower and upper bound enforcement; exposed as config.oracle.pollIntervalMs
- Add apps/oracle/oracle-scheduler.ts with getOraclePollIntervalMs() helper, exported MIN/MAX/DEFAULT constants, and inline JSDoc closes #74 