### PR TITLE
fix(workers): improve dead-letter log message

### DIFF
--- a/apps/workers/src/consumers/dead-letter.test.ts
+++ b/apps/workers/src/consumers/dead-letter.test.ts
@@ -21,12 +21,13 @@ describe("Dead Letter Log", () => {
 
     expect(mockLogger.error).toHaveBeenCalledOnce();
     expect(mockLogger.error).toHaveBeenCalledWith(
-      "Dead letter message recorded",
+      "Job dead-lettered",
       expect.objectContaining({
         messageId: "msg-123",
         queue: "settlement",
         reason: "Max retries exceeded",
-        timestamp: expect.any(String)
+        payloadType: "object",
+        timestamp: expect.any(String),
       })
     );
   });

--- a/apps/workers/src/consumers/dead-letter.ts
+++ b/apps/workers/src/consumers/dead-letter.ts
@@ -8,10 +8,11 @@ export interface DeadLetterMessage {
 }
 
 export function logDeadLetter(logger: ILogger, message: DeadLetterMessage): void {
-  logger.error("Dead letter message recorded", {
+  logger.error("Job dead-lettered", {
     messageId: message.id,
     queue: message.queue,
     reason: message.reason,
-    timestamp: new Date().toISOString()
+    payloadType: typeof message.payload,
+    timestamp: new Date().toISOString(),
   });
 }

--- a/docs/dead-letter-log.md
+++ b/docs/dead-letter-log.md
@@ -34,19 +34,20 @@ const message: DeadLetterMessage = {
 };
 
 logDeadLetter(logger, message);
-// => logger.error("Dead letter message recorded", { messageId, queue, reason, timestamp })
+// => logger.error("Job dead-lettered", { messageId, queue, reason, payloadType, timestamp })
 ```
 
 **Log fields emitted:**
 
-| Field        | Source              | Description                           |
-| ------------ | ------------------- | ------------------------------------- |
-| `messageId`  | `message.id`        | Correlates with upstream job ID       |
-| `queue`      | `message.queue`     | Which queue the message came from     |
-| `reason`     | `message.reason`    | Why the message was dead-lettered     |
-| `timestamp`  | `new Date().toISOString()` | When the dead letter was recorded |
+| Field         | Source                      | Description                               |
+| ------------- | --------------------------- | ----------------------------------------- |
+| `messageId`   | `message.id`                | Correlates with upstream job ID           |
+| `queue`       | `message.queue`             | Which queue the message came from         |
+| `reason`      | `message.reason`            | Why the message was dead-lettered         |
+| `payloadType` | `typeof message.payload`    | JS type of the payload (e.g. `"object"`)  |
+| `timestamp`   | `new Date().toISOString()`  | When the dead letter was recorded         |
 
-> **Note:** The `payload` field is intentionally **not** logged to avoid leaking sensitive data. If you need payload details, inspect the dead letter store or enable `debug`-level logging upstream.
+> **Note:** The `payload` value is intentionally **not** logged to avoid leaking sensitive data. `payloadType` gives operators enough context to distinguish missing payloads from structured ones. If you need payload details, inspect the dead letter store or enable `debug`-level logging upstream.
 
 ## When Messages Are Dead-Lettered
 
@@ -60,7 +61,7 @@ A message is sent to the dead letter log when:
 A Vitest test file is colocated at `apps/workers/src/consumers/dead-letter.test.ts`. It verifies:
 
 - `logDeadLetter` calls `logger.error` exactly once
-- Structured fields (`messageId`, `queue`, `reason`, `timestamp`) are present in the log output
+- Structured fields (`messageId`, `queue`, `reason`, `payloadType`, `timestamp`) are present in the log output
 
 Run tests:
 


### PR DESCRIPTION
## Summary

Improves the dead-letter log entry with a clearer message string and an additional structured field.

## Changes

**`apps/workers/src/consumers/dead-letter.ts`**
- Log message changed from `"Dead letter message recorded"` → `"Job dead-lettered"` (action-oriented, consistent with queue-consumer log style)
- Added `payloadType` field (`typeof message.payload`) — gives operators enough context (e.g. `"object"` vs `"string"` vs `"undefined"`) without logging raw payload data

**`apps/workers/src/consumers/dead-letter.test.ts`**
- Updated assertions to match new message string and `payloadType` field

**`docs/dead-letter-log.md`**
- Updated log field table to include `payloadType`
- Updated code example and test description

## Acceptance Criteria

- [x] Structured fields — `messageId`, `queue`, `reason`, `payloadType`, `timestamp`
- [x] Appropriate log level — `error` (terminal failure)

Closes #284