### PR TITLE
feat: indexer and oracle onboarding tasks (#259 #260 #261 #262)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,12 @@ STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 # Indexer
 # -----------------------------------------------------------------------------
 
+# Required: Stellar network passphrase used by the event parser to identify the network.
+# The passphrase is embedded in every transaction envelope and must match the target network.
+# Testnet : "Test SDF Network ; September 2015"
+# Mainnet : "Public Global Stellar Network ; September 2015"
+SOROBAN_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
 # Optional: Persisted ledger cursor checkpoint key.
 # Change only when running multiple indexer consumers against the same network.
 INDEXER_CURSOR_KEY=ingestion

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -12,3 +12,7 @@ Handles ledger/event ingestion and indexing.
 ## Notes
 
 Must remain isolated from API request/response logic.
+
+## Further reading
+
+- [Ledger cursor](../../docs/indexer-ledger-cursor.md) — how the indexer tracks its position in the Stellar blockchain and recovers after restarts.

--- a/apps/oracle/oracle-config.ts
+++ b/apps/oracle/oracle-config.ts
@@ -1,0 +1,102 @@
+/**
+ * Oracle Config Loader
+ *
+ * Reads and validates all oracle environment variables in one place,
+ * returning a strongly-typed OracleConfig object.
+ *
+ * @module apps/oracle/oracle-config
+ */
+
+import {
+  getOraclePollIntervalMs,
+  DEFAULT_POLL_INTERVAL_MS,
+} from "./oracle-scheduler.js";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+/**
+ * Fully resolved oracle configuration derived from environment variables.
+ * All fields have concrete types — no `any`.
+ */
+export interface OracleConfig {
+  /** Polling interval for oracle resolution checks, in milliseconds. */
+  pollIntervalMs: number;
+  /** Duration of the oracle challenge window, in seconds. */
+  challengeWindowSeconds: number;
+  /** Log verbosity for the oracle scheduler. */
+  logLevel: LogLevel;
+  /**
+   * Stellar secret key used to sign resolution reports.
+   * Present only when `ORACLE_SECRET_KEY` is set in the environment.
+   */
+  secretKey: string | undefined;
+}
+
+const VALID_LOG_LEVELS: ReadonlySet<string> = new Set([
+  "debug",
+  "info",
+  "warn",
+  "error",
+]);
+
+const DEFAULT_CHALLENGE_WINDOW_SECONDS = 86_400;
+const DEFAULT_LOG_LEVEL: LogLevel = "info";
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Read and validate oracle environment variables.
+ *
+ * @param env - Environment map (defaults to `process.env`).
+ * @returns Validated OracleConfig.
+ * @throws {Error} When any present variable fails validation.
+ */
+export function loadOracleConfig(env: Env = process.env): OracleConfig {
+  const pollIntervalMs = getOraclePollIntervalMs();
+
+  const challengeWindowSeconds = parseOptionalPositiveInt(
+    env["ORACLE_CHALLENGE_WINDOW_SECONDS"],
+    "ORACLE_CHALLENGE_WINDOW_SECONDS",
+    DEFAULT_CHALLENGE_WINDOW_SECONDS
+  );
+
+  const logLevel = parseLogLevel(env["ORACLE_LOG_LEVEL"], "ORACLE_LOG_LEVEL");
+
+  return {
+    pollIntervalMs,
+    challengeWindowSeconds,
+    logLevel,
+    secretKey: env["ORACLE_SECRET_KEY"] ?? undefined,
+  };
+}
+
+function parseOptionalPositiveInt(
+  raw: string | undefined,
+  name: string,
+  defaultValue: number
+): number {
+  if (raw === undefined || raw === "") {
+    return defaultValue;
+  }
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer, got: ${JSON.stringify(raw)}`);
+  }
+
+  return value;
+}
+
+function parseLogLevel(raw: string | undefined, name: string): LogLevel {
+  if (raw === undefined || raw === "") {
+    return DEFAULT_LOG_LEVEL;
+  }
+
+  if (!VALID_LOG_LEVELS.has(raw)) {
+    throw new Error(
+      `${name} must be one of ${[...VALID_LOG_LEVELS].join(" | ")}, got: ${JSON.stringify(raw)}`
+    );
+  }
+
+  return raw as LogLevel;
+}

--- a/apps/oracle/signature-helper.test.ts
+++ b/apps/oracle/signature-helper.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { Keypair } from "@stellar/stellar-sdk";
+import {
+  signResolutionReport,
+  verifyResolutionReport,
+} from "./signature-helper.js";
+import type { ResolutionPayload } from "./signature-helper.js";
+
+const testKeypair = Keypair.random();
+const SECRET = testKeypair.secret();
+
+const basePayload: ResolutionPayload = {
+  marketId: "market-001",
+  outcome: true,
+  timestamp: "2026-01-01T00:00:00.000Z",
+};
+
+describe("signResolutionReport", () => {
+  it("returns a report with payload, signature, and publicKey", () => {
+    const report = signResolutionReport(basePayload, SECRET);
+
+    expect(report.payload).toEqual(basePayload);
+    expect(typeof report.signature).toBe("string");
+    expect(report.signature.length).toBeGreaterThan(0);
+    expect(report.publicKey).toBe(testKeypair.publicKey());
+  });
+
+  it("produces the same signature for identical payloads (deterministic)", () => {
+    const r1 = signResolutionReport(basePayload, SECRET);
+    const r2 = signResolutionReport(basePayload, SECRET);
+
+    expect(r1.signature).toBe(r2.signature);
+  });
+
+  it("produces different signatures when marketId differs", () => {
+    const r1 = signResolutionReport(basePayload, SECRET);
+    const r2 = signResolutionReport({ ...basePayload, marketId: "market-002" }, SECRET);
+
+    expect(r1.signature).not.toBe(r2.signature);
+  });
+
+  it("produces different signatures when outcome differs", () => {
+    const r1 = signResolutionReport({ ...basePayload, outcome: true }, SECRET);
+    const r2 = signResolutionReport({ ...basePayload, outcome: false }, SECRET);
+
+    expect(r1.signature).not.toBe(r2.signature);
+  });
+
+  it("throws on an invalid secret key", () => {
+    expect(() => signResolutionReport(basePayload, "not-a-key")).toThrow();
+  });
+});
+
+describe("verifyResolutionReport", () => {
+  it("returns true for a freshly signed report", () => {
+    const report = signResolutionReport(basePayload, SECRET);
+
+    expect(verifyResolutionReport(report)).toBe(true);
+  });
+
+  it("returns false when the signature is tampered", () => {
+    const report = signResolutionReport(basePayload, SECRET);
+    const tampered = { ...report, signature: "dGFtcGVyZWQ=" };
+
+    expect(verifyResolutionReport(tampered)).toBe(false);
+  });
+
+  it("returns false when the payload marketId is changed after signing", () => {
+    const report = signResolutionReport(basePayload, SECRET);
+    const tampered = {
+      ...report,
+      payload: { ...report.payload, marketId: "market-evil" },
+    };
+
+    expect(verifyResolutionReport(tampered)).toBe(false);
+  });
+
+  it("returns false when the payload outcome is changed after signing", () => {
+    const report = signResolutionReport(basePayload, SECRET);
+    const tampered = {
+      ...report,
+      payload: { ...report.payload, outcome: false },
+    };
+
+    expect(verifyResolutionReport(tampered)).toBe(false);
+  });
+
+  it("returns false for a malformed signature string", () => {
+    const report = signResolutionReport(basePayload, SECRET);
+    const tampered = { ...report, signature: "!!!not-base64!!!" };
+
+    expect(verifyResolutionReport(tampered)).toBe(false);
+  });
+
+  it("returns false when the publicKey does not match the signing key", () => {
+    const other = Keypair.random();
+    const report = signResolutionReport(basePayload, SECRET);
+    const tampered = { ...report, publicKey: other.publicKey() };
+
+    expect(verifyResolutionReport(tampered)).toBe(false);
+  });
+});

--- a/apps/oracle/signature-helper.ts
+++ b/apps/oracle/signature-helper.ts
@@ -1,0 +1,81 @@
+/**
+ * Oracle Signature Helper
+ *
+ * Provides Ed25519 sign / verify helpers for oracle resolution reports.
+ * Uses the Stellar Keypair primitive so the same key material works
+ * with on-chain submission.
+ *
+ * @module apps/oracle/signature-helper
+ */
+
+import { Keypair } from "@stellar/stellar-sdk";
+
+/**
+ * The data payload that is signed for a resolution report.
+ */
+export interface ResolutionPayload {
+  /** Market ID being resolved */
+  marketId: string;
+  /** Resolved outcome (true = YES, false = NO) */
+  outcome: boolean;
+  /** ISO timestamp of the resolution */
+  timestamp: string;
+}
+
+/**
+ * A resolution report with the oracle's signature and public key attached.
+ */
+export interface SignedResolutionReport {
+  payload: ResolutionPayload;
+  /** Base64-encoded Ed25519 signature */
+  signature: string;
+  /** Stellar-format public key of the signing keypair */
+  publicKey: string;
+}
+
+/**
+ * Produce a deterministic canonical string from a payload.
+ * Keys are sorted so the same data always serialises identically.
+ */
+function canonicalise(payload: ResolutionPayload): string {
+  return JSON.stringify({
+    marketId: payload.marketId,
+    outcome: payload.outcome,
+    timestamp: payload.timestamp,
+  });
+}
+
+/**
+ * Sign a resolution payload with the given Stellar secret key.
+ *
+ * @param payload - Resolution data to sign
+ * @param secretKey - Stellar secret key (S…)
+ * @returns Signed report containing the payload, signature, and public key
+ */
+export function signResolutionReport(
+  payload: ResolutionPayload,
+  secretKey: string
+): SignedResolutionReport {
+  const keypair = Keypair.fromSecret(secretKey);
+  const message = Buffer.from(canonicalise(payload), "utf8");
+  const signature = keypair.sign(message).toString("base64");
+
+  return { payload, signature, publicKey: keypair.publicKey() };
+}
+
+/**
+ * Verify a signed resolution report.
+ *
+ * @param report - The signed report to check
+ * @returns `true` when the signature is valid and the payload is unmodified
+ */
+export function verifyResolutionReport(report: SignedResolutionReport): boolean {
+  try {
+    const message = Buffer.from(canonicalise(report.payload), "utf8");
+    const signatureBuffer = Buffer.from(report.signature, "base64");
+    const keypair = Keypair.fromPublicKey(report.publicKey);
+    return keypair.verify(message, signatureBuffer);
+  } catch {
+    return false;
+  }
+}

--- a/docs/indexer-ledger-cursor.md
+++ b/docs/indexer-ledger-cursor.md
@@ -1,0 +1,65 @@
+# Indexer Ledger Cursor
+
+## Overview
+
+The **ledger cursor** is the indexer's bookmark into the Stellar blockchain. It records the
+sequence number of the last ledger successfully processed so the indexer can resume from the
+correct position after a restart instead of re-scanning from genesis.
+
+## How it works
+
+1. On startup the indexer calls `PrismaCursorStorageClient.loadCursor()` to read the persisted
+   sequence number from the `indexerCursor` table in PostgreSQL.
+2. Each ingestion tick advances the cursor by one ledger and calls `saveCursor()` every
+   `checkpointFlushEveryBatches` successful batches (or immediately on shutdown).
+3. The cursor value is a plain decimal string matching the Stellar ledger sequence number
+   (e.g. `"1234567"`).
+
+## Database schema
+
+The cursor is stored in the `indexerCursor` table with a composite primary key of
+`(networkId, cursorKey)`.  This allows multiple indexer consumers to coexist on the same
+database — each with a distinct `cursorKey` — without clobbering one another.
+
+| Column       | Type   | Description                                         |
+|--------------|--------|-----------------------------------------------------|
+| `networkId`  | string | Stellar network identifier (e.g. `"testnet"`)       |
+| `cursorKey`  | string | Logical consumer name, configured via `INDEXER_CURSOR_KEY` |
+| `cursor`     | string | Last processed ledger sequence number               |
+
+## Configuration
+
+| Variable             | Required | Default      | Description                                                      |
+|----------------------|----------|--------------|------------------------------------------------------------------|
+| `INDEXER_CURSOR_KEY` | Optional | `ingestion`  | Key used to namespace the cursor row. Change only when running multiple consumers against the same network. |
+
+## Checkpoint flushing
+
+The cursor is not written to the database on every tick — frequent small writes would create
+unnecessary load.  Instead it is flushed after a configurable number of successful batches
+(`checkpointFlushEveryBatches`) and unconditionally on graceful shutdown.  If the process
+crashes between checkpoints the indexer will re-process a small number of ledgers, which is
+safe because event ingestion is idempotent.
+
+## Recovery
+
+If the cursor row is absent (e.g. first run, or after manual deletion) the indexer starts from
+ledger 0 and scans forward.  To reset the indexer to a specific ledger, delete or update the
+`indexerCursor` row directly in PostgreSQL.
+
+```sql
+-- Reset to a specific ledger
+UPDATE "indexerCursor"
+SET cursor = '1234567'
+WHERE "networkId" = 'testnet' AND "cursorKey" = 'ingestion';
+
+-- Remove the cursor entirely (restart from genesis)
+DELETE FROM "indexerCursor"
+WHERE "networkId" = 'testnet' AND "cursorKey" = 'ingestion';
+```
+
+## Related source files
+
+- `apps/indexer/src/storage.ts` — `PrismaCursorStorageClient` reads and writes the cursor
+- `apps/indexer/src/ingestion.ts` — `PollingIngestionLoop` drives cursor advancement
+- `.env.example` — documents the `INDEXER_CURSOR_KEY` variable


### PR DESCRIPTION
## Summary

- **#259** — `docs/indexer-ledger-cursor.md` documenting ledger cursor mechanics, DB schema, checkpoint flushing, recovery SQL, and `INDEXER_CURSOR_KEY`. Link added to `apps/indexer/README.md`.
- **#260** — Added `SOROBAN_NETWORK_PASSPHRASE` (Required) to `.env.example` under the Indexer section with a comment explaining its purpose and listing both testnet/mainnet values.
- **#261** — Created `apps/oracle/signature-helper.ts` (Ed25519 sign/verify for resolution reports) and `apps/oracle/signature-helper.test.ts` (Vitest suite covering signing, determinism, tampering, and error paths).
- **#262** — Created `apps/oracle/oracle-config.ts` exporting `OracleConfig` interface and `loadOracleConfig()` — fully typed, no `any`, validates all oracle env vars in one place.

## Test plan

- [ ] `pnpm test:run` passes (covers `signature-helper.test.ts`)
- [ ] Review `docs/indexer-ledger-cursor.md` for accuracy against `ingestion.ts` and `storage.ts`
- [ ] Confirm `.env.example` `SOROBAN_NETWORK_PASSPHRASE` matches `apps/indexer/src/config.ts` validation
- [ ] Confirm `OracleConfig` has no `any` and all fields are exported

Closes #259 
closes  #260 
closes #261 
closes  #262 

🤖 Generated with [Claude Code](https://claude.com/claude-code)