### PR TITLE
feat(api,indexer,oracle,workers): address issues #346-#349

### DIFF
--- a/apps/indexer/src/main.ts
+++ b/apps/indexer/src/main.ts
@@ -2,7 +2,10 @@ import "dotenv/config";
 import { loadConfig } from "./config.js";
 import { PollingIngestionLoop } from "./ingestion.js";
 import { createLogger } from "./logger.js";
-import { InternalIndexerMetricsService } from "./metrics.js";
+import {
+  InternalIndexerMetricsService,
+  type IndexerMetricsLog,
+} from "./metrics.js";
 import { PrismaCursorStorageClient } from "./storage.js";
 import { disconnectPrisma } from "../../../src/services/prisma.js";
 
@@ -42,7 +45,7 @@ async function bootstrap(): Promise<void> {
 
   await ingestionLoop.start(initialCursor);
   logger.info("Indexer startup complete", {
-    metrics: metrics.getSnapshot(),
+    metrics: metrics.getSnapshot() satisfies IndexerMetricsLog,
   });
 
   let isShuttingDown = false;

--- a/apps/indexer/src/metrics.ts
+++ b/apps/indexer/src/metrics.ts
@@ -2,6 +2,11 @@ export interface IndexerMetricsSnapshot {
   latestIndexedLedgerSequence: number | null;
 }
 
+/** Typed payload used when logging a metrics snapshot. */
+export interface IndexerMetricsLog {
+  latestIndexedLedgerSequence: number | null;
+}
+
 export class InternalIndexerMetricsService {
   private latestIndexedLedgerSequence: number | null = null;
 

--- a/apps/oracle/oracle-service.ts
+++ b/apps/oracle/oracle-service.ts
@@ -14,6 +14,7 @@ import type {
 } from "./provider-adapter.js";
 import { withTimeout, DEFAULT_TIMEOUT_MS } from "./timeout-utils.js";
 import { withRetry, RetryConfig, isRetryableError } from "./retry-utils.js";
+import type { Logger } from "../indexer/src/logger.js";
 
 /**
  * Oracle service configuration.
@@ -29,6 +30,8 @@ export interface OracleServiceConfig {
   defaultTimeoutMs?: number;
   /** Retry configuration for provider calls */
   retryConfig?: Partial<RetryConfig>;
+  /** Structured logger — defaults to a no-op logger if omitted */
+  logger?: Logger;
 }
 
 /**
@@ -57,6 +60,7 @@ export class OracleService {
   private primaryAdapter: ProviderAdapter;
   private fallbackAdapter: ProviderAdapter;
   private config: OracleServiceConfig;
+  private readonly logger: Logger;
 
   private metrics: OracleMetrics = {
     primarySuccessCount: 0,
@@ -70,6 +74,12 @@ export class OracleService {
   constructor(config: OracleServiceConfig) {
     this.primaryAdapter = config.primaryAdapter;
     this.fallbackAdapter = config.fallbackAdapter;
+    this.logger = config.logger ?? {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
     this.config = {
       enableFallback: true,
       defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
@@ -91,32 +101,39 @@ export class OracleService {
 
     try {
       // Attempt primary provider
-      console.log(
-        `[OracleService] Resolving market ${request.marketId} using primary provider`
-      );
+      this.logger.info("Resolving market via primary provider", {
+        marketId: request.marketId,
+      });
 
       const result = await withRetry(
         () => this.primaryAdapter.resolve(request),
         this.config.retryConfig,
         (error, attempt, delay) => {
           this.metrics.retryCount++;
-          console.warn(
-            `[OracleService] Primary provider retry ${attempt} for market ${request.marketId} (delay: ${delay.toFixed(0)}ms): ${error.message}`
-          );
+          this.logger.warn("Primary provider retry", {
+            marketId: request.marketId,
+            attempt,
+            delayMs: Math.round(delay),
+            error: error.message,
+          });
         }
       );
 
       this.metrics.primarySuccessCount++;
-      console.log(
-        `[OracleService] Primary provider succeeded for market ${request.marketId} (source: ${result.source})`
-      );
+      this.logger.info("Primary provider resolved market", {
+        marketId: request.marketId,
+        source: result.source,
+      });
       return result;
     } catch (primaryError) {
       this.metrics.primaryFailureCount++;
-      console.error(
-        `[OracleService] Primary provider failed for market ${request.marketId}:`,
-        primaryError instanceof Error ? primaryError.message : primaryError
-      );
+      this.logger.error("Primary provider failed", {
+        marketId: request.marketId,
+        error:
+          primaryError instanceof Error
+            ? primaryError.message
+            : String(primaryError),
+      });
 
       // If fallback is disabled, re-throw the error
       if (!this.config.enableFallback) {
@@ -144,23 +161,27 @@ export class OracleService {
   private async resolveWithFallback(
     request: ResolutionRequest
   ): Promise<ProviderResult> {
-    console.warn(
-      `[OracleService] Falling back to secondary provider for market ${request.marketId}`
-    );
+    this.logger.warn("Falling back to secondary provider", {
+      marketId: request.marketId,
+    });
 
     try {
       const result = await this.fallbackAdapter.resolve(request);
       this.metrics.fallbackUsageCount++;
-      console.log(
-        `[OracleService] Fallback provider succeeded for market ${request.marketId} (source: ${result.source})`
-      );
+      this.logger.info("Fallback provider resolved market", {
+        marketId: request.marketId,
+        source: result.source,
+      });
       return result;
     } catch (fallbackError) {
       this.metrics.fallbackFailureCount++;
-      console.error(
-        `[OracleService] Fallback provider also failed for market ${request.marketId}:`,
-        fallbackError instanceof Error ? fallbackError.message : fallbackError
-      );
+      this.logger.error("Fallback provider failed", {
+        marketId: request.marketId,
+        error:
+          fallbackError instanceof Error
+            ? fallbackError.message
+            : String(fallbackError),
+      });
 
       throw new Error(
         `All providers failed for market ${request.marketId}. Primary: ${

--- a/apps/workers/src/finalization/job.test.ts
+++ b/apps/workers/src/finalization/job.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { FinalizationJob, FinalizationValidationError } from "./job.js";
+import type { Logger } from "../../../indexer/src/logger.js";
+
+function makeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function makePrisma(candidates: unknown[] = []) {
+  return {
+    resolutionCandidate: {
+      findMany: vi.fn().mockResolvedValue(candidates),
+    },
+  } as unknown as Parameters<typeof FinalizationJob>[0];
+}
+
+describe("FinalizationJob", () => {
+  describe("input validation", () => {
+    it("throws FinalizationValidationError (statusCode 400) for negative challengeWindowSeconds", async () => {
+      const job = new FinalizationJob(makePrisma(), makeLogger(), -1);
+      await expect(job.run()).rejects.toThrow(FinalizationValidationError);
+      await expect(job.run()).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it("throws FinalizationValidationError for NaN challengeWindowSeconds", async () => {
+      const job = new FinalizationJob(makePrisma(), makeLogger(), NaN);
+      await expect(job.run()).rejects.toThrow(FinalizationValidationError);
+    });
+
+    it("throws FinalizationValidationError for Infinity challengeWindowSeconds", async () => {
+      const job = new FinalizationJob(makePrisma(), makeLogger(), Infinity);
+      await expect(job.run()).rejects.toThrow(FinalizationValidationError);
+    });
+
+    it("accepts zero challengeWindowSeconds", async () => {
+      const job = new FinalizationJob(makePrisma(), makeLogger(), 0);
+      await expect(job.run()).resolves.toBeUndefined();
+    });
+
+    it("accepts a positive challengeWindowSeconds", async () => {
+      const job = new FinalizationJob(makePrisma(), makeLogger(), 3600);
+      await expect(job.run()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/workers/src/finalization/job.ts
+++ b/apps/workers/src/finalization/job.ts
@@ -9,6 +9,14 @@ export interface FinalizationCandidate {
   createdAt: Date;
 }
 
+export class FinalizationValidationError extends Error {
+  readonly statusCode = 400;
+  constructor(message: string) {
+    super(message);
+    this.name = "FinalizationValidationError";
+  }
+}
+
 export class FinalizationJob {
   constructor(
     private readonly prisma: PrismaClient,
@@ -17,6 +25,15 @@ export class FinalizationJob {
   ) {}
 
   async run(): Promise<void> {
+    if (
+      !Number.isFinite(this.challengeWindowSeconds) ||
+      this.challengeWindowSeconds < 0
+    ) {
+      throw new FinalizationValidationError(
+        `challengeWindowSeconds must be a non-negative number, got: ${this.challengeWindowSeconds}`
+      );
+    }
+
     const windowCutoff = new Date(
       Date.now() - this.challengeWindowSeconds * 1000
     );

--- a/tests/docker-compose.test.ts
+++ b/tests/docker-compose.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const COMPOSE_PATH = resolve(process.cwd(), "docker-compose.yml");
+
+describe("docker-compose.yml", () => {
+  it("file exists and is readable", () => {
+    expect(() => readFileSync(COMPOSE_PATH, "utf8")).not.toThrow();
+  });
+
+  it("defines postgres and redis services", () => {
+    const content = readFileSync(COMPOSE_PATH, "utf8");
+    expect(content).toContain("postgres:");
+    expect(content).toContain("redis:");
+  });
+
+  it("postgres service exposes port 5433", () => {
+    const content = readFileSync(COMPOSE_PATH, "utf8");
+    expect(content).toContain("5433:5432");
+  });
+
+  it("redis service exposes port 6379", () => {
+    const content = readFileSync(COMPOSE_PATH, "utf8");
+    expect(content).toContain("6379:6379");
+  });
+
+  it("defines named volumes for persistence", () => {
+    const content = readFileSync(COMPOSE_PATH, "utf8");
+    expect(content).toContain("postgres_data:");
+    expect(content).toContain("redis_data:");
+  });
+});


### PR DESCRIPTION
closes: #346
closes: #347
closes: #348
closes: #349

- #346 [api]: Add Vitest test for docker-compose.yml Added tests/docker-compose.test.ts that validates the compose file exists, defines postgres and redis services, exposes the expected ports, and declares named volumes for persistence.

- #347 [indexer]: Add TypeScript type for metrics log Added IndexerMetricsLog interface to apps/indexer/src/metrics.ts and used it with a 'satisfies' check in main.ts when logging the startup metrics snapshot. No 'any' in new code; exported from metrics module.

- #348 [oracle]: Improve log messages in submission queue Replaced all console.log/warn/error calls in oracle-service.ts with structured Logger calls (info/warn/error). Logger is injected via OracleServiceConfig.logger (optional, defaults to no-op) so existing tests require no changes. Each log entry carries structured fields (marketId, source, error, attempt, delayMs) at the appropriate level.

- #349 [workers]: Add input validation to finalization job Added FinalizationValidationError (statusCode=400) and a guard at the top of FinalizationJob.run() that throws it when challengeWindowSeconds is negative, NaN, or Infinity. Added job.test.ts covering the invalid and valid input cases.