### PR TITLE
test(indexer): add Vitest coverage for metrics service

### DIFF
--- a/apps/indexer/src/metrics.test.ts
+++ b/apps/indexer/src/metrics.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { InternalIndexerMetricsService, type IndexerMetricsLog } from "./metrics.js";
+
+describe("InternalIndexerMetricsService", () => {
+  it("initializes with latestIndexedLedgerSequence = null", () => {
+    const service = new InternalIndexerMetricsService();
+    expect(service.getLatestIndexedLedgerSequence()).toBeNull();
+  });
+
+  it("setLatestIndexedLedgerSequence updates the stored value", () => {
+    const service = new InternalIndexerMetricsService();
+    service.setLatestIndexedLedgerSequence(12345);
+    expect(service.getLatestIndexedLedgerSequence()).toBe(12345);
+  });
+
+  it("getSnapshot returns the expected payload shape", () => {
+    const service = new InternalIndexerMetricsService();
+    const snapshot = service.getSnapshot();
+    expect(snapshot).toEqual({
+      latestIndexedLedgerSequence: null,
+    });
+  });
+
+  it("verify the snapshot conforms to the IndexerMetricsLog contract", () => {
+    const service = new InternalIndexerMetricsService();
+    service.setLatestIndexedLedgerSequence(98765);
+    const snapshot = service.getSnapshot();
+
+    // Verify type assertion/satisfaction at compile time (TypeScript check)
+    const logPayload: IndexerMetricsLog = snapshot;
+
+    expect(logPayload).toEqual({
+      latestIndexedLedgerSequence: 98765,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Vitest coverage for the indexer metrics service.

## Changes

* Added `apps/indexer/src/metrics.test.ts`
* Added tests for:

  * initial state (`latestIndexedLedgerSequence` defaults to `null`)
  * updating the latest indexed ledger sequence
  * snapshot generation via `getSnapshot()`
  * compatibility with the `IndexerMetricsLog` payload contract

## Validation

* All new tests pass
* No production code changes
* No new dependencies added

Closes #366
