### PR TITLE
feat(db): add markets table migration closes #138

### DIFF
--- a/packages/db/migrations/20260122080015_add_markets_table/README.md
+++ b/packages/db/migrations/20260122080015_add_markets_table/README.md
@@ -1,0 +1,26 @@
+# Migration: Add Markets Table
+
+**Migration ID:** `20260122080015_add_markets_table`
+
+Creates the `markets` table — the core entity for all prediction market data.
+
+## Table Structure
+
+| Column            | Type          | Nullable | Description                        |
+| ----------------- | ------------- | -------- | ---------------------------------- |
+| id                | UUID          | No       | Primary key                        |
+| question          | TEXT          | No       | Market question                    |
+| end_time          | TIMESTAMPTZ   | No       | When the market closes             |
+| resolution_time   | TIMESTAMPTZ   | Yes      | When the market was resolved       |
+| oracle_address    | VARCHAR(56)   | No       | Stellar address of the oracle      |
+| status            | MarketStatus  | No       | `ACTIVE`, `RESOLVED`, `CANCELLED`  |
+| outcome           | BOOLEAN       | Yes      | Final outcome once resolved        |
+| created_at        | TIMESTAMPTZ   | No       | Row creation timestamp             |
+| updated_at        | TIMESTAMPTZ   | No       | Last update timestamp              |
+
+## Indexes
+
+- `markets_status_idx` — filter by status
+- `markets_end_time_idx` — filter/sort by end time
+- `markets_status_end_time_idx` — combined status + end time queries
+- `markets_status_created_at_idx` — sorted market listings by creation date

--- a/packages/db/migrations/20260122080015_add_markets_table/migration.sql
+++ b/packages/db/migrations/20260122080015_add_markets_table/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "MarketStatus" AS ENUM ('ACTIVE', 'RESOLVED', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "markets" (
+    "id"              UUID           NOT NULL DEFAULT gen_random_uuid(),
+    "question"        TEXT           NOT NULL,
+    "end_time"        TIMESTAMPTZ    NOT NULL,
+    "resolution_time" TIMESTAMPTZ,
+    "oracle_address"  VARCHAR(56)    NOT NULL,
+    "status"          "MarketStatus" NOT NULL DEFAULT 'ACTIVE',
+    "outcome"         BOOLEAN,
+    "created_at"      TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    "updated_at"      TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT "markets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "markets_status_idx"            ON "markets" ("status");
+CREATE INDEX "markets_end_time_idx"          ON "markets" ("end_time");
+CREATE INDEX "markets_status_end_time_idx"   ON "markets" ("status", "end_time");
+CREATE INDEX "markets_status_created_at_idx" ON "markets" ("status", "created_at" DESC);


### PR DESCRIPTION
closes #138 

Closes #138

Creates the `markets` table migration under `packages/db/migrations`.

### Changes
- `migration.sql` — creates `markets` table with primary key, `MarketStatus` enum, required fields, and 4 indexes
- `README.md` — documents table structure, nullable fields, and index rationale

### Schema highlights
- UUID primary key via `gen_random_uuid()`
- Only 2 nullable fields (`resolution_time`, `outcome`) — unset until market resolves
- `TIMESTAMPTZ` for all timestamps (timezone-aware)
- Indexes cover status filtering, end time sorting, and paginated market listings

### Testing
Applies cleanly on an empty database.
