### PR TITLE
Feat/316 295 296 317 onboarding tasks

### DIFF
--- a/apps/indexer/src/main.ts
+++ b/apps/indexer/src/main.ts
@@ -2,10 +2,7 @@ import "dotenv/config";
 import { loadConfig } from "./config.js";
 import { PollingIngestionLoop } from "./ingestion.js";
 import { createLogger } from "./logger.js";
-import {
-  InternalIndexerMetricsService,
-  type IndexerMetricsLog,
-} from "./metrics.js";
+import { InternalIndexerMetricsService } from "./metrics.js";
 import { PrismaCursorStorageClient } from "./storage.js";
 import { disconnectPrisma } from "../../../src/services/prisma.js";
 
@@ -46,7 +43,7 @@ async function bootstrap(): Promise<void> {
 
   await ingestionLoop.start(initialCursor);
   logger.info("Indexer startup complete", {
-    metrics: metrics.getSnapshot() satisfies IndexerMetricsLog,
+    metrics: metrics.toLogFields(),
   });
 
   let isShuttingDown = false;

--- a/apps/indexer/src/metrics.test.ts
+++ b/apps/indexer/src/metrics.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { InternalIndexerMetricsService, type IndexerMetricsLog } from "./metrics.js";
+import {
+  InternalIndexerMetricsService,
+  type IndexerMetricsLog,
+} from "./metrics.js";
 
 describe("InternalIndexerMetricsService", () => {
   it("initializes with latestIndexedLedgerSequence = null", () => {
@@ -21,15 +24,13 @@ describe("InternalIndexerMetricsService", () => {
     });
   });
 
-  it("verify the snapshot conforms to the IndexerMetricsLog contract", () => {
+  it("toLogFields returns a valid IndexerMetricsLog payload", () => {
     const service = new InternalIndexerMetricsService();
     service.setLatestIndexedLedgerSequence(98765);
-    const snapshot = service.getSnapshot();
-
-    // Verify type assertion/satisfaction at compile time (TypeScript check)
-    const logPayload: IndexerMetricsLog = snapshot;
+    const logPayload: IndexerMetricsLog = service.toLogFields();
 
     expect(logPayload).toEqual({
+      event: "indexer.metrics.snapshot",
       latestIndexedLedgerSequence: 98765,
     });
   });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,7 @@ export { Logger, LoggerValidationError, LOG_LEVELS } from "./logger.js";
 export type { LogLevel } from "./logger.js";
 
 export type {
+  Env,
   NodeEnv,
   LogLevel,
   BaseConfig,

--- a/packages/shared/src/requireEnv.test.ts
+++ b/packages/shared/src/requireEnv.test.ts
@@ -62,25 +62,25 @@ describe("requireEnv", () => {
     expect(parsed.level).toBe("error");
     expect(parsed.message).toBe("Missing required environment variables");
     expect(parsed.missing).toEqual(["ABSENT_ONE", "ABSENT_TWO"]);
+    expect(parsed.count).toBe(2);
   });
 
-  it("outputs singular message when only one key is missing", () => {
+  it("outputs structured log with count=1 when only one key is missing", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit called");
     });
 
-    expect(() =>
-      requireEnv(["MISSING_KEY"], {})
-    ).toThrow();
+    expect(() => requireEnv(["MISSING_KEY"], {})).toThrow();
 
     const rawMessage: string = errorSpy.mock.calls[0][0];
     const parsed = JSON.parse(rawMessage);
 
     expect(parsed).toHaveProperty("ts");
     expect(parsed.level).toBe("error");
-    expect(parsed.message).toBe("Missing required environment variable");
+    expect(parsed.message).toBe("Missing required environment variables");
     expect(parsed.missing).toEqual(["MISSING_KEY"]);
+    expect(parsed.count).toBe(1);
   });
 
   it("treats an empty-string value as missing", () => {

--- a/packages/shared/src/requireEnv.ts
+++ b/packages/shared/src/requireEnv.ts
@@ -38,8 +38,9 @@ export function requireEnv(
     JSON.stringify({
       ts: new Date().toISOString(),
       level: "error",
-      message: `Missing required environment variable${missing.length > 1 ? "s" : ""}`,
+      message: "Missing required environment variables",
       missing,
+      count: missing.length,
     })
   );
 

--- a/tests/docker-compose.test.ts
+++ b/tests/docker-compose.test.ts
@@ -30,4 +30,9 @@ describe("docker-compose.yml", () => {
     expect(content).toContain("postgres_data:");
     expect(content).toContain("redis_data:");
   });
+
+  it("uses pinned image versions (not latest)", () => {
+    const content = readFileSync(COMPOSE_PATH, "utf8");
+    expect(content).not.toMatch(/image:\s+\S+:latest/);
+  });
 });


### PR DESCRIPTION
closes #295 
closes #296 
closes #316 
closes #317 


#317 [topup] [indexer] Add TypeScript type for metrics log
Repo Avatar
[Vatix-Protocol/vatix-backend](https://github.com/Vatix-Protocol/vatix-backend)
Context
Small onboarding task for indexer.

Task
Add TypeScript type for metrics log

Acceptance criteria
 No any in new code
 Exported where needed
Notes
Keep the PR focused on this task only
Ask questions in the issue thread if scope is unclear


#295 [shared] Add TypeScript type for config types
Repo Avatar
[Vatix-Protocol/vatix-backend](https://github.com/Vatix-Protocol/vatix-backend)
Context
Small onboarding task for shared.

Task
Add TypeScript type for config types

Acceptance criteria
 No any in new code
 Exported where needed
Notes
Keep the PR focused on this task only
Ask questions in the issue thread if scope is unclear