### PR TITLE
Wire indexer ingestion pipeline from RPC fetch through Prisma batch w…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,13 @@ INDEXER_NETWORK_ID=mainnet
 # Default: ingestion
 INDEXER_CURSOR_KEY=ingestion
 
+# Required: Soroban market contract whose events the indexer ingests.
+# Alias: MARKET_CONTRACT_ID is also accepted.
+INDEXER_CONTRACT_ID=
+
+# Optional: Max ledgers scanned per ingestion tick. Default: 100.
+INDEXER_LEDGER_WINDOW_SIZE=100
+
 # Optional: How often (ms) the ingestion loop polls for new ledgers. Default: 5000.
 # Minimum: 100.
 INDEXER_INGESTION_INTERVAL_MS=5000

--- a/apps/indexer/src/batchWriter.test.ts
+++ b/apps/indexer/src/batchWriter.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PrismaBatchWriter } from "./batchWriter.js";
+import { withIdempotencyKey } from "./idempotency.js";
+import type { NormalizedTrade, NormalizedResolution } from "./types.js";
+
+const TRADE: NormalizedTrade = {
+  eventId: "0000000042-0000000001-0000000003",
+  ledger: 42,
+  ledgerClosedAt: "2024-06-01T00:00:00Z",
+  contractId: "CTEST",
+  marketId: "market-abc",
+  traderAddress: "GABC",
+  counterpartyAddress: "GXYZ",
+  direction: "buy",
+  outcome: "YES",
+  priceRaw: 5_000_000n,
+  quantityRaw: 100n,
+  buyOrderId: "buy-1",
+  sellOrderId: "sell-1",
+};
+
+const RESOLUTION: NormalizedResolution = {
+  eventId: "0000000099-0000000002-0000000000",
+  ledger: 99,
+  ledgerClosedAt: "2024-09-01T00:00:00Z",
+  contractId: "CTEST",
+  marketId: "market-xyz",
+  outcome: "NO",
+  oracleAddress: "GORACLE",
+};
+
+function createMockTx() {
+  return {
+    indexerProcessedEvent: {
+      findUnique: vi.fn(),
+      create: vi.fn().mockResolvedValue({}),
+    },
+    indexedTrade: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+    resolutionCandidate: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+const mockPrisma = {
+  $transaction: vi.fn(),
+};
+
+vi.mock("../../../src/services/prisma.js", () => ({
+  getPrismaClient: () => mockPrisma,
+}));
+
+describe("PrismaBatchWriter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty result for empty batch", async () => {
+    const writer = new PrismaBatchWriter();
+    await expect(writer.write([])).resolves.toEqual({
+      written: 0,
+      skipped: 0,
+      errors: [],
+    });
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("writes trade and resolution records in one transaction", async () => {
+    const tx = createMockTx();
+    tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);
+    mockPrisma.$transaction.mockImplementation(async (fn) => fn(tx));
+
+    const writer = new PrismaBatchWriter();
+    const result = await writer.write([
+      { kind: "trade", data: withIdempotencyKey(TRADE) },
+      { kind: "resolution", data: withIdempotencyKey(RESOLUTION) },
+    ]);
+
+    expect(result).toEqual({ written: 2, skipped: 0, errors: [] });
+    expect(tx.indexedTrade.create).toHaveBeenCalledTimes(1);
+    expect(tx.resolutionCandidate.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          marketId: "market-xyz",
+          proposedOutcome: false,
+          status: "PROPOSED",
+          operatorAddress: "GORACLE",
+        }),
+      })
+    );
+  });
+
+  it("skips duplicate replays", async () => {
+    const tx = createMockTx();
+    const persisted = withIdempotencyKey(TRADE);
+    tx.indexerProcessedEvent.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ idempotencyKey: persisted.idempotencyKey });
+    mockPrisma.$transaction.mockImplementation(async (fn) => fn(tx));
+
+    const writer = new PrismaBatchWriter();
+    const first = await writer.write([{ kind: "trade", data: persisted }]);
+    const second = await writer.write([{ kind: "trade", data: persisted }]);
+
+    expect(first).toEqual({ written: 1, skipped: 0, errors: [] });
+    expect(second).toEqual({ written: 0, skipped: 1, errors: [] });
+    expect(tx.indexedTrade.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("collects per-record errors without aborting the transaction", async () => {
+    const tx = createMockTx();
+    tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);
+    tx.indexedTrade.create.mockRejectedValue(new Error("fk violation"));
+    mockPrisma.$transaction.mockImplementation(async (fn) => fn(tx));
+
+    const writer = new PrismaBatchWriter();
+    const result = await writer.write([
+      { kind: "trade", data: withIdempotencyKey(TRADE) },
+    ]);
+
+    expect(result.written).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].error).toContain("fk violation");
+  });
+});

--- a/apps/indexer/src/batchWriter.ts
+++ b/apps/indexer/src/batchWriter.ts
@@ -1,8 +1,17 @@
 import type { NormalizedTrade, NormalizedResolution } from "./types.js";
+import type {
+  PersistedTrade,
+  PersistedResolution,
+  DuplicateEventLogger,
+} from "./idempotency.js";
+import { insertIfNew } from "./idempotency.js";
+import { getPrismaClient } from "../../../src/services/prisma.js";
+import type { ILogger } from "../../packages/shared/src/logger.js";
+import type { PrismaClient } from "../../../src/generated/prisma/client/index.js";
 
 export type BatchRecord =
