### PR TITLE
feat(shared): add ILogger interface type (#335)

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,7 +7,7 @@ export {
 } from "./logRedactor.js";
 
 export { Logger, LoggerValidationError, LOG_LEVELS } from "./logger.js";
-export type { LogLevel } from "./logger.js";
+export type { LogLevel, ILogger } from "./logger.js";
 
 export type {
   NodeEnv,

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -39,7 +39,15 @@ function validateLogLevel(level: unknown): asserts level is LogLevel {
   }
 }
 
-export class Logger {
+export interface ILogger {
+  debug(msg: string): void;
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+  child(childPrefix: string): ILogger;
+}
+
+export class Logger implements ILogger {
   private level: LogLevel;
   private prefix: string;
 


### PR DESCRIPTION
Added an ILogger interface to packages/shared that mirrors the public API of the Logger class. Logger now implements ILogger, and the interface is exported from the package root so consumers can type logger parameters without coupling to the concrete class.

closes #335 