### PR TITLE
feat(orders): wire CLOB matching engine into POST /orders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,6 +192,11 @@ ORACLE_LOG_LEVEL=info
 # Default: oracle-submissions
 SUBMISSION_QUEUE_NAME=oracle-submissions
 
+# Optional. Redis stream name for settlement jobs.
+# Used to enqueue settlement jobs for off-chain execution.
+# Default: settlement-trades
+SETTLEMENT_QUEUE_NAME=settlement-trades
+
 # Optional. Log level for the finalization worker.
 # Accepted values: debug | info | warn | error
 # Controls verbosity of finalization worker logging.

--- a/apps/workers/src/settlement/consumer.ts
+++ b/apps/workers/src/settlement/consumer.ts
@@ -1,0 +1,224 @@
+import "dotenv/config";
+import { redis } from "../../../src/services/redis.js";
+import { createLogger } from "../../../indexer/src/logger.js";
+import {
+  getPrismaClient,
+  disconnectPrisma,
+} from "../../../src/services/prisma.js";
+import type { ILogger } from "../../../packages/shared/src/logger.js";
+
+const STREAM_KEY = () => {
+  const queueName = process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades";
+  const keyPrefix = process.env.REDIS_KEY_PREFIX ?? "vatix:";
+  return `${keyPrefix}${queueName}`;
+};
+
+const CONSUMER_GROUP = "settlement-worker";
+
+interface SettlementJob {
+  tradeId: string;
+  marketId: string;
+  outcome: string;
+  buyOrderId: string;
+  sellOrderId: string;
+  buyerAddress: string;
+  sellerAddress: string;
+  price: string;
+  quantity: string;
+  timestamp: string;
+}
+
+class SettlementConsumer {
+  private logger: ILogger;
+
+  constructor(logger: ILogger) {
+    this.logger = logger;
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      await redis.xgroup("CREATE", STREAM_KEY(), CONSUMER_GROUP, "$", {
+        MKSTREAM: true,
+      });
+      this.logger.info("Settlement consumer group initialized", {
+        stream: STREAM_KEY(),
+        group: CONSUMER_GROUP,
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("BUSYGROUP")) {
+        this.logger.info("Settlement consumer group already exists", {
+          stream: STREAM_KEY(),
+          group: CONSUMER_GROUP,
+        });
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  async processJob(job: SettlementJob, streamId: string): Promise<void> {
+    this.logger.info(
+      {
+        event: "settlement.received",
+        tradeId: job.tradeId,
+        marketId: job.marketId,
+        buyOrderId: job.buyOrderId,
+        sellOrderId: job.sellOrderId,
+        price: job.price,
+        quantity: job.quantity,
+      },
+      "Settlement job received"
+    );
+
+    // TODO: Implement actual settlement execution on-chain
+    // For now, this is a stub that logs the job
+  }
+
+  async run(): Promise<void> {
+    const streamKey = STREAM_KEY();
+
+    try {
+      const client = redis["getClient"]?.();
+      if (!client) {
+        this.logger.error("Redis client not available");
+        return;
+      }
+
+      // Read pending messages (any messages not yet acknowledged)
+      const pending = await (client.xreadgroup as any)(
+        "GROUP",
+        CONSUMER_GROUP,
+        `settlement-consumer-${Date.now()}`,
+        "BLOCK",
+        "1000",
+        "STREAMS",
+        streamKey,
+        ">"
+      );
+
+      if (!pending || pending.length === 0) {
+        return;
+      }
+
+      const [, messages] = pending[0];
+
+      for (const [streamId, fields] of messages) {
+        try {
+          const jobData = Object.fromEntries(
+            fields.reduce((acc: any[], val: any, i: number) => {
+              if (i % 2 === 0) acc.push([val]);
+              else acc[acc.length - 1].push(val);
+              return acc;
+            }, [])
+          ) as SettlementJob;
+
+          await this.processJob(jobData, streamId);
+
+          // Acknowledge the message
+          await (client.xack as any)(streamKey, CONSUMER_GROUP, streamId);
+        } catch (error) {
+          this.logger.error(
+            {
+              event: "settlement.processing_failed",
+              streamId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "Settlement job processing failed"
+          );
+        }
+      }
+    } catch (error) {
+      this.logger.error(
+        {
+          event: "settlement.consumer_error",
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Settlement consumer error"
+      );
+    }
+  }
+}
+
+async function bootstrap(): Promise<void> {
+  const logLevel = process.env.LOG_LEVEL ?? "info";
+  const logger = createLogger(logLevel);
+  const prisma = getPrismaClient();
+  const consumer = new SettlementConsumer(logger);
+
+  logger.info("Settlement worker started", {
+    stream: STREAM_KEY(),
+    group: CONSUMER_GROUP,
+  });
+
+  await consumer.initialize();
+  await consumer.run();
+
+  const timer = setInterval(() => void consumer.run(), 5000);
+
+  const VALID_SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+
+  let isShuttingDown = false;
+  const shutdown = async (signal: string) => {
+    if (
+      typeof signal !== "string" ||
+      signal.trim() === "" ||
+      !VALID_SHUTDOWN_SIGNALS.includes(
+        signal as (typeof VALID_SHUTDOWN_SIGNALS)[number]
+      )
+    ) {
+      logger.warn("Graceful shutdown called with invalid signal", {
+        signal,
+        statusCode: 400,
+        component: "settlement-worker",
+        validSignals: [...VALID_SHUTDOWN_SIGNALS],
+      });
+      return;
+    }
+
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+
+    logger.info("Settlement worker shutdown initiated", {
+      signal,
+      component: "settlement-worker",
+      status: "initiated",
+    });
+    clearInterval(timer);
+
+    try {
+      await disconnectPrisma();
+      logger.info("Settlement worker shutdown complete", {
+        signal,
+        component: "settlement-worker",
+        status: "complete",
+        exitCode: 0,
+      });
+      process.exit(0);
+    } catch (error) {
+      logger.error("Settlement worker shutdown failed", {
+        signal,
+        component: "settlement-worker",
+        status: "failed",
+        exitCode: 1,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      process.exit(1);
+    }
+  };
+
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+}
+
+void bootstrap().catch((error) => {
+  console.error(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      level: "error",
+      message: "Settlement worker failed during bootstrap",
+      error: error instanceof Error ? error.message : String(error),
+    })
+  );
+  process.exit(1);
+});

--- a/src/api/routes/orders.test.ts
+++ b/src/api/routes/orders.test.ts
@@ -5,21 +5,26 @@ import { errorHandler } from "../middleware/errorHandler.js";
 import type { PrismaClient } from "../../generated/prisma/client";
 import { clearRateLimitStores } from "../middleware/rateLimiter.js";
 
-const { mockAuditService, mockPrismaClient } = vi.hoisted(() => ({
-  mockAuditService: {
-    getWalletTradeHistory: vi.fn(),
-  },
-  mockPrismaClient: {
-    order: {
-      findMany: vi.fn(),
-      count: vi.fn(),
-      create: vi.fn(),
+const { mockAuditService, mockPrismaClient, mockMatchingService } = vi.hoisted(
+  () => ({
+    mockAuditService: {
+      getWalletTradeHistory: vi.fn(),
     },
-    market: {
-      findUnique: vi.fn(),
+    mockPrismaClient: {
+      order: {
+        findMany: vi.fn(),
+        count: vi.fn(),
+        create: vi.fn(),
+      },
+      market: {
+        findUnique: vi.fn(),
+      },
+    } as unknown as PrismaClient,
+    mockMatchingService: {
+      placeOrder: vi.fn(),
     },
-  } as unknown as PrismaClient,
-}));
+  })
+);
 
 vi.mock("../../services/prisma.js", () => ({
   getPrismaClient: () => mockPrismaClient,
@@ -27,6 +32,10 @@ vi.mock("../../services/prisma.js", () => ({
 
 vi.mock("../../services/audit.js", () => ({
   auditService: mockAuditService,
+}));
+
+vi.mock("../../matching/matching-service.js", () => ({
+  matchingService: mockMatchingService,
 }));
 
 describe("GET /trades/user/:address", () => {
@@ -436,9 +445,18 @@ describe("POST /orders", () => {
       createdAt: new Date(),
     };
 
+    // Mock market for validation
     (
-      mockPrismaClient.order.create as ReturnType<typeof vi.fn>
-    ).mockResolvedValue(createdOrder);
+      mockPrismaClient.market.findUnique as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(validMarket);
+
+    (
+      mockMatchingService.placeOrder as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      order: createdOrder,
+      trades: [],
+      filledQuantity: 0,
+    });
 
     const response = await app.inject({
       method: "POST",
@@ -453,6 +471,8 @@ describe("POST /orders", () => {
     expect(body.order.id).toBe("order-123");
     expect(body.order.side).toBe("BUY");
     expect(body.order.status).toBe("OPEN");
+    expect(body.trades).toEqual([]);
+    expect(body.filledQuantity).toBe(0);
   });
 
   it("should reject order with invalid Stellar address", async () => {
@@ -700,8 +720,13 @@ describe("POST /orders", () => {
   });
 
   it("should handle database errors gracefully", async () => {
+    // Mock market for validation
     (
-      mockPrismaClient.order.create as ReturnType<typeof vi.fn>
+      mockPrismaClient.market.findUnique as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(validMarket);
+
+    (
+      mockMatchingService.placeOrder as ReturnType<typeof vi.fn>
     ).mockRejectedValue(new Error("Database error"));
 
     const response = await app.inject({

--- a/src/api/routes/orders.ts
+++ b/src/api/routes/orders.ts
@@ -3,6 +3,7 @@ import { getPrismaClient } from "../../services/prisma.js";
 import { ValidationError } from "../middleware/errors.js";
 import type { OrderSide, Outcome, OrderStatus } from "../../types/index.js";
 import { auditService } from "../../services/audit.js";
+import { matchingService } from "../../matching/matching-service.js";
 import {
   validateUserAddress,
   assertValidOrder,
@@ -379,6 +380,25 @@ export async function ordersRoutes(fastify: FastifyInstance) {
                   createdAt: { type: "string" },
                 },
               },
+              trades: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    marketId: { type: "string" },
+                    outcome: { type: "string" },
+                    buyerAddress: { type: "string" },
+                    sellerAddress: { type: "string" },
+                    buyOrderId: { type: "string" },
+                    sellOrderId: { type: "string" },
+                    price: { type: "number" },
+                    quantity: { type: "number" },
+                    timestamp: { type: "number" },
+                  },
+                },
+              },
+              filledQuantity: { type: "number" },
             },
           },
         },
@@ -402,24 +422,11 @@ export async function ordersRoutes(fastify: FastifyInstance) {
       // Validates: address format, market exists/active, price range, quantity > 0
       await assertValidOrder(orderInput);
 
-      // Create order in database
-      const order = await prisma.order.create({
-        data: {
-          marketId,
-          userAddress,
-          side,
-          outcome,
-          price: price.toString(),
-          quantity,
-          filledQuantity: 0,
-          status: "OPEN",
-        },
-      });
+      // Wire into matching engine and persist atomically
+      const { order, trades, filledQuantity } =
+        await matchingService.placeOrder(orderInput);
 
-      // TODO: Add to matching engine
-      // await matchingEngine.addOrder(order);
-
-      reply.status(201).send({ order });
+      reply.status(201).send({ order, trades, filledQuantity });
     }
   );
 }

--- a/src/matching/engine.ts
+++ b/src/matching/engine.ts
@@ -1,7 +1,6 @@
 import type { Outcome, OrderSide } from "../types/index.js";
 import type { Order as BookOrder } from "./orderbook.js";
 import { OrderBook } from "./orderbook.js";
-import { auditService } from "../services/audit.js";
 
 export interface MatchingOrder {
   id: string;
@@ -245,12 +244,6 @@ export function matchOrder(
         timestamp
       );
       trades.push(trade);
-
-      // Log trade to audit stream
-      auditService.logOrderMatch(trade).catch((error) => {
-        // Don't fail matching if audit log fails
-        console.error("Failed to log trade to audit:", error);
-      });
 
       const newBookOrderQty = bookOrder.quantity - fillQty;
       let cmd: MatchCommand;

--- a/src/matching/matching-service.ts
+++ b/src/matching/matching-service.ts
@@ -1,0 +1,309 @@
+import { randomUUID } from "crypto";
+import type { Outcome } from "../types/index.js";
+import type { OrderInput } from "./validation.js";
+import { OrderBook } from "./orderbook.js";
+import {
+  matchOrder,
+  outcomeToNumber,
+  type MatchingOrder,
+  type Trade,
+} from "./engine.js";
+import { auditService } from "../services/audit.js";
+import { settlementQueue } from "../services/settlement-queue.js";
+import { redis } from "../services/redis.js";
+import { getPrismaClient } from "../services/prisma.js";
+import { ValidationError } from "../api/middleware/errors.js";
+
+export interface PlaceOrderResult {
+  order: any;
+  trades: Trade[];
+  filledQuantity: number;
+}
+
+class MatchingService {
+  private books: Map<string, OrderBook> = new Map();
+  private locks: Map<string, Promise<void>> = new Map();
+
+  private getBookKey(marketId: string, outcome: Outcome): string {
+    return `${marketId}:${outcome}`;
+  }
+
+  private async serialize<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.locks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>((r) => {
+      release = r;
+    });
+    this.locks.set(key, next);
+
+    try {
+      return await prev.then(() => fn());
+    } finally {
+      release();
+      if (this.locks.get(key) === next) {
+        this.locks.delete(key);
+      }
+    }
+  }
+
+  private async hydrateBook(
+    marketId: string,
+    outcome: Outcome
+  ): Promise<OrderBook> {
+    const prisma = getPrismaClient();
+    const outcomeNum = outcomeToNumber(outcome);
+    const bookKey = this.getBookKey(marketId, outcome);
+
+    const book = new OrderBook(marketId, outcomeNum);
+
+    const resting = await prisma.order.findMany({
+      where: {
+        marketId,
+        outcome,
+        status: { in: ["OPEN", "PARTIALLY_FILLED"] },
+      },
+      orderBy: [{ price: "asc" }, { createdAt: "asc" }],
+    });
+
+    for (const order of resting) {
+      const remaining = order.quantity - order.filledQuantity;
+      if (remaining <= 0) continue;
+
+      book.addOrder({
+        id: order.id,
+        userAddress: order.userAddress,
+        side: order.side === "BUY" ? "bid" : "ask",
+        price: Number(order.price),
+        quantity: remaining,
+        timestamp: order.createdAt.getTime(),
+        marketId,
+        outcome: outcomeNum,
+      });
+    }
+
+    this.books.set(bookKey, book);
+    return book;
+  }
+
+  private invalidateBook(marketId: string, outcome: Outcome): void {
+    const bookKey = this.getBookKey(marketId, outcome);
+    this.books.delete(bookKey);
+  }
+
+  private async getOrHydrateBook(
+    marketId: string,
+    outcome: Outcome
+  ): Promise<OrderBook> {
+    const bookKey = this.getBookKey(marketId, outcome);
+    let book = this.books.get(bookKey);
+
+    if (!book) {
+      book = await this.hydrateBook(marketId, outcome);
+    }
+
+    return book;
+  }
+
+  async placeOrder(input: OrderInput): Promise<PlaceOrderResult> {
+    const bookKey = this.getBookKey(input.marketId, input.outcome);
+
+    return this.serialize(bookKey, async () => {
+      const prisma = getPrismaClient();
+      const book = await this.getOrHydrateBook(input.marketId, input.outcome);
+
+      // Self-trade check
+      const userOrders = book.getOrdersByUser(input.userAddress);
+      const hasOppositeResting = userOrders.some((o) => {
+        const oppositeSide = input.side === "BUY" ? "ask" : "bid";
+        return o.side === oppositeSide;
+      });
+
+      if (hasOppositeResting) {
+        throw new ValidationError(
+          "Self-trade: cannot match against your own resting order"
+        );
+      }
+
+      const orderId = randomUUID();
+      const timestamp = Date.now();
+
+      const takerOrder: MatchingOrder = {
+        id: orderId,
+        userAddress: input.userAddress,
+        side: input.side,
+        price: input.price,
+        quantity: input.quantity,
+        marketId: input.marketId,
+        outcome: input.outcome,
+        timestamp,
+      };
+
+      const matchResult = matchOrder(takerOrder, book);
+
+      let takerFilledQuantity =
+        input.quantity - (matchResult.remainingOrder?.quantity ?? 0);
+
+      let takerStatus: "OPEN" | "PARTIALLY_FILLED" | "FILLED";
+      if (takerFilledQuantity === 0) {
+        takerStatus = "OPEN";
+      } else if (takerFilledQuantity < input.quantity) {
+        takerStatus = "PARTIALLY_FILLED";
+      } else {
+        takerStatus = "FILLED";
+      }
+
+      let order: any;
+      try {
+        await prisma.$transaction(async (tx) => {
+          // Create taker order
+          order = await tx.order.create({
+            data: {
+              id: orderId,
+              marketId: input.marketId,
+              userAddress: input.userAddress,
+              side: input.side,
+              outcome: input.outcome,
+              price: input.price.toString(),
+              quantity: input.quantity,
+              filledQuantity: takerFilledQuantity,
+              status: takerStatus,
+            },
+          });
+
+          // Update maker orders
+          for (const trade of matchResult.trades) {
+            const maker =
+              trade.buyOrderId === orderId
+                ? trade.sellOrderId
+                : trade.buyOrderId;
+
+            const makerOrder = await tx.order.findUnique({
+              where: { id: maker },
+              select: { quantity: true, filledQuantity: true },
+            });
+
+            if (!makerOrder) {
+              throw new Error(`Maker order not found: ${maker}`);
+            }
+
+            const newFilledQty = makerOrder.filledQuantity + trade.quantity;
+
+            let makerStatus: "OPEN" | "PARTIALLY_FILLED" | "FILLED";
+            if (newFilledQty === 0) {
+              makerStatus = "OPEN";
+            } else if (newFilledQty < makerOrder.quantity) {
+              makerStatus = "PARTIALLY_FILLED";
+            } else {
+              makerStatus = "FILLED";
+            }
+
+            await tx.order.update({
+              where: { id: maker },
+              data: {
+                filledQuantity: newFilledQty,
+                status: makerStatus,
+              },
+            });
+          }
+
+          // Update positions
+          for (const delta of matchResult.positionDeltas) {
+            await tx.userPosition.upsert({
+              where: {
+                marketId_userAddress: {
+                  marketId: input.marketId,
+                  userAddress: delta.userAddress,
+                },
+              },
+              create: {
+                marketId: input.marketId,
+                userAddress: delta.userAddress,
+                yesShares: delta.yesSharesDelta,
+                noShares: delta.noSharesDelta,
+              },
+              update: {
+                yesShares: {
+                  increment: delta.yesSharesDelta,
+                },
+                noShares: {
+                  increment: delta.noSharesDelta,
+                },
+              },
+            });
+          }
+        });
+      } catch (error) {
+        this.invalidateBook(input.marketId, input.outcome);
+        throw error;
+      }
+
+      // After successful commit:
+      // 1. Add remaining order to book if any
+      if (matchResult.remainingOrder) {
+        book.addOrder({
+          id: matchResult.remainingOrder.id,
+          userAddress: matchResult.remainingOrder.userAddress,
+          side: input.side === "BUY" ? "bid" : "ask",
+          price: matchResult.remainingOrder.price,
+          quantity: matchResult.remainingOrder.quantity,
+          timestamp: matchResult.remainingOrder.timestamp,
+          marketId: input.marketId,
+          outcome: outcomeToNumber(input.outcome),
+        });
+      }
+
+      // 2. Log trades to audit (fire-and-forget)
+      for (const trade of matchResult.trades) {
+        auditService.logOrderMatch(trade).catch((error) => {
+          console.error("Failed to log trade to audit:", error);
+        });
+      }
+
+      // 3. Enqueue settlement jobs (fire-and-forget)
+      for (const trade of matchResult.trades) {
+        settlementQueue
+          .enqueue({
+            tradeId: trade.id,
+            marketId: trade.marketId,
+            outcome: trade.outcome,
+            buyOrderId: trade.buyOrderId,
+            sellOrderId: trade.sellOrderId,
+            buyerAddress: trade.buyerAddress,
+            sellerAddress: trade.sellerAddress,
+            price: trade.price,
+            quantity: trade.quantity,
+            timestamp: trade.timestamp,
+          })
+          .catch((error) => {
+            console.error("Failed to enqueue settlement job:", error);
+          });
+      }
+
+      // 4. Refresh Redis cache (soft)
+      const depth = book.getDepth(20);
+      redis
+        .setOrderBook(input.marketId, input.outcome, {
+          bids: depth.bids.map((d) => ({
+            price: d.price,
+            quantity: d.quantity,
+          })),
+          asks: depth.asks.map((d) => ({
+            price: d.price,
+            quantity: d.quantity,
+          })),
+          timestamp: Date.now(),
+        })
+        .catch((error) => {
+          console.error("Failed to refresh Redis orderbook:", error);
+        });
+
+      return {
+        order,
+        trades: matchResult.trades,
+        filledQuantity: takerFilledQuantity,
+      };
+    });
+  }
+}
+
+export const matchingService = new MatchingService();

--- a/src/services/settlement-queue.ts
+++ b/src/services/settlement-queue.ts
@@ -1,0 +1,54 @@
+import { redis } from "./redis.js";
+import type { Outcome } from "../types/index.js";
+
+export interface SettlementJob {
+  tradeId: string;
+  marketId: string;
+  outcome: Outcome;
+  buyOrderId: string;
+  sellOrderId: string;
+  buyerAddress: string;
+  sellerAddress: string;
+  price: number;
+  quantity: number;
+  timestamp: number;
+}
+
+class SettlementQueueProducer {
+  private streamKey: string;
+
+  constructor() {
+    const queueName = process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades";
+    const keyPrefix = process.env.REDIS_KEY_PREFIX ?? "vatix:";
+    this.streamKey = `${keyPrefix}${queueName}`;
+  }
+
+  async enqueue(job: SettlementJob): Promise<void> {
+    const fields = [
+      "tradeId",
+      job.tradeId,
+      "marketId",
+      job.marketId,
+      "outcome",
+      job.outcome,
+      "buyOrderId",
+      job.buyOrderId,
+      "sellOrderId",
+      job.sellOrderId,
+      "buyerAddress",
+      job.buyerAddress,
+      "sellerAddress",
+      job.sellerAddress,
+      "price",
+      job.price.toString(),
+      "quantity",
+      job.quantity.toString(),
+      "timestamp",
+      job.timestamp.toString(),
+    ];
+
+    await redis.xadd(this.streamKey, "*", ...fields);
+  }
+}
+
+export const settlementQueue = new SettlementQueueProducer();

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -1,0 +1,406 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
+import Fastify, { FastifyInstance } from "fastify";
+import { ordersRoutes } from "../../src/api/routes/orders.js";
+import { errorHandler } from "../../src/api/middleware/errorHandler.js";
+import { testUtils, getTestPrismaClient } from "../setup.js";
+import {
+  acquireDatabaseLock,
+  releaseDatabaseLock,
+} from "../helpers/test-database.js";
+import { matchingService } from "../../src/matching/matching-service.js";
+import { settlementQueue } from "../../src/services/settlement-queue.js";
+
+const validAddress = testUtils.generateStellarAddress("GUSER");
+const makerAddress = testUtils.generateStellarAddress("GMAKER");
+
+describe("Integration Tests: POST /orders with Matching", () => {
+  let app: FastifyInstance;
+  const prisma = getTestPrismaClient();
+
+  beforeAll(async () => {
+    await acquireDatabaseLock();
+    app = Fastify({ logger: false });
+    app.setErrorHandler(errorHandler);
+    await app.register(ordersRoutes);
+
+    // Mock settlement queue to track calls
+    vi.spyOn(settlementQueue, "enqueue").mockResolvedValue(undefined);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await releaseDatabaseLock();
+  });
+
+  beforeEach(async () => {
+    // Clear matching service book cache between tests
+    (matchingService as any).books.clear();
+    (matchingService as any).locks.clear();
+    vi.clearAllMocks();
+  });
+
+  it("should match two crossing orders and return both FILLED", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    // Maker: sell order at 0.5
+    const makerOrder = await testUtils.createTestOrder(
+      market.id,
+      makerAddress,
+      {
+        side: "SELL",
+        outcome: "YES",
+        price: 0.5,
+        quantity: 100,
+        filledQuantity: 0,
+        status: "OPEN",
+      }
+    );
+
+    // Taker: buy order at 0.5 (should match fully)
+    const response = await app.inject({
+      method: "POST",
+      url: "/orders",
+      payload: {
+        marketId: market.id,
+        userAddress: validAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: 0.5,
+        quantity: 100,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const body = JSON.parse(response.body);
+
+    // Taker should be FILLED
+    expect(body.order.status).toBe("FILLED");
+    expect(body.order.filledQuantity).toBe(100);
+    expect(body.filledQuantity).toBe(100);
+
+    // Should have 1 trade
+    expect(body.trades).toHaveLength(1);
+    expect(body.trades[0].price).toBe(0.5);
+    expect(body.trades[0].quantity).toBe(100);
+    expect(body.trades[0].buyOrderId).toBe(body.order.id);
+    expect(body.trades[0].sellOrderId).toBe(makerOrder.id);
+
+    // Maker should be FILLED in DB
+    const makerInDb = await prisma.order.findUnique({
+      where: { id: makerOrder.id },
+    });
+    expect(makerInDb?.status).toBe("FILLED");
+    expect(makerInDb?.filledQuantity).toBe(100);
+
+    // Settlement queue should be called once
+    expect(settlementQueue.enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("should create PARTIALLY_FILLED orders on partial match", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    // Maker: sell 50 at 0.4
+    const makerOrder = await testUtils.createTestOrder(
+      market.id,
+      makerAddress,
+      {
+        side: "SELL",
+        outcome: "YES",
+        price: 0.4,
+        quantity: 50,
+        filledQuantity: 0,
+        status: "OPEN",
+      }
+    );
+
+    // Taker: buy 100 at 0.5 (only 50 will match, 50 will rest)
+    const response = await app.inject({
+      method: "POST",
+      url: "/orders",
+      payload: {
+        marketId: market.id,
+        userAddress: validAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: 0.5,
+        quantity: 100,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const body = JSON.parse(response.body);
+
+    // Taker should be PARTIALLY_FILLED
+    expect(body.order.status).toBe("PARTIALLY_FILLED");
+    expect(body.order.filledQuantity).toBe(50);
+    expect(body.filledQuantity).toBe(50);
+
+    // Should have 1 trade
+    expect(body.trades).toHaveLength(1);
+    expect(body.trades[0].quantity).toBe(50);
+
+    // Maker should be FILLED
+    const makerInDb = await prisma.order.findUnique({
+      where: { id: makerOrder.id },
+    });
+    expect(makerInDb?.status).toBe("FILLED");
+    expect(makerInDb?.filledQuantity).toBe(50);
+
+    // Taker should be in DB with PARTIALLY_FILLED status
+    const takerInDb = await prisma.order.findUnique({
+      where: { id: body.order.id },
+    });
+    expect(takerInDb?.status).toBe("PARTIALLY_FILLED");
+    expect(takerInDb?.filledQuantity).toBe(50);
+  });
+
+  it("should create OPEN order when no match found", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    // No existing orders, so this should be OPEN
+    const response = await app.inject({
+      method: "POST",
+      url: "/orders",
+      payload: {
+        marketId: market.id,
+        userAddress: validAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: 0.5,
+        quantity: 100,
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const body = JSON.parse(response.body);
+
+    expect(body.order.status).toBe("OPEN");
+    expect(body.order.filledQuantity).toBe(0);
+    expect(body.filledQuantity).toBe(0);
+    expect(body.trades).toHaveLength(0);
+
+    // Order should be visible in orderbook API
+    const ordersResponse = await app.inject({
+      method: "GET",
+      url: `/orders/user/${validAddress}`,
+    });
+    expect(ordersResponse.statusCode).toBe(200);
+    const ordersBody = JSON.parse(ordersResponse.body);
+    expect(ordersBody.orders).toHaveLength(1);
+    expect(ordersBody.orders[0].status).toBe("OPEN");
+  });
+
+  it("should update UserPosition after match", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    // Maker: sell 100 YES at 0.5
+    await testUtils.createTestOrder(market.id, makerAddress, {
+      side: "SELL",
+      outcome: "YES",
+      price: 0.5,
+      quantity: 100,
+      filledQuantity: 0,
+      status: "OPEN",
+    });
+
+    // Taker: buy 100 YES at 0.5
+    await app.inject({
+      method: "POST",
+      url: "/orders",
+      payload: {
+        marketId: market.id,
+        userAddress: validAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: 0.5,
+        quantity: 100,
+      },
+    });
+
+    // Taker should have +100 YES shares
+    let takerPos = await prisma.userPosition.findUnique({
+      where: {
+        marketId_userAddress: {
+          marketId: market.id,
+          userAddress: validAddress,
+        },
+      },
+    });
+    expect(takerPos?.yesShares).toBe(100);
+    expect(takerPos?.noShares).toBe(0);
+
+    // Maker should have -100 YES shares
+    let makerPos = await prisma.userPosition.findUnique({
+      where: {
+        marketId_userAddress: {
+          marketId: market.id,
+          userAddress: makerAddress,
+        },
+      },
+    });
+    expect(makerPos?.yesShares).toBe(-100);
+    expect(makerPos?.noShares).toBe(0);
+  });
+
+  it("should reject self-trade", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    // Place a resting sell order
+    await testUtils.createTestOrder(market.id, validAddress, {
+      side: "SELL",
+      outcome: "YES",
+      price: 0.5,
+      quantity: 100,
+      filledQuantity: 0,
+      status: "OPEN",
+    });
+
+    // Try to place a crossing buy order from the same user
+    const response = await app.inject({
+      method: "POST",
+      url: "/orders",
+      payload: {
+        marketId: market.id,
+        userAddress: validAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: 0.5,
+        quantity: 100,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain("self-trade");
+  });
+
+  it("should enqueue settlement job per trade", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    // Maker: sell 100 at 0.5
+    await testUtils.createTestOrder(market.id, makerAddress, {
+      side: "SELL",
+      outcome: "YES",
+      price: 0.5,
+      quantity: 100,
+      filledQuantity: 0,
+      status: "OPEN",
+    });
+
+    // Taker: buy 100 (1 trade)
+    await app.inject({
+      method: "POST",
+      url: "/orders",
+      payload: {
+        marketId: market.id,
+        userAddress: validAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: 0.5,
+        quantity: 100,
+      },
+    });
+
+    // Should have called enqueue once
+    expect(settlementQueue.enqueue).toHaveBeenCalledTimes(1);
+    const call = (settlementQueue.enqueue as any).mock.calls[0][0];
+    expect(call.marketId).toBe(market.id);
+    expect(call.outcome).toBe("YES");
+    expect(call.quantity).toBe(100);
+    expect(call.price).toBe(0.5);
+  });
+
+  it("should serialize concurrent orders to same market", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    // Create two buy orders concurrently at different prices
+    const promise1 = app.inject({
+      method: "POST",
+      url: "/orders",
+      payload: {
+        marketId: market.id,
+        userAddress: validAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: 0.3,
+        quantity: 50,
+      },
+    });
+
+    const promise2 = app.inject({
+      method: "POST",
+      url: "/orders",
+      payload: {
+        marketId: market.id,
+        userAddress: makerAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: 0.4,
+        quantity: 50,
+      },
+    });
+
+    const [response1, response2] = await Promise.all([promise1, promise2]);
+
+    // Both should succeed and be OPEN (no matching)
+    expect(response1.statusCode).toBe(201);
+    expect(response2.statusCode).toBe(201);
+
+    const body1 = JSON.parse(response1.body);
+    const body2 = JSON.parse(response2.body);
+
+    expect(body1.order.status).toBe("OPEN");
+    expect(body2.order.status).toBe("OPEN");
+
+    // Both should be in DB
+    const orders = await prisma.order.findMany({
+      where: { marketId: market.id },
+    });
+    expect(orders).toHaveLength(2);
+  });
+
+  it("should rebuild book from DB on restart (simulated)", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    // Place initial order
+    await testUtils.createTestOrder(market.id, makerAddress, {
+      side: "SELL",
+      outcome: "YES",
+      price: 0.5,
+      quantity: 100,
+      filledQuantity: 0,
+      status: "OPEN",
+    });
+
+    // Clear book cache (simulating restart)
+    (matchingService as any).books.clear();
+
+    // Place matching order (book should be re-hydrated)
+    const response = await app.inject({
+      method: "POST",
+      url: "/orders",
+      payload: {
+        marketId: market.id,
+        userAddress: validAddress,
+        side: "BUY",
+        outcome: "YES",
+        price: 0.5,
+        quantity: 100,
+      },
+    });
+
+    // Should still match correctly
+    expect(response.statusCode).toBe(201);
+    const body = JSON.parse(response.body);
+    expect(body.trades).toHaveLength(1);
+    expect(body.order.status).toBe("FILLED");
+  });
+});

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -279,7 +279,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
 
     expect(response.statusCode).toBe(400);
     const body = JSON.parse(response.body);
-    expect(body.error).toContain("self-trade");
+    expect(body.error).toMatch(/self-trade/i);
   });
 
   it("should enqueue settlement job per trade", async () => {


### PR DESCRIPTION
## Summary

Wires the CLOB matching engine into `POST /orders`, so orders are matched in-memory, persisted atomically, and followed by post-commit audit logging and settlement enqueueing. The 201 response now includes `trades[]` and `filledQuantity`.

## Changes

### MatchingService (`src/matching/matching-service.ts`)
- In-memory order book registry with lazy hydration from Prisma
- Per-book promise-chaining lock for serialized matching (no new deps)
- `placeOrder()` orchestration: validation → matching → DB transaction → post-commit side effects
- Self-trade rejection via `ValidationError`
- Atomic transaction: create order, update maker orders, upsert positions
- Post-commit: audit logging, settlement queue enqueue, Redis book cache refresh (soft TTL)

### Orders route (`src/api/routes/orders.ts`)
- Replaces direct `prisma.order.create()` with `matchingService.placeOrder()`
- Extends 201 response schema with `trades[]` and `filledQuantity`
- Removes matching-engine TODO

### Matching engine (`src/matching/engine.ts`)
- Removes audit logging from engine layer (moved to service post-commit to avoid logging rolled-back trades)

### Settlement queue (`src/services/settlement-queue.ts`)
- Redis Streams producer for settlement jobs
- Env-configurable queue name (`SETTLEMENT_QUEUE_NAME`, default: `settlement-trades`)

### Settlement worker stub (`apps/workers/src/settlement/consumer.ts`)
- Log-only consumer proving the settlement pipeline path
- Bootstrap pattern aligned with finalization worker

### Config (`.env.example`)
- Adds `SETTLEMENT_QUEUE_NAME`

### Tests
- **Unit:** Updated `src/api/routes/orders.test.ts` with `MatchingService` mocks (27 tests)
- **Integration:** Added `tests/integration/orders.test.ts` — crossing orders, partial fills, self-trade rejection, position updates, settlement enqueue, concurrent orders, book hydration

## Design decisions

| Aspect | Choice | Rationale |
|--------|--------|-----------|
| Concurrency | Promise-chaining lock | Single-threaded Node.js; can scale to advisory locks for multi-process |
| Audit timing | After DB commit | Prevents audit entries for rolled-back trades |
| Self-trade | Reject with `ValidationError` | Prevents market manipulation |
| Trade model | Audit streams only | Matches existing architecture; trades returned in-memory for API responses |
| Book cache | Soft Redis TTL (60s) | Prisma is source of truth |
| Settlement | Redis Streams (no BullMQ) | Matches oracle queue pattern |

closes #423 