### PR TITLE
docs: add indexer cursor env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,14 @@ STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 
 # -----------------------------------------------------------------------------
+# Indexer
+# -----------------------------------------------------------------------------
+# Optional. Identifies the persisted ledger cursor checkpoint used by the
+# indexer. Leave the default unless you run multiple indexer consumers against
+# the same network and need separate checkpoints.
+INDEXER_CURSOR_KEY=ingestion
+
+# -----------------------------------------------------------------------------
 # Stellar network (optional — defaults shown)
 # -----------------------------------------------------------------------------
 # STELLAR_NETWORK=testnet


### PR DESCRIPTION
## Summary
- add `INDEXER_CURSOR_KEY` to `.env.example`
- document that it is optional and defaults to the existing `ingestion` checkpoint key
- explain when operators should change it for multiple indexer consumers

Closes #357.

## Validation
- `git diff --check`

Note: no runtime test suite was run because this is a documentation/example-env-only change.