### PR TITLE
Feature/oracle onboarding tasks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,6 +159,10 @@ FINALIZATION_LOG_LEVEL=info
 # Applies to all loggers unless overridden. Default: info
 LOG_LEVEL=info
 
+# Required for signing oracle resolution reports.
+# Stellar secret key for the oracle service account.
+ORACLE_SECRET_KEY=
+
 # -----------------------------------------------------------------------------
 # Signature Helper
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ docker compose down        # Stop containers
 
 See [docs/architecture.md](docs/architecture.md) for service boundaries and data flow.
 For details on external data retrieval, see [docs/price-fetcher.md](docs/price-fetcher.md).
+For oracle report signing and verification, see [docs/signature-helper.md](docs/signature-helper.md).
 
 ## Project Structure
 

--- a/apps/oracle/submission-queue.test.ts
+++ b/apps/oracle/submission-queue.test.ts
@@ -148,3 +148,46 @@ describe("validateSubmissionQueueItem", () => {
     ).toThrow(SubmissionQueueValidationError);
   });
 });
+
+// ─── SubmissionQueue ─────────────────────────────────────────────────────────
+
+import { SubmissionQueue } from "./submission-queue.js";
+
+describe("SubmissionQueue", () => {
+  it("enqueues a valid item and logs it", () => {
+    const logs: any[] = [];
+    const mockLogger = {
+      info: (msg: string, meta?: any) => logs.push({ level: "info", msg, meta }),
+      warn: (msg: string, meta?: any) => logs.push({ level: "warn", msg, meta }),
+      error: (msg: string, meta?: any) => logs.push({ level: "error", msg, meta }),
+    };
+
+    const queue = new SubmissionQueue(mockLogger);
+    const item = makeItem();
+
+    queue.enqueue(item);
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].level).toBe("info");
+    expect(logs[0].msg).toBe("Submission queued successfully");
+    expect(logs[0].meta).toMatchObject({
+      id: item.id,
+      marketId: item.request.marketId,
+      oracleAddress: item.request.oracleAddress,
+      status: item.status,
+      enqueuedAt: item.enqueuedAt,
+    });
+  });
+
+  it("throws when enqueueing an invalid item", () => {
+    const mockLogger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+
+    const queue = new SubmissionQueue(mockLogger);
+
+    expect(() => queue.enqueue(null as any)).toThrow(SubmissionQueueValidationError);
+  });
+});

--- a/apps/oracle/timeout-utils.ts
+++ b/apps/oracle/timeout-utils.ts
@@ -133,6 +133,12 @@ export function createTimeoutSignal(
 }
 
 /**
+ * A function that executes an operation with support for abort signaling.
+ * Used with withTimeout to handle long-running operations.
+ */
+export type TimeoutHandler<T> = (signal: AbortSignal) => Promise<T>;
+
+/**
  * Execute an async operation with a timeout.
  * If the operation exceeds the timeout, it is aborted and a timeout error is returned.
  *
@@ -141,7 +147,7 @@ export function createTimeoutSignal(
  * @returns Promise resolving to a TimedResult
  */
 export async function withTimeout<T>(
-  operation: (signal: AbortSignal) => Promise<T>,
+  operation: TimeoutHandler<T>,
   config: TimeoutConfig
 ): Promise<TimedResult<T>> {
   const startTime = performance.now();

--- a/docs/signature-helper.md
+++ b/docs/signature-helper.md
@@ -1,0 +1,38 @@
+# Signature Helper
+
+The Oracle Signature Helper provides Ed25519 signing and verification utilities for oracle resolution reports. It uses the Stellar Keypair primitive, ensuring that the same key material works seamlessly with on-chain submission.
+
+## Resolution Payload
+
+The data payload that is signed for a resolution report includes:
+- `marketId`: The ID of the market being resolved.
+- `outcome`: The resolved outcome (`true` for YES, `false` for NO).
+- `timestamp`: ISO timestamp of the resolution.
+
+## Canonicalisation
+
+Before signing, the payload is converted into a deterministic canonical string. Keys are sorted so the same data always serializes identically.
+
+## Usage
+
+### Signing a Report
+
+```typescript
+import { signResolutionReport } from "../apps/oracle/signature-helper";
+
+const payload = {
+  marketId: "12345",
+  outcome: true,
+  timestamp: new Date().toISOString()
+};
+
+const signedReport = signResolutionReport(payload, process.env.ORACLE_SECRET_KEY);
+```
+
+### Verifying a Report
+
+```typescript
+import { verifyResolutionReport } from "../apps/oracle/signature-helper";
+
+const isValid = verifyResolutionReport(signedReport);
+```


### PR DESCRIPTION
closes #271 
closes #272
closes #273
closes #274


1ssue 1 (Config Loader Env Var):

Added ORACLE_SECRET_KEY under the Oracle section in .env.example.
Included a comment explaining its purpose and clarifying that it's required for signing oracle resolution reports.
Issue 2 (Document Signature Helper):

Created a new markdown file docs/signature-helper.md explaining the signature helper's payload structure, canonicalisation, and usage with TypeScript examples.
Added a link to this new document in the Project Map section of README.md.
Issue 3 (Submission Queue Test):

Expanded apps/oracle/submission-queue.test.ts to include tests specifically for the SubmissionQueue class itself.
The test asserts that valid items are enqueued and logged successfully, and invalid items throw SubmissionQueueValidationError.
Issue 4 (Timeout Handler Type):

Extracted the anonymous function type in apps/oracle/timeout-utils.ts into a named TimeoutHandler<T> type.
Exported the type and used it in the signature of the withTimeout utility, removing the need for implicit or inline typing.