### PR TITLE
docs: add docker compose documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Backend services for the Vatix prediction market protocol on Stellar.
 
+## Documentation
+
+- [Docker Compose Setup](docs/docker-compose.md)
+
 ## Tech Stack
 
 Node.js • TypeScript • Fastify • PostgreSQL • Prisma • Redis • Stellar SDK

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -1,0 +1,77 @@
+# Docker Compose Setup for Vatix Backend
+
+This guide explains how to use Docker Compose to set up the required services for the Vatix backend.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+## Services
+
+- **PostgreSQL** (database)
+- **Redis** (cache)
+
+## Setup Steps
+
+1. **Clone the repository and install dependencies:**
+
+   ```bash
+   git clone https://github.com/vatix-protocol/vatix-backend.git
+   cd vatix-backend
+   pnpm install
+   ```
+
+2. **Copy environment variables:**
+
+   ```bash
+   cp .env.example .env
+   ```
+   Edit `.env` if needed (see `.env.example` for details).
+
+3. **Start Docker services:**
+
+   ```bash
+   docker compose up -d
+   ```
+   This will start PostgreSQL (on port 5433) and Redis (on port 6379).
+
+4. **Initialize the database:**
+
+   ```bash
+   pnpm prisma:generate
+   pnpm prisma:migrate dev
+   ```
+
+5. **Run the backend:**
+
+   ```bash
+   pnpm dev
+   ```
+
+## Stopping Services
+
+To stop and remove containers:
+
+```bash
+docker compose down
+```
+
+## Useful Commands
+
+- View running containers:
+  ```bash
+  docker compose ps
+  ```
+- View logs:
+  ```bash
+  docker compose logs
+  ```
+- Stop services:
+  ```bash
+  docker compose down
+  ```
+
+---
+
+For more details, see the main [README.md](../README.md).


### PR DESCRIPTION
## Summary

Added Docker Compose setup documentation for the Vatix backend.

### Changes made

* Added `docs/docker-compose.md`
* Documented:

  * prerequisites
  * setup steps
  * environment configuration
  * starting/stopping services
  * useful Docker Compose commands
* Added documentation link in `README.md`

Closes Vatix-Protocol/vatix-backend#253