-  | { kind: "trade"; data: NormalizedTrade }
-  | { kind: "resolution"; data: NormalizedResolution };
+  | { kind: "trade"; data: PersistedTrade }
+  | { kind: "resolution"; data: PersistedResolution };
 
 export interface BatchWriteError {
   record: BatchRecord;
@@ -19,3 +28,128 @@ export interface BatchWriter {
   write(records: BatchRecord[]): Promise<BatchWriteResult>;
   flush(): Promise<void>;
 }
+
+const CHAIN_RESOLUTION_SOURCE_PREFIX = "chain:market_resolved";
+/** Stellar null account — used when the on-chain tuple omits oracle address. */
+const UNKNOWN_OPERATOR_ADDRESS =
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+export class PrismaBatchWriter implements BatchWriter {
+  private readonly prisma = getPrismaClient();
+
+  constructor(private readonly logger?: ILogger) {}
+
+  async write(records: BatchRecord[]): Promise<BatchWriteResult> {
+    if (records.length === 0) {
+      return { written: 0, skipped: 0, errors: [] };
+    }
+
+    let written = 0;
+    let skipped = 0;
+    const errors: BatchWriteError[] = [];
+    const duplicateLogger: DuplicateEventLogger | undefined = this.logger
+      ? {
+          info: (message, meta) => this.logger!.info(message, meta),
+        }
+      : undefined;
+
+    await this.prisma.$transaction(async (tx) => {
+      for (const record of records) {
+        try {
+          const result = await insertIfNew(
+            record.data,
+            async (persisted) => this.persistRecord(tx, record, persisted),
+            { logger: duplicateLogger }
+          );
+
+          if (result.status === "inserted") {
+            written += 1;
+          } else {
+            skipped += 1;
+          }
+        } catch (error) {
+          errors.push({
+            record,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          this.logger?.warn("Failed to persist indexer batch record", {
+            kind: record.kind,
+            idempotencyKey: record.data.idempotencyKey,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    });
+
+    return { written, skipped, errors };
+  }
+
+  async flush(): Promise<void> {
+    // Single $transaction per write() — nothing buffered between batches.
+  }
+
+  private async persistRecord(
+    tx: Omit<
+      PrismaClient,
+      "$connect" | "$disconnect" | "$on" | "$transaction" | "$extends"
+    >,
+    record: BatchRecord,
+    persisted: PersistedTrade | PersistedResolution
+  ): Promise<PersistedTrade | PersistedResolution | null> {
+    const existing = await tx.indexerProcessedEvent.findUnique({
+      where: { idempotencyKey: persisted.idempotencyKey },
+    });
+    if (existing) {
+      return null;
+    }
+
+    await tx.indexerProcessedEvent.create({
+      data: {
+        idempotencyKey: persisted.idempotencyKey,
+        eventKind: record.kind,
+        ledger: persisted.ledger,
+      },
+    });
+
+    if (record.kind === "trade") {
+      const trade = persisted as PersistedTrade;
+      await tx.indexedTrade.create({
+        data: {
+          idempotencyKey: trade.idempotencyKey,
+          eventId: trade.eventId,
+          ledger: trade.ledger,
+          marketId: trade.marketId,
+          traderAddress: trade.traderAddress,
+          counterpartyAddress: trade.counterpartyAddress,
+          direction: trade.direction,
+          outcome: trade.outcome,
+          priceRaw: trade.priceRaw.toString(),
+          quantityRaw: trade.quantityRaw.toString(),
+          buyOrderId: trade.buyOrderId,
+          sellOrderId: trade.sellOrderId,
+        },
+      });
+      // TODO: update UserPosition shares/collateral when position events are parsed.
+    } else {
+      const resolution = persisted as PersistedResolution;
+      await tx.resolutionCandidate.create({
+        data: {
+          marketId: resolution.marketId,
+          proposedOutcome: resolution.outcome === "YES",
+          source: `${CHAIN_RESOLUTION_SOURCE_PREFIX}:${resolution.contractId}`,
+          status: "PROPOSED",
+          operatorAddress:
+            resolution.oracleAddress.trim() !== ""
+              ? resolution.oracleAddress
+              : UNKNOWN_OPERATOR_ADDRESS,
+          idempotencyKey: resolution.idempotencyKey,
+        },
+      });
+    }
+
+    return persisted;
+  }
+}
+
+/** @deprecated Use PersistedTrade in BatchRecord after withIdempotencyKey(). */
+export type { NormalizedTrade, NormalizedResolution };

--- a/apps/indexer/src/config.ts
+++ b/apps/indexer/src/config.ts
@@ -1,4 +1,9 @@
-export type { IndexerConfig } from "../../../packages/shared/src/config.js";
+import {
+  loadIndexerConfig as loadSharedIndexerConfig,
+  type IndexerConfig as SharedIndexerConfig,
+} from "../../../packages/shared/src/config.js";
+
+export type { SharedIndexerConfig };
 
 export const KNOWN_PASSPHRASES = {
   testnet: "Test SDF Network ; September 2015",
@@ -7,12 +12,14 @@ export const KNOWN_PASSPHRASES = {
 
 type Env = Record<string, string | undefined>;
 
-export interface IndexerConfig {
+export interface ChainConfig {
   sorobanNetworkPassphrase: string;
   horizonUrl: string;
 }
 
-export function loadIndexerConfig(env: Env = process.env): IndexerConfig {
+export interface IndexerAppConfig extends SharedIndexerConfig, ChainConfig {}
+
+export function loadChainConfig(env: Env = process.env): ChainConfig {
   const passphrase = env["SOROBAN_NETWORK_PASSPHRASE"];
 
   if (!passphrase || passphrase.trim() === "") {
@@ -40,4 +47,17 @@ export function loadIndexerConfig(env: Env = process.env): IndexerConfig {
       : "https://horizon-testnet.stellar.org");
 
   return { sorobanNetworkPassphrase: passphrase, horizonUrl };
+}
+
+/** Unified indexer bootstrap config (shared env + chain parser env). */
+export function loadConfig(env: Env = process.env): IndexerAppConfig {
+  return {
+    ...loadSharedIndexerConfig(env),
+    ...loadChainConfig(env),
+  };
+}
+
+/** @deprecated Use loadChainConfig — kept for existing tests. */
+export function loadIndexerConfig(env: Env = process.env): ChainConfig {
+  return loadChainConfig(env);
 }

--- a/apps/indexer/src/index.ts
+++ b/apps/indexer/src/index.ts
@@ -37,3 +37,4 @@ export type {
   BatchWriteResult,
   BatchWriter,
 } from "./batchWriter.js";
+export { PrismaBatchWriter } from "./batchWriter.js";

--- a/apps/indexer/src/ingestion.test.ts
+++ b/apps/indexer/src/ingestion.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PollingIngestionLoop } from "./ingestion.js";
+import type { EventFetcher } from "./eventFetcher.js";
+import type { BatchWriter } from "./batchWriter.js";
+import type { CursorStorageClient } from "./storage.js";
+import type { InternalIndexerMetricsService } from "./metrics.js";
+import type { ILogger } from "../../packages/shared/src/logger.js";
+import type { RawChainEvent } from "./types.js";
+import { nativeToScVal } from "@stellar/stellar-sdk";
+
+const TRADE_TOPIC = "AAAADwAAAA50cmFkZV9leGVjdXRlZAAA";
+const RESOLUTION_TOPIC = "AAAADwAAAA9tYXJrZXRfcmVzb2x2ZWQA";
+
+function makeTradeEvent(id: string): RawChainEvent {
+  const valueXdr = nativeToScVal({
+    market_id: "market-1",
+    trader: "GTRADER",
+    counterparty: "GCOUNTER",
+    direction: "buy",
+    outcome: "YES",
+    price: 5_000_000n,
+    quantity: 10n,
+    buy_order_id: "buy-1",
+    sell_order_id: "sell-1",
+  }).toXDR("base64");
+
+  return {
+    id,
+    ledger: 50,
+    ledgerClosedAt: "2024-01-01T00:00:00Z",
+    contractId: "CTEST",
+    type: "contract",
+    pagingToken: `token-${id}`,
+    valueXdr,
+    topicsXdr: [TRADE_TOPIC],
+  };
+}
+
+function makeResolutionEvent(id: string): RawChainEvent {
+  const valueXdr = nativeToScVal({
+    market_id: "market-1",
+    outcome: "YES",
+    oracle: "GORACLE",
+  }).toXDR("base64");
+
+  return {
+    id,
+    ledger: 51,
+    ledgerClosedAt: "2024-01-01T00:00:00Z",
+    contractId: "CTEST",
+    type: "contract",
+    pagingToken: `token-${id}`,
+    valueXdr,
+    topicsXdr: [RESOLUTION_TOPIC],
+  };
+}
+
+function makeLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe("PollingIngestionLoop", () => {
+  let logger: ILogger;
+  let storage: CursorStorageClient;
+  let metrics: InternalIndexerMetricsService;
+  let eventFetcher: EventFetcher;
+  let batchWriter: BatchWriter;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    storage = {
+      loadCursor: vi.fn().mockResolvedValue("10"),
+      saveCursor: vi.fn().mockResolvedValue(undefined),
+    };
+    metrics = {
+      setLatestIndexedLedgerSequence: vi.fn(),
+      getLatestIndexedLedgerSequence: vi.fn().mockReturnValue(10),
+      toLogFields: vi.fn().mockReturnValue({}),
+    } as unknown as InternalIndexerMetricsService;
+    eventFetcher = {
+      fetchByLedgerWindow: vi.fn(),
+    } as unknown as EventFetcher;
+    batchWriter = {
+      write: vi.fn().mockResolvedValue({ written: 2, skipped: 0, errors: [] }),
+      flush: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  function createLoop(checkpointEvery = 10) {
+    return new PollingIngestionLoop(
+      logger,
+      storage,
+      metrics,
+      5_000,
+      checkpointEvery,
+      {
+        eventFetcher,
+        batchWriter,
+        contractId: "CTEST",
+        ledgerWindowSize: 100,
+      }
+    );
+  }
+
+  async function runIngest(loop: PollingIngestionLoop, cursor: string | null) {
+    return (
+      loop as unknown as {
+        ingestFromCursor(c: string | null): Promise<{
+          nextCursor: string;
+          lastIndexedLedgerSequence: number;
+        }>;
+      }
+    ).ingestFromCursor(cursor);
+  }
+
+  it("happy path: fetches window, writes batch, advances cursor", async () => {
+    vi.mocked(eventFetcher.fetchByLedgerWindow).mockResolvedValue({
+      events: [
+        makeTradeEvent("0000000050-0000000001-0000000000"),
+        makeResolutionEvent("0000000051-0000000001-0000000000"),
+      ],
+      latestLedger: 200,
+    });
+
+    const loop = createLoop();
+    const result = await runIngest(loop, "10");
+
+    expect(eventFetcher.fetchByLedgerWindow).toHaveBeenCalledWith({
+      startLedger: 11,
+      endLedger: 110,
+    });
+    expect(batchWriter.write).toHaveBeenCalledTimes(1);
+    expect(batchWriter.write).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "trade" }),
+        expect.objectContaining({ kind: "resolution" }),
+      ])
+    );
+    expect(result.nextCursor).toBe("110");
+    expect(result.lastIndexedLedgerSequence).toBe(110);
+  });
+
+  it("RPC failure: tick logs error and does not advance cursor", async () => {
+    vi.mocked(eventFetcher.fetchByLedgerWindow).mockRejectedValue(
+      new Error("rpc unavailable")
+    );
+
+    const loop = createLoop();
+    (loop as unknown as { cursor: string | null }).cursor = "10";
+
+    await (loop as unknown as { tick(): Promise<void> }).tick();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "Ingestion tick failed",
+      expect.objectContaining({ error: "rpc unavailable" })
+    );
+    expect(storage.saveCursor).not.toHaveBeenCalled();
+    expect((loop as unknown as { cursor: string | null }).cursor).toBe("10");
+  });
+
+  it("parse failure isolation: one bad trade and one good resolution", async () => {
+    const badTrade = makeTradeEvent("0000000050-0000000001-0000000001");
+    badTrade.valueXdr = nativeToScVal({ market_id: "only-field" }).toXDR(
+      "base64"
+    );
+
+    vi.mocked(eventFetcher.fetchByLedgerWindow).mockResolvedValue({
+      events: [
+        badTrade,
+        makeResolutionEvent("0000000051-0000000001-0000000000"),
+      ],
+      latestLedger: 200,
+    });
+    vi.mocked(batchWriter.write).mockResolvedValue({
+      written: 1,
+      skipped: 0,
+      errors: [],
+    });
+
+    const loop = createLoop();
+    await runIngest(loop, "10");
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Trade parse error — skipping event",
+      expect.objectContaining({
+        eventId: "0000000050-0000000001-0000000001",
+      })
+    );
+    expect(batchWriter.write).toHaveBeenCalledWith([
+      expect.objectContaining({ kind: "resolution" }),
+    ]);
+  });
+
+  it("checkpoint gating: persists cursor only after N successful batches", async () => {
+    vi.mocked(eventFetcher.fetchByLedgerWindow).mockResolvedValue({
+      events: [],
+      latestLedger: 500,
+    });
+
+    const loop = createLoop(2);
+    (loop as unknown as { cursor: string | null }).cursor = "0";
+
+    await (loop as unknown as { tick(): Promise<void> }).tick();
+    expect(storage.saveCursor).not.toHaveBeenCalled();
+
+    await (loop as unknown as { tick(): Promise<void> }).tick();
+    expect(storage.saveCursor).toHaveBeenCalledTimes(1);
+    expect(storage.saveCursor).toHaveBeenCalledWith("200");
+  });
+});

--- a/apps/indexer/src/ingestion.ts
+++ b/apps/indexer/src/ingestion.ts
@@ -1,10 +1,23 @@
 import type { ILogger } from "../../packages/shared/src/logger.js";
 import type { CursorStorageClient } from "./storage.js";
 import type { InternalIndexerMetricsService } from "./metrics.js";
+import type { BatchWriter, BatchRecord } from "./batchWriter.js";
+import type { EventFetcher } from "./eventFetcher.js";
+import { parseTradeEvents } from "./tradeParser.js";
+import { parseResolutionEvents } from "./resolutionParser.js";
+import { withIdempotencyKey } from "./idempotency.js";
+import { TradeParseError, ResolutionParseError } from "./types.js";
 
 export interface IngestionLoop {
   start(initialCursor: string | null): Promise<void>;
   stop(): Promise<void>;
+}
+
+export interface IngestionDependencies {
+  eventFetcher: EventFetcher;
+  batchWriter: BatchWriter;
+  contractId: string;
+  ledgerWindowSize: number;
 }
 
 interface IngestionBatchResult {
@@ -28,7 +41,8 @@ export class PollingIngestionLoop implements IngestionLoop {
     private readonly storage: CursorStorageClient,
     private readonly metrics: InternalIndexerMetricsService,
     private readonly intervalMs: number,
-    private readonly checkpointFlushEveryBatches: number
+    private readonly checkpointFlushEveryBatches: number,
+    private readonly deps: IngestionDependencies
   ) {}
 
   async start(initialCursor: string | null): Promise<void> {
@@ -42,6 +56,8 @@ export class PollingIngestionLoop implements IngestionLoop {
       startCursor: initialCursor,
       intervalMs: this.intervalMs,
       checkpointFlushEveryBatches: this.checkpointFlushEveryBatches,
+      ledgerWindowSize: this.deps.ledgerWindowSize,
+      contractId: this.deps.contractId,
     });
 
     await this.tick();
@@ -151,17 +167,80 @@ export class PollingIngestionLoop implements IngestionLoop {
   ): Promise<IngestionBatchResult> {
     this.logger.debug("Running ingestion tick", { cursor: currentCursor });
 
-    // Placeholder for source ingestion. Simulate successful batch progression.
     const currentSequence = currentCursor ? Number(currentCursor) : 0;
     const safeCurrentSequence =
       Number.isFinite(currentSequence) && currentSequence >= 0
         ? currentSequence
         : 0;
-    const nextSequence = safeCurrentSequence + 1;
+    const startLedger = safeCurrentSequence + 1;
+    const provisionalEnd = startLedger + this.deps.ledgerWindowSize - 1;
+
+    const { events, latestLedger } =
+      await this.deps.eventFetcher.fetchByLedgerWindow({
+        startLedger,
+        endLedger: provisionalEnd,
+      });
+
+    if (startLedger > latestLedger) {
+      return {
+        nextCursor: currentCursor ?? String(safeCurrentSequence),
+        lastIndexedLedgerSequence: safeCurrentSequence,
+      };
+    }
+
+    const endLedger = Math.min(provisionalEnd, latestLedger);
+
+    const { trades, errors: tradeErrors } = parseTradeEvents(events);
+    const { resolutions, errors: resolutionErrors } =
+      parseResolutionEvents(events);
+
+    for (const error of tradeErrors) {
+      this.logger.warn("Trade parse error — skipping event", {
+        eventId: error.eventId,
+        error: error.message,
+        parseErrorType: TradeParseError.name,
+      });
+    }
+
+    for (const error of resolutionErrors) {
+      this.logger.warn("Resolution parse error — skipping event", {
+        eventId: error.eventId,
+        error: error.message,
+        parseErrorType: ResolutionParseError.name,
+      });
+    }
+
+    const records: BatchRecord[] = [
+      ...trades.map(
+        (trade): BatchRecord => ({
+          kind: "trade",
+          data: withIdempotencyKey(trade),
+        })
+      ),
+      ...resolutions.map(
+        (resolution): BatchRecord => ({
+          kind: "resolution",
+          data: withIdempotencyKey(resolution),
+        })
+      ),
+    ];
+
+    const writeResult = await this.deps.batchWriter.write(records);
+
+    this.logger.debug("Ingestion batch complete", {
+      startLedger,
+      endLedger,
+      eventsFetched: events.length,
+      tradesParsed: trades.length,
+      resolutionsParsed: resolutions.length,
+      written: writeResult.written,
+      skipped: writeResult.skipped,
+      writeErrors: writeResult.errors.length,
+    });
 
     return {
-      nextCursor: String(nextSequence),
-      lastIndexedLedgerSequence: nextSequence,
+      nextCursor: String(endLedger),
+      lastIndexedLedgerSequence: endLedger,
     };
   }
 }

--- a/apps/indexer/src/main.ts
+++ b/apps/indexer/src/main.ts
@@ -4,6 +4,8 @@ import { PollingIngestionLoop } from "./ingestion.js";
 import { createLogger } from "./logger.js";
 import { InternalIndexerMetricsService } from "./metrics.js";
 import { PrismaCursorStorageClient } from "./storage.js";
+import { EventFetcher } from "./eventFetcher.js";
+import { PrismaBatchWriter } from "./batchWriter.js";
 import { disconnectPrisma } from "../../../src/services/prisma.js";
 
 async function bootstrap(): Promise<void> {
@@ -15,19 +17,32 @@ async function bootstrap(): Promise<void> {
     config.cursorKey,
     logger
   );
+  const eventFetcher = new EventFetcher({
+    rpcUrl: config.stellarRpcUrl,
+    contractId: config.contractId,
+  });
+  const batchWriter = new PrismaBatchWriter(logger);
   const ingestionLoop = new PollingIngestionLoop(
     logger,
     storage,
     metrics,
     config.ingestionIntervalMs,
-    config.checkpointFlushEveryBatches
+    config.checkpointFlushEveryBatches,
+    {
+      eventFetcher,
+      batchWriter,
+      contractId: config.contractId,
+      ledgerWindowSize: config.ledgerWindowSize,
+    }
   );
 
   logger.info("Indexer bootstrap started", {
     nodeEnv: config.nodeEnv,
     ingestionIntervalMs: config.ingestionIntervalMs,
+    ledgerWindowSize: config.ledgerWindowSize,
     networkId: config.networkId,
     cursorKey: config.cursorKey,
+    contractId: config.contractId,
     checkpointFlushEveryBatches: config.checkpointFlushEveryBatches,
   });
 

--- a/apps/indexer/src/resolutionParser.test.ts
+++ b/apps/indexer/src/resolutionParser.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { nativeToScVal } from "@stellar/stellar-sdk";
 import {
   parseResolutionEvent,
   parseResolutionEvents,
@@ -46,6 +47,23 @@ function makeEvent(overrides: Partial<RawChainEvent> = {}): RawChainEvent {
 // ─── parseResolutionEvent ────────────────────────────────────────────────────
 
 describe("parseResolutionEvent", () => {
+  it("parses on-chain tuple payload (market_id, outcome, resolved_at)", () => {
+    const tupleXdr = nativeToScVal([42, true, 1_700_000_000n]).toXDR("base64");
+    const r = parseResolutionEvent(
+      makeEvent({ valueXdr: tupleXdr, id: "evt-tuple" })
+    );
+
+    expect(r.marketId).toBe("42");
+    expect(r.outcome).toBe("YES");
+    expect(r.oracleAddress).toBe("");
+  });
+
+  it("parses tuple NO outcome as boolean false", () => {
+    const tupleXdr = nativeToScVal([7, false, 99n]).toXDR("base64");
+    const r = parseResolutionEvent(makeEvent({ valueXdr: tupleXdr }));
+    expect(r.outcome).toBe("NO");
+  });
+
   it("parses a YES resolution correctly", () => {
     const r = parseResolutionEvent(makeEvent());
 

--- a/apps/indexer/src/resolutionParser.ts
+++ b/apps/indexer/src/resolutionParser.ts
@@ -29,8 +29,10 @@ function toResolutionOutcome(
   eventId: string
 ): ResolutionOutcome {
   if (value === "YES" || value === "NO") return value;
+  if (value === true) return "YES";
+  if (value === false) return "NO";
   throw new ResolutionParseError(
-    `Unknown resolution outcome: "${String(value)}" — must be "YES" or "NO"`,
+    `Unknown resolution outcome: "${String(value)}" — must be YES/NO or boolean`,
     eventId
   );
 }
@@ -44,14 +46,61 @@ function isResolutionEvent(topicsXdr: string[]): boolean {
   }
 }
 
+interface ResolutionPayload {
+  marketId: string;
+  outcome: ResolutionOutcome;
+  oracleAddress: string;
+}
+
+/**
+ * Supports both legacy ScvMap payloads ({ market_id, outcome, oracle })
+ * and the on-chain tuple (market_id: u32, outcome: bool, resolved_at: u64).
+ */
+function parseResolutionPayload(
+  decoded: unknown,
+  eventId: string
+): ResolutionPayload {
+  if (Array.isArray(decoded)) {
+    if (decoded.length < 2) {
+      throw new ResolutionParseError(
+        "Tuple resolution payload must include market_id and outcome",
+        eventId
+      );
+    }
+
+    return {
+      marketId: String(decoded[0]),
+      outcome: toResolutionOutcome(decoded[1], eventId),
+      oracleAddress: "",
+    };
+  }
+
+  if (
+    typeof decoded !== "object" ||
+    decoded === null ||
+    Array.isArray(decoded)
+  ) {
+    throw new ResolutionParseError(
+      "Event value is not an ScvMap or tuple",
+      eventId
+    );
+  }
+
+  const map = decoded as Record<string, unknown>;
+
+  return {
+    marketId: String(field(map, "market_id", eventId)),
+    outcome: toResolutionOutcome(field(map, "outcome", eventId), eventId),
+    oracleAddress: map.oracle != null ? String(map.oracle) : "",
+  };
+}
+
 /**
  * Parse a single RawChainEvent into a NormalizedResolution.
  *
- * Contract event value is expected to be an ScvMap with keys:
- *   market_id, outcome, oracle
- *
- * The source ledger sequence is preserved in the returned record
- * as the authoritative timestamp for settlement ordering.
+ * Contract event value may be:
+ *   - ScvMap: market_id, outcome (YES/NO), oracle
+ *   - Tuple:  (market_id: u32, outcome: bool, resolved_at: u64)
  *
  * @throws ResolutionParseError if the event is not a resolution event or payload is malformed
  */
@@ -76,24 +125,20 @@ export function parseResolutionEvent(
     );
   }
 
-  if (
-    typeof decoded !== "object" ||
-    decoded === null ||
-    Array.isArray(decoded)
-  ) {
-    throw new ResolutionParseError("Event value is not an ScvMap", event.id);
-  }
+  const payload = parseResolutionPayload(decoded, event.id);
 
-  const map = decoded as Record<string, unknown>;
+  if (payload.oracleAddress === "" && !Array.isArray(decoded)) {
+    throw new ResolutionParseError('Missing field "oracle"', event.id);
+  }
 
   return {
     eventId: event.id,
     ledger: event.ledger,
     ledgerClosedAt: event.ledgerClosedAt,
     contractId: event.contractId,
-    marketId: String(field(map, "market_id", event.id)),
-    outcome: toResolutionOutcome(field(map, "outcome", event.id), event.id),
-    oracleAddress: String(field(map, "oracle", event.id)),
+    marketId: payload.marketId,
+    outcome: payload.outcome,
+    oracleAddress: payload.oracleAddress,
   };
 }
 

--- a/apps/indexer/src/storage.ts
+++ b/apps/indexer/src/storage.ts
@@ -24,11 +24,11 @@ export class PrismaCursorStorageClient implements CursorStorageClient {
         },
       },
       select: {
-        cursor: true,
+        cursorValue: true,
       },
     });
 
-    const cursor = row?.cursor ?? null;
+    const cursor = row?.cursorValue ?? null;
     this.logger?.debug("Ledger cursor loaded", {
       networkId: this.networkId,
       cursorKey: this.cursorKey,
@@ -50,10 +50,10 @@ export class PrismaCursorStorageClient implements CursorStorageClient {
         create: {
           networkId: this.networkId,
           cursorKey: this.cursorKey,
-          cursor,
+          cursorValue: cursor,
         },
         update: {
-          cursor,
+          cursorValue: cursor,
         },
       });
     });

--- a/docs/indexer-ledger-cursor.md
+++ b/docs/indexer-ledger-cursor.md
@@ -9,57 +9,72 @@ correct position after a restart instead of re-scanning from genesis.
 ## How it works
 
 1. On startup the indexer calls `PrismaCursorStorageClient.loadCursor()` to read the persisted
-   sequence number from the `indexerCursor` table in PostgreSQL.
-2. Each ingestion tick advances the cursor by one ledger and calls `saveCursor()` every
-   `checkpointFlushEveryBatches` successful batches (or immediately on shutdown).
-3. The cursor value is a plain decimal string matching the Stellar ledger sequence number
+   sequence number from the `indexer_cursors` table in PostgreSQL.
+2. Each ingestion tick fetches a ledger window via `EventFetcher`, parses events, writes them
+   through `PrismaBatchWriter`, and advances the in-memory cursor to the window end **only after
+   a successful batch write**.
+3. The cursor is flushed to PostgreSQL every `checkpointFlushEveryBatches` successful batches
+   (or immediately on shutdown).
+4. The cursor value is a plain decimal string matching the Stellar ledger sequence number
    (e.g. `"1234567"`).
 
 ## Database schema
 
-The cursor is stored in the `indexerCursor` table with a composite primary key of
-`(networkId, cursorKey)`. This allows multiple indexer consumers to coexist on the same
-database — each with a distinct `cursorKey` — without clobbering one another.
+The cursor is stored in the `indexer_cursors` table with a composite primary key of
+`(network_id, cursor_key)`. This allows multiple indexer consumers to coexist on the same
+database — each with a distinct `cursor_key` — without clobbering one another.
 
-| Column      | Type   | Description                                                |
-| ----------- | ------ | ---------------------------------------------------------- |
-| `networkId` | string | Stellar network identifier (e.g. `"testnet"`)              |
-| `cursorKey` | string | Logical consumer name, configured via `INDEXER_CURSOR_KEY` |
-| `cursor`    | string | Last processed ledger sequence number                      |
+| Column         | Type   | Description                                                |
+| -------------- | ------ | ---------------------------------------------------------- |
+| `network_id`   | string | Stellar network identifier (e.g. `"testnet"`)              |
+| `cursor_key`   | string | Logical consumer name, configured via `INDEXER_CURSOR_KEY` |
+| `cursor_value` | string | Last processed ledger sequence number                      |
+
+Replay safety is provided by `indexer_processed_events.idempotency_key` (SHA-256 of
+`{contractId}:{ledger}:{txIndex}:{eventIndex}`). Re-processing ledgers between checkpoints
+inserts no duplicate rows.
 
 ## Configuration
 
-| Variable             | Required | Default     | Description                                                                                                 |
-| -------------------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------- |
-| `INDEXER_CURSOR_KEY` | Optional | `ingestion` | Key used to namespace the cursor row. Change only when running multiple consumers against the same network. |
+| Variable                                 | Required | Default     | Description                                                                                                 |
+| ---------------------------------------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------- |
+| `INDEXER_CURSOR_KEY`                     | Optional | `ingestion` | Key used to namespace the cursor row. Change only when running multiple consumers against the same network. |
+| `INDEXER_CONTRACT_ID`                    | Required | —           | Soroban contract ID to ingest (also accepts `MARKET_CONTRACT_ID`).                                          |
+| `INDEXER_LEDGER_WINDOW_SIZE`             | Optional | `100`       | Ledgers scanned per ingestion tick.                                                                         |
+| `INDEXER_CHECKPOINT_FLUSH_EVERY_BATCHES` | Optional | `10`        | Successful batches between cursor checkpoints.                                                              |
 
 ## Checkpoint flushing
 
 The cursor is not written to the database on every tick — frequent small writes would create
 unnecessary load. Instead it is flushed after a configurable number of successful batches
-(`checkpointFlushEveryBatches`) and unconditionally on graceful shutdown. If the process
-crashes between checkpoints the indexer will re-process a small number of ledgers, which is
-safe because event ingestion is idempotent.
+(`INDEXER_CHECKPOINT_FLUSH_EVERY_BATCHES`) and unconditionally on graceful shutdown.
 
 ## Recovery
 
 If the cursor row is absent (e.g. first run, or after manual deletion) the indexer starts from
 ledger 0 and scans forward. To reset the indexer to a specific ledger, delete or update the
-`indexerCursor` row directly in PostgreSQL.
+`indexer_cursors` row directly in PostgreSQL.
+
+**Crash between write and checkpoint:** Events in the un-checkpointed window are written to
+PostgreSQL (trades → `indexed_trades`, resolutions → `resolution_candidates`) but the cursor
+may still point to an earlier ledger. On restart the indexer re-fetches that window; duplicate
+events are skipped via `indexer_processed_events` idempotency keys (`skipped` count increments,
+no duplicate DB rows).
 
 ```sql
 -- Reset to a specific ledger
-UPDATE "indexerCursor"
-SET cursor = '1234567'
-WHERE "networkId" = 'testnet' AND "cursorKey" = 'ingestion';
+UPDATE indexer_cursors
+SET cursor_value = '1234567'
+WHERE network_id = 'testnet' AND cursor_key = 'ingestion';
 
 -- Remove the cursor entirely (restart from genesis)
-DELETE FROM "indexerCursor"
-WHERE "networkId" = 'testnet' AND "cursorKey" = 'ingestion';
+DELETE FROM indexer_cursors
+WHERE network_id = 'testnet' AND cursor_key = 'ingestion';
 ```
 
 ## Related source files
 
 - `apps/indexer/src/storage.ts` — `PrismaCursorStorageClient` reads and writes the cursor
-- `apps/indexer/src/ingestion.ts` — `PollingIngestionLoop` drives cursor advancement
-- `.env.example` — documents the `INDEXER_CURSOR_KEY` variable
+- `apps/indexer/src/ingestion.ts` — `PollingIngestionLoop` drives fetch → parse → write
+- `apps/indexer/src/batchWriter.ts` — `PrismaBatchWriter` persists trades and resolutions
+- `.env.example` — documents indexer environment variables

--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -61,13 +61,30 @@ describe("loadBaseConfig", () => {
 describe("loadIndexerConfig", () => {
   const INDEXER_ENV = {
     STELLAR_RPC_URL: "https://soroban-testnet.stellar.org",
+    INDEXER_CONTRACT_ID: "CABC123",
   };
 
   it("loads valid indexer config with defaults", () => {
     const config = loadIndexerConfig(INDEXER_ENV);
     expect(config.stellarRpcUrl).toBe(INDEXER_ENV.STELLAR_RPC_URL);
+    expect(config.contractId).toBe("CABC123");
+    expect(config.ledgerWindowSize).toBe(100);
     expect(config.networkId).toBe("mainnet");
     expect(config.cursorKey).toBe("ingestion");
+  });
+
+  it("accepts MARKET_CONTRACT_ID as alias", () => {
+    const config = loadIndexerConfig({
+      STELLAR_RPC_URL: INDEXER_ENV.STELLAR_RPC_URL,
+      MARKET_CONTRACT_ID: "CMARKET",
+    });
+    expect(config.contractId).toBe("CMARKET");
+  });
+
+  it("throws on missing contract id", () => {
+    expect(() =>
+      loadIndexerConfig({ STELLAR_RPC_URL: INDEXER_ENV.STELLAR_RPC_URL })
+    ).toThrow("INDEXER_CONTRACT_ID");
   });
 
   it("throws on missing STELLAR_RPC_URL", () => {

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -314,7 +314,11 @@ export function loadBaseConfig(env: Env = processEnv): BaseConfig {
 export interface IndexerConfig {
   nodeEnv: NodeEnv;
   stellarRpcUrl: string;
+  /** Soroban contract ID whose events the indexer ingests. */
+  contractId: string;
   ingestionIntervalMs: number;
+  /** Max ledgers to scan per ingestion tick. */
+  ledgerWindowSize: number;
   networkId: string;
   cursorKey: string;
   checkpointFlushEveryBatches: number;
@@ -326,16 +330,33 @@ export interface IndexerConfig {
  *
  * @param env - Defaults to process.env. Pass a custom object in tests.
  */
+function loadIndexerContractId(env: Env): string {
+  const contractId =
+    env["INDEXER_CONTRACT_ID"]?.trim() ||
+    env["MARKET_CONTRACT_ID"]?.trim() ||
+    "";
+  if (contractId === "") {
+    throw new ConfigValidationError(
+      "Missing required environment variable: INDEXER_CONTRACT_ID (or MARKET_CONTRACT_ID)"
+    );
+  }
+  return contractId;
+}
+
 export function loadIndexerConfig(env: Env = processEnv): IndexerConfig {
   return {
     nodeEnv: loadNodeEnv(env),
     stellarRpcUrl: loadUrl("STELLAR_RPC_URL", env, ["https:", "http:"]),
+    contractId: loadIndexerContractId(env),
     ingestionIntervalMs: requireMinNumber(
       "INDEXER_INGESTION_INTERVAL_MS",
       env,
       100,
       5_000
     ),
+    ledgerWindowSize: requirePositiveInt("INDEXER_LEDGER_WINDOW_SIZE", env, {
+      fallback: 100,
+    }),
     networkId: optionalString("INDEXER_NETWORK_ID", "mainnet", env),
     cursorKey: optionalString("INDEXER_CURSOR_KEY", "ingestion", env),
     checkpointFlushEveryBatches: requirePositiveInt(

--- a/prisma/migrations/20260616000000_indexer_ingestion_idempotency/migration.sql
+++ b/prisma/migrations/20260616000000_indexer_ingestion_idempotency/migration.sql
@@ -1,0 +1,47 @@
+-- CreateTable
+CREATE TABLE "indexer_processed_events" (
+    "idempotency_key" VARCHAR(64) NOT NULL,
+    "event_kind" VARCHAR(32) NOT NULL,
+    "ledger" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "indexer_processed_events_pkey" PRIMARY KEY ("idempotency_key")
+);
+
+-- CreateTable
+CREATE TABLE "indexed_trades" (
+    "id" TEXT NOT NULL,
+    "idempotency_key" VARCHAR(64) NOT NULL,
+    "event_id" TEXT NOT NULL,
+    "ledger" INTEGER NOT NULL,
+    "market_id" TEXT NOT NULL,
+    "trader_address" VARCHAR(56) NOT NULL,
+    "counterparty_address" VARCHAR(56) NOT NULL,
+    "direction" VARCHAR(8) NOT NULL,
+    "outcome" VARCHAR(8) NOT NULL,
+    "price_raw" TEXT NOT NULL,
+    "quantity_raw" TEXT NOT NULL,
+    "buy_order_id" TEXT NOT NULL,
+    "sell_order_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "indexed_trades_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "resolution_candidates" ADD COLUMN "idempotency_key" VARCHAR(64);
+
+-- CreateIndex
+CREATE INDEX "indexer_processed_events_ledger_idx" ON "indexer_processed_events"("ledger");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "indexed_trades_idempotency_key_key" ON "indexed_trades"("idempotency_key");
+
+-- CreateIndex
+CREATE INDEX "indexed_trades_market_id_idx" ON "indexed_trades"("market_id");
+
+-- CreateIndex
+CREATE INDEX "indexed_trades_ledger_idx" ON "indexed_trades"("ledger");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "resolution_candidates_idempotency_key_key" ON "resolution_candidates"("idempotency_key");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,6 +152,7 @@ model ResolutionCandidate {
   /// where 0.0 = no confidence and 1.0 = full confidence. Null if not reported by the source.
   confidenceScore Decimal?                  @map("confidence_score") @db.Decimal(5, 4)
   operatorAddress String                    @map("operator_address") @db.VarChar(56)
+  idempotencyKey  String?                   @unique @map("idempotency_key") @db.VarChar(64)
   createdAt       DateTime                  @default(now()) @map("created_at")
   updatedAt       DateTime                  @default(now()) @updatedAt @map("updated_at")
 
@@ -165,17 +166,17 @@ model ResolutionCandidate {
 }
 
 model Resolution {
-  id                           String           @id @default(uuid())
-  marketId                     String           @map("market_id")
-  outcome                      Boolean
-  finalizedAt                  DateTime         @map("finalized_at")
-  provenance                   String
-  status                       ResolutionStatus @default(ACTIVE)
+  id                         String           @id @default(uuid())
+  marketId                   String           @map("market_id")
+  outcome                    Boolean
+  finalizedAt                DateTime         @map("finalized_at")
+  provenance                 String
+  status                     ResolutionStatus @default(ACTIVE)
   /// JSONB field tracking correction and override history
   /// Example: { "corrected_at": "2026-04-28T00:00:00Z", "previous_outcome": false, "reason": "..." }
-  correctionOverrideMetadata   Json?            @map("correction_override_metadata")
-  createdAt                    DateTime         @default(now()) @map("created_at")
-  updatedAt                    DateTime         @default(now()) @updatedAt @map("updated_at")
+  correctionOverrideMetadata Json?            @map("correction_override_metadata")
+  createdAt                  DateTime         @default(now()) @map("created_at")
+  updatedAt                  DateTime         @default(now()) @updatedAt @map("updated_at")
 
   market Market @relation(fields: [marketId], references: [id], onDelete: Cascade, map: "resolutions_market_id_fkey")
 
@@ -216,6 +217,40 @@ model IndexerCursor {
   @@id([networkId, cursorKey])
   @@index([networkId])
   @@map("indexer_cursors")
+}
+
+/// Dedupe ledger for replay-safe indexer ingestion.
+model IndexerProcessedEvent {
+  idempotencyKey String   @id @map("idempotency_key") @db.VarChar(64)
+  eventKind      String   @map("event_kind") @db.VarChar(32)
+  ledger         Int
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  @@index([ledger])
+  @@map("indexer_processed_events")
+}
+
+/// On-chain trade events. Order rows are API/CLOB-owned (uuid PK); chain trades
+/// are stored here keyed by idempotencyKey until fill reconciliation exists.
+model IndexedTrade {
+  id                  String   @id @default(uuid())
+  idempotencyKey      String   @unique @map("idempotency_key") @db.VarChar(64)
+  eventId             String   @map("event_id")
+  ledger              Int
+  marketId            String   @map("market_id")
+  traderAddress       String   @map("trader_address") @db.VarChar(56)
+  counterpartyAddress String   @map("counterparty_address") @db.VarChar(56)
+  direction           String   @db.VarChar(8)
+  outcome             String   @db.VarChar(8)
+  priceRaw            String   @map("price_raw")
+  quantityRaw         String   @map("quantity_raw")
+  buyOrderId          String   @map("buy_order_id")
+  sellOrderId         String   @map("sell_order_id")
+  createdAt           DateTime @default(now()) @map("created_at")
+
+  @@index([marketId])
+  @@index([ledger])
+  @@map("indexed_trades")
 }
 
 model OracleSourceAlias {

--- a/tests/prisma.schema.test.ts
+++ b/tests/prisma.schema.test.ts
@@ -27,6 +27,8 @@ describe("Prisma Schema", () => {
     expect(prisma.userPosition).toBeDefined();
     expect(prisma.position).toBeDefined();
     expect(prisma.indexerCursor).toBeDefined();
+    expect(prisma.indexerProcessedEvent).toBeDefined();
+    expect(prisma.indexedTrade).toBeDefined();
   });
 
   it("should define the expected schema models", () => {
@@ -39,8 +41,10 @@ describe("Prisma Schema", () => {
       "Resolution",
       "Position",
       "IndexerCursor",
+      "IndexerProcessedEvent",
+      "IndexedTrade",
       "OracleSourceAlias",
     ]);
-    expect(modelNames).toHaveLength(9);
+    expect(modelNames).toHaveLength(11);
   });
 });


### PR DESCRIPTION
## Wire indexer ingestion pipeline: EventFetcher → parsers → PrismaBatchWriter

### Summary

- Replace the stub `ingestFromCursor` loop (fake `+1` cursor advance) with a real pipeline: fetch ledger window → parse events → idempotent batch write → advance cursor only after successful write.
- Implement `PrismaBatchWriter` with replay-safe dedupe via `indexer_processed_events`, trade persistence to `indexed_trades`, and resolution persistence to `resolution_candidates`.
- Fix `PrismaCursorStorageClient` to use `cursorValue` (schema field), add `INDEXER_CONTRACT_ID` / `INDEXER_LEDGER_WINDOW_SIZE` config, and align `parseResolutionEvent` with both ScvMap and on-chain tuple payloads.

### Problem

The indexer looked healthy but indexed nothing. `PollingIngestionLoop` advanced a fake cursor every tick while `EventFetcher`, parsers, idempotency, and batch writer sat unused.

### Changes

**Ingestion loop (`apps/indexer/src/ingestion.ts`)**
- Inject `EventFetcher`, `BatchWriter`, `contractId`, and `ledgerWindowSize`.
- Compute ledger window per tick and call `fetchByLedgerWindow`.
- Route events through `parseTradeEvents` / `parseResolutionEvents`.
- Stamp records with `withIdempotencyKey()` before write.
- Advance cursor only after successful batch write; RPC failures leave cursor unchanged.
- Skip bad events on parse failure and continue the batch.

**Batch writer (`apps/indexer/src/batchWriter.ts`)**
- Add `PrismaBatchWriter` implementing `BatchWriter`.
- Single Prisma `$transaction` per batch using `insertIfNew`.
- Trades → `indexed_trades` (chain order IDs don't map cleanly to UUID `orders`).
- Resolutions → `resolution_candidates` with `status: PROPOSED`.
- Return `{ written, skipped, errors }` per batch.

**Config & bootstrap**
- `packages/shared/src/config.ts`: `contractId`, `ledgerWindowSize`.
- `apps/indexer/src/config.ts`: unified `loadConfig()`.
- `apps/indexer/src/main.ts`: wire fetcher + writer + config.
- `.env.example`: `INDEXER_CONTRACT_ID`, `INDEXER_LEDGER_WINDOW_SIZE`.

**Fixes**
- `storage.ts`: `cursor` → `cursorValue`.
- `resolutionParser.ts`: adapter for ScvMap `{ market_id, outcome, oracle }` and tuple `(u32, bool, u64)`.

**Schema / migration**
- `IndexerProcessedEvent` — idempotency dedupe ledger.
- `IndexedTrade` — on-chain trade storage.
- `ResolutionCandidate.idempotencyKey` — unique nullable column.

**Tests**
- `ingestion.test.ts` — happy path, RPC failure, parse isolation, checkpoint gating.
- `batchWriter.test.ts` — write, duplicate skip, per-record errors.
- `resolutionParser.test.ts` — tuple payload parsing.

**Docs**
- `docs/indexer-ledger-cursor.md` — crash recovery and idempotency semantics.

Closes #425 
### Notes

- `ResolutionCandidate.marketId` is FK-constrained to `markets.id` — resolution writes fail until matching markets exist (logged as write errors).
- `UserPosition` updates deferred (TODO) until position events are parsed.
- `trade_executed` parser is wired but contract may not emit that topic yet.

### Labels

`enhancement`, `indexer`, `bug`