### PR TITLE
feat(workers): add TypeScript types for graceful shutdown

### DIFF
--- a/apps/workers/src/finalization/main.ts
+++ b/apps/workers/src/finalization/main.ts
@@ -6,6 +6,7 @@ import {
   getPrismaClient,
   disconnectPrisma,
 } from "../../../../src/services/prisma.js";
+import type { ShutdownHandler, ShutdownSignal } from "./types.js";
 
 async function bootstrap(): Promise<void> {
   const config = loadFinalizationConfig();
@@ -26,7 +27,7 @@ async function bootstrap(): Promise<void> {
   const VALID_SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
 
   let isShuttingDown = false;
-  const shutdown = async (signal: string) => {
+  const shutdown: ShutdownHandler = async (signal: ShutdownSignal) => {
     if (
       typeof signal !== "string" ||
       signal.trim() === "" ||

--- a/apps/workers/src/finalization/types.ts
+++ b/apps/workers/src/finalization/types.ts
@@ -47,6 +47,18 @@ export interface FinalizationJobResult {
   durationMs: number;
 }
 
+/**
+ * Valid OS signals that trigger a graceful shutdown.
+ * Constrained to the three signals the finalization worker handles.
+ */
+export type ShutdownSignal = "SIGINT" | "SIGTERM" | "SIGHUP";
+
+/**
+ * Async handler invoked when a shutdown signal is received.
+ * Receives the signal name, performs cleanup, and exits the process.
+ */
+export type ShutdownHandler = (signal: ShutdownSignal) => Promise<void>;
+
 /** Payload shape for a finalization job enqueued via Redis or similar. */
 export interface FinalizationJobPayload {
   /** Unique job ID for idempotency. */


### PR DESCRIPTION
## Summary

Adds explicit TypeScript types for the graceful shutdown logic in the finalization worker.

## Changes

- **`apps/workers/src/finalization/types.ts`**
  - `ShutdownSignal` — string union of the three valid signals: `"SIGINT" | "SIGTERM" | "SIGHUP"`
  - `ShutdownHandler` — type alias `(signal: ShutdownSignal) => Promise<void>`
  - Both types are exported
- **`apps/workers/src/finalization/main.ts`**
  - Imports `ShutdownHandler` and `ShutdownSignal` from `./types.js`
  - `shutdown` variable annotated as `ShutdownHandler`
  - `signal` parameter annotated as `ShutdownSignal`

## Acceptance Criteria

- [x] No `any` in new code
- [x] Exported where needed (`ShutdownSignal`, `ShutdownHandler` exported from `types.ts`)

Closes #283