### PR TITLE
feat: v1 API Prefix and Eliminate Route Documentation Drift

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,9 @@
+#!/bin/sh
+set -e
+
 echo "🔍 Running pre-commit checks..."
 
 # Run lint-staged (TypeScript check + Prisma format)
-pnpm lint-staged
+./node_modules/.bin/lint-staged
 
 echo "All checks passed!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Public API routes are canonical under `/v1/*`. Update frontend clients
+  (`apps/web`) and external integrations to use `/v1/health`, `/v1/ready`,
+  `/v1/markets`, `/v1/orders`, `/v1/orders/user/:address`,
+  `/v1/trades/user/:address`, and `/v1/wallets/:wallet/positions`.
+- Legacy root aliases such as `/markets`, `/orders`, and
+  `/positions/user/:address` return `308` with deprecation headers until
+  `2027-01-01T00:00:00Z`, then return `404`.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pnpm prisma:migrate dev
 pnpm dev
 ```
 
-Visit `http://localhost:3000/health` to verify.
+Visit `http://localhost:3000/v1/health` to verify.
 
 ## Development
 
@@ -183,8 +183,13 @@ See [docs/runbooks/incident-runbook.md](docs/runbooks/incident-runbook.md) for t
 
 Key endpoints with comprehensive test coverage:
 
+- `GET /v1/health` - Liveness and dependency health summary
+- `GET /v1/ready` - Readiness check for serving traffic
 - `GET /v1/markets` - Market listing with pagination and filtering
-- `GET /v1/positions/:wallet` - Wallet position data with PnL calculations
+- `GET /v1/wallets/:wallet/positions` - Wallet position data with PnL calculations
+- `POST /v1/orders` - Order placement
+- `GET /v1/orders/user/:address` - Wallet order history
+- `GET /v1/trades/user/:address` - Wallet trade history
 - Orders route docs: [docs/orders-route.md](docs/orders-route.md)
 
 ## License

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -8,8 +8,27 @@ All public API routes are versioned under the `/v1` prefix.
 GET /v1/health
 ```
 
-Non-versioned paths (e.g. `GET /health`) are **not registered** and return
-`404 Not Found`. Clients must use the versioned path.
+Non-versioned paths (e.g. `GET /health`) are supported as compatibility redirects to the canonical versioned path.
+The server responds with `308 Permanent Redirect` and includes `Location`, `Deprecation`, `Sunset`, and `Link` headers until `2027-01-01T00:00:00Z`.
+Deprecated path usage is logged with `{ event: "api.deprecated_path", path, clientIp }`.
+After the sunset timestamp, unversioned paths return `404`.
+
+## Public Route Table
+
+| Method | Canonical path                  | Legacy alias                | Notes                           |
+| ------ | ------------------------------- | --------------------------- | ------------------------------- |
+| GET    | `/v1/health`                    | `/health`                   | Liveness and health summary     |
+| GET    | `/v1/ready`                     | `/ready`, `/readiness`      | Readiness checks                |
+| GET    | `/v1/markets`                   | `/markets`                  | Market listing                  |
+| GET    | `/v1/markets/:id`               | `/markets/:id`              | Market details                  |
+| GET    | `/v1/markets/:id/orderbook`     | `/markets/:id/orderbook`    | Market orderbook                |
+| POST   | `/v1/orders`                    | `/orders`                   | Create order                    |
+| GET    | `/v1/orders/user/:address`      | `/orders/user/:address`     | Wallet order history            |
+| GET    | `/v1/trades/user/:address`      | `/trades/user/:address`     | Wallet trade history            |
+| GET    | `/v1/wallets/:wallet/positions` | `/positions/user/:address`  | Canonical wallet positions path |
+| GET    | `/v1/admin/markets`             | `/admin/markets`            | Requires API key and admin auth |
+| PATCH  | `/v1/admin/markets/:id/status`  | `/admin/markets/:id/status` | Requires API key and admin auth |
+| GET    | `/v1/openapi.json`              | none                        | OpenAPI specification           |
 
 ## Adding New Routes
 
@@ -36,6 +55,8 @@ server.register(
   for a documented deprecation window before removal.
 - Deprecation notices will be communicated via response headers
   (`Deprecation`, `Sunset`) and updated in this document.
+- Root-level compatibility aliases are temporary only. New clients must use
+  `/v1/*` paths and must not introduce new unversioned API URLs.
 
 ## Current Versions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,10 @@ Vatix Backend is a monorepo of services that together power the Vatix prediction
 
 ## Major Data Flows
 
+All public HTTP routes are mounted under `/v1`. The canonical positions read is
+`GET /v1/wallets/:wallet/positions`; the older
+`GET /positions/user/:address` root path is a temporary deprecation redirect.
+
 ### Order placement
 
 1. Client `POST /v1/orders` → API validates and writes order to PostgreSQL

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -175,7 +175,7 @@ import { Logger } from "@vatix/shared";
 const logger = new Logger("MarketsRoute");
 
 export async function getMarkets(request, reply) {
-  logger.info("GET /markets request received");
+  logger.info("GET /v1/markets request received");
 
   try {
     const markets = await fetchMarkets();

--- a/docs/migration-rollback.md
+++ b/docs/migration-rollback.md
@@ -86,8 +86,8 @@ After completing the rollback:
 3. **Restart the application** and verify the health endpoint responds correctly:
 
    ```bash
-   curl http://localhost:3000/health
-   # Expected: {"status":"ok","service":"vatix-backend"}
+   curl http://localhost:3000/v1/health
+   # Expected: {"status":"ok","service":"vatix-backend",...}
    ```
 
 4. **Restore application traffic** once health checks pass.

--- a/docs/orders-route.md
+++ b/docs/orders-route.md
@@ -3,7 +3,10 @@
 The orders route lets clients create market orders and fetch a wallet's order
 history. Routes are implemented in `src/api/routes/orders.ts`.
 
-## `GET /orders/user/:address`
+All public paths are mounted under `/v1`. Legacy root aliases redirect with
+deprecation headers during the compatibility window.
+
+## `GET /v1/orders/user/:address`
 
 Returns orders submitted by a Stellar wallet, sorted newest first.
 
@@ -55,7 +58,7 @@ Common errors:
 | `400`  | Invalid Stellar address, status, page, or limit. |
 | `500`  | Database lookup failed.                          |
 
-## `POST /orders`
+## `POST /v1/orders`
 
 Creates a new order after validating the wallet address, market state, price,
 quantity, side, and outcome.
@@ -116,3 +119,17 @@ Common errors:
 | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `400`  | Missing field, invalid Stellar address, invalid side/outcome, invalid price or quantity, unknown market, closed market, or expired market. |
 | `500`  | Database write failed.                                                                                                                     |
+
+## `GET /v1/trades/user/:address`
+
+Returns trade history for a Stellar wallet.
+
+Query parameters:
+
+| Field      | Type   | Required | Description                                     |
+| ---------- | ------ | -------- | ----------------------------------------------- |
+| `page`     | number | no       | Page number, minimum `1`. Defaults to `1`.      |
+| `limit`    | number | no       | Page size, from `1` to `100`. Defaults to `20`. |
+| `from`     | string | no       | Inclusive UTC ISO-8601 start timestamp.         |
+| `to`       | string | no       | Inclusive UTC ISO-8601 end timestamp.           |
+| `marketId` | string | no       | Restrict results to one market.                 |

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -21,11 +21,11 @@ not consume the global budget and vice versa.
 
 These routes perform expensive database operations on every call:
 
-| Route                          | Reason                                         |
-| ------------------------------ | ---------------------------------------------- |
-| `GET /markets`                 | Full-table scan; no cursor-based pagination    |
-| `GET /orders/user/:address`    | Two parallel DB queries (`findMany` + `count`) |
-| `GET /positions/user/:address` | `findMany` with a `market` JOIN                |
+| Route                                | Reason                                         |
+| ------------------------------------ | ---------------------------------------------- |
+| `GET /v1/markets`                    | Full-table scan; no cursor-based pagination    |
+| `GET /v1/orders/user/:address`       | Two parallel DB queries (`findMany` + `count`) |
+| `GET /v1/wallets/{wallet}/positions` | `findMany` with a `market` JOIN                |
 
 Limit: **20 req / 60 s** per IP.
 
@@ -34,15 +34,15 @@ Limit: **20 req / 60 s** per IP.
 Mutation routes carry the highest per-request cost (input validation, DB
 write, and future matching-engine work):
 
-| Route          | Reason                                              |
-| -------------- | --------------------------------------------------- |
-| `POST /orders` | Validation + DB write + matching-engine integration |
+| Route             | Reason                                              |
+| ----------------- | --------------------------------------------------- |
+| `POST /v1/orders` | Validation + DB write + matching-engine integration |
 
 Limit: **10 req / 60 s** per IP.
 
 ### Standard endpoints
 
-All other routes (e.g. `GET /health`, admin routes) are covered only by the
+All other routes (e.g. `GET /v1/health`, admin routes) are covered only by the
 global baseline.
 
 Limit: **100 req / 60 s** per IP.

--- a/docs/runbooks/incident-runbook.md
+++ b/docs/runbooks/incident-runbook.md
@@ -778,6 +778,25 @@ WHERE market_id = '[MARKET_ID]'
 
 ## Useful Commands & Queries
 
+### Canonical API URLs
+
+Use these URLs as the operational source of truth:
+
+| Purpose             | Method | Path                            |
+| ------------------- | ------ | ------------------------------- |
+| Health              | GET    | `/v1/health`                    |
+| Readiness           | GET    | `/v1/ready`                     |
+| Markets             | GET    | `/v1/markets`                   |
+| Market details      | GET    | `/v1/markets/:id`               |
+| Market orderbook    | GET    | `/v1/markets/:id/orderbook`     |
+| Create order        | POST   | `/v1/orders`                    |
+| User orders         | GET    | `/v1/orders/user/:address`      |
+| User trades         | GET    | `/v1/trades/user/:address`      |
+| Wallet positions    | GET    | `/v1/wallets/:wallet/positions` |
+| Admin markets       | GET    | `/v1/admin/markets`             |
+| Admin market status | PATCH  | `/v1/admin/markets/:id/status`  |
+| OpenAPI spec        | GET    | `/v1/openapi.json`              |
+
 ### Quick Health Checks
 
 ```bash
@@ -785,7 +804,7 @@ WHERE market_id = '[MARKET_ID]'
 docker ps
 
 # Backend health endpoint
-curl http://localhost:3000/health
+curl http://localhost:3000/v1/health
 
 # Database connectivity
 docker exec -it vatix-postgres pg_isready -U postgres

--- a/src/api/openapi.test.ts
+++ b/src/api/openapi.test.ts
@@ -41,18 +41,23 @@ describe("OpenAPI Stub", () => {
   });
 
   it("has expected API endpoints documented", () => {
-    expect(openApiSpec.paths).toHaveProperty("/health");
-    expect(openApiSpec.paths).toHaveProperty("/markets");
-    expect(openApiSpec.paths).toHaveProperty("/orders");
+    expect(openApiSpec.paths).toHaveProperty("/v1/health");
+    expect(openApiSpec.paths).toHaveProperty("/v1/markets");
+    expect(openApiSpec.paths).toHaveProperty("/v1/orders");
+    expect(openApiSpec.paths).toHaveProperty("/v1/ready");
+    expect(openApiSpec.paths).toHaveProperty("/v1/wallets/{wallet}/positions");
   });
 
   it("health endpoint is documented with GET method", () => {
-    const healthPath = openApiSpec.paths["/health"] as Record<string, unknown>;
+    const healthPath = openApiSpec.paths["/v1/health"] as Record<
+      string,
+      unknown
+    >;
     expect(healthPath).toHaveProperty("get");
   });
 
   it("markets endpoint is documented with GET method", () => {
-    const marketsPath = openApiSpec.paths["/markets"] as Record<
+    const marketsPath = openApiSpec.paths["/v1/markets"] as Record<
       string,
       unknown
     >;
@@ -60,7 +65,10 @@ describe("OpenAPI Stub", () => {
   });
 
   it("orders endpoint is documented with POST method", () => {
-    const ordersPath = openApiSpec.paths["/orders"] as Record<string, unknown>;
+    const ordersPath = openApiSpec.paths["/v1/orders"] as Record<
+      string,
+      unknown
+    >;
     expect(ordersPath).toHaveProperty("post");
   });
 

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -48,7 +48,7 @@ export const openApiSpec = {
     },
   ],
   paths: {
-    "/health": {
+    "/v1/health": {
       get: {
         summary: "Health check",
         description: "Returns the health status of the API",
@@ -77,7 +77,7 @@ export const openApiSpec = {
         },
       },
     },
-    "/readiness": {
+    "/v1/ready": {
       get: {
         summary: "Readiness check",
         description: "Returns the readiness status including dependency health",
@@ -92,7 +92,7 @@ export const openApiSpec = {
         },
       },
     },
-    "/markets": {
+    "/v1/markets": {
       get: {
         summary: "List markets",
         description: "Retrieve a paginated list of prediction markets",
@@ -126,7 +126,53 @@ export const openApiSpec = {
         },
       },
     },
-    "/orders": {
+    "/v1/markets/{id}": {
+      get: {
+        summary: "Market details",
+        description: "Retrieve a single market by ID",
+        tags: ["Markets"],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Market details",
+          },
+          "404": {
+            description: "Market not found",
+          },
+        },
+      },
+    },
+    "/v1/markets/{id}/orderbook": {
+      get: {
+        summary: "Market orderbook",
+        description: "Retrieve the orderbook for a market",
+        tags: ["Markets"],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Market orderbook",
+          },
+          "404": {
+            description: "Market not found",
+          },
+        },
+      },
+    },
+    "/v1/orders": {
       post: {
         summary: "Create an order",
         description: "Submit a new order to the prediction market",
@@ -177,6 +223,118 @@ export const openApiSpec = {
         responses: {
           "201": {
             description: "Order created",
+          },
+          "400": {
+            description: "Invalid request",
+          },
+        },
+      },
+    },
+    "/v1/orders/user/{address}": {
+      get: {
+        summary: "User orders",
+        description: "Retrieve orders submitted by a user",
+        tags: ["Orders"],
+        parameters: [
+          {
+            name: "address",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "User orders",
+          },
+        },
+      },
+    },
+    "/v1/trades/user/{address}": {
+      get: {
+        summary: "User trade history",
+        description: "Retrieve trade history for a wallet",
+        tags: ["Trades"],
+        parameters: [
+          {
+            name: "address",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "User trades",
+          },
+        },
+      },
+    },
+    "/v1/wallets/{wallet}/positions": {
+      get: {
+        summary: "Wallet positions",
+        description: "Retrieve position exposures for a wallet",
+        tags: ["Positions"],
+        parameters: [
+          {
+            name: "wallet",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Wallet positions",
+          },
+        },
+      },
+    },
+    "/v1/admin/markets": {
+      get: {
+        summary: "Admin market listing",
+        description: "List markets for admin users",
+        tags: ["Admin"],
+        responses: {
+          "200": {
+            description: "Admin market list",
+          },
+        },
+      },
+    },
+    "/v1/admin/markets/{id}/status": {
+      patch: {
+        summary: "Update market status",
+        description: "Admin endpoint to change market status",
+        tags: ["Admin"],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["status"],
+                properties: {
+                  status: {
+                    type: "string",
+                    enum: ["ACTIVE", "RESOLVED", "CANCELLED"],
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Market updated",
           },
           "400": {
             description: "Invalid request",

--- a/src/api/routes/health.ts
+++ b/src/api/routes/health.ts
@@ -13,43 +13,40 @@ interface HealthResponse {
 }
 
 export async function healthRoutes(fastify: FastifyInstance) {
-  fastify.get<{ Reply: HealthResponse }>(
-    "/v1/health",
-    async (request, reply) => {
-      let dbStatus: "ok" | "error" = "ok";
+  fastify.get<{ Reply: HealthResponse }>("/health", async (request, reply) => {
+    let dbStatus: "ok" | "error" = "ok";
 
-      try {
-        const prisma = getPrismaClient();
-        await prisma.$queryRaw`SELECT 1`;
-      } catch {
-        dbStatus = "error";
-      }
+    try {
+      const prisma = getPrismaClient();
+      await prisma.$queryRaw`SELECT 1`;
+    } catch {
+      dbStatus = "error";
+    }
 
-      const status = dbStatus === "ok" ? "ok" : "degraded";
-      const uptime = Math.floor(process.uptime());
+    const status = dbStatus === "ok" ? "ok" : "degraded";
+    const uptime = Math.floor(process.uptime());
 
-      request.log[status === "ok" ? "debug" : "warn"](
-        {
-          route: "/v1/health",
-          status,
-          dependencies: {
-            database: dbStatus,
-          },
-          uptime,
-        },
-        "Health check completed"
-      );
-
-      return reply.status(200).send({
+    request.log[status === "ok" ? "debug" : "warn"](
+      {
+        route: "/v1/health",
         status,
-        service: process.env.SERVICE_NAME ?? "vatix-backend",
-        version: process.env.npm_package_version ?? "unknown",
-        uptime,
-        timestamp: new Date().toISOString(),
         dependencies: {
           database: dbStatus,
         },
-      });
-    }
-  );
+        uptime,
+      },
+      "Health check completed"
+    );
+
+    return reply.status(200).send({
+      status,
+      service: process.env.SERVICE_NAME ?? "vatix-backend",
+      version: process.env.npm_package_version ?? "unknown",
+      uptime,
+      timestamp: new Date().toISOString(),
+      dependencies: {
+        database: dbStatus,
+      },
+    });
+  });
 }

--- a/src/api/routes/legacy.test.ts
+++ b/src/api/routes/legacy.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fastify from "fastify";
+import { registerDeprecatedAliases } from "./legacy.js";
+
+describe("Legacy alias redirects", () => {
+  let app: ReturnType<typeof fastify>;
+
+  beforeEach(async () => {
+    app = fastify({ logger: false });
+    registerDeprecatedAliases(app);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await app.close();
+  });
+
+  it("redirects /health to /v1/health with deprecation headers", async () => {
+    const response = await app.inject({ method: "GET", url: "/health" });
+
+    expect(response.statusCode).toBe(308);
+    expect(response.headers.location).toBe("/v1/health");
+    expect(response.headers.deprecation).toBe("true");
+    expect(response.headers.sunset).toBe("2027-01-01T00:00:00Z");
+    expect(response.headers.link).toBe('</v1/health>; rel="alternate"');
+  });
+
+  it("redirects /positions/user/:address to /v1/wallets/:wallet/positions", async () => {
+    const address =
+      "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const response = await app.inject({
+      method: "GET",
+      url: `/positions/user/${address}`,
+    });
+
+    expect(response.statusCode).toBe(308);
+    expect(response.headers.location).toBe(`/v1/wallets/${address}/positions`);
+  });
+
+  it("preserves query strings when redirecting legacy endpoints", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/markets/123/orderbook?depth=10&page=2",
+    });
+
+    expect(response.statusCode).toBe(308);
+    expect(response.headers.location).toBe(
+      "/v1/markets/123/orderbook?depth=10&page=2"
+    );
+  });
+
+  it("returns 404 for legacy aliases after the sunset date", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-01-01T00:00:00Z"));
+
+    const response = await app.inject({ method: "GET", url: "/markets" });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.headers.location).toBeUndefined();
+  });
+});

--- a/src/api/routes/legacy.ts
+++ b/src/api/routes/legacy.ts
@@ -1,0 +1,117 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+const DEPRECATION_DATE = "2027-01-01T00:00:00Z";
+const DEPRECATION_SUNSET_MS = Date.parse(DEPRECATION_DATE);
+const DEPRECATION_HEADERS = {
+  Deprecation: "true",
+  Sunset: DEPRECATION_DATE,
+};
+
+interface LegacyRoute {
+  method: "GET" | "POST" | "PATCH";
+  url: string;
+  canonical: string;
+  paramMap?: Record<string, string>;
+}
+
+const legacyRoutes: LegacyRoute[] = [
+  { method: "GET", url: "/health", canonical: "/v1/health" },
+  { method: "GET", url: "/ready", canonical: "/v1/ready" },
+  { method: "GET", url: "/readiness", canonical: "/v1/ready" },
+  { method: "GET", url: "/markets", canonical: "/v1/markets" },
+  { method: "GET", url: "/markets/:id", canonical: "/v1/markets/:id" },
+  {
+    method: "GET",
+    url: "/markets/:id/orderbook",
+    canonical: "/v1/markets/:id/orderbook",
+  },
+  { method: "POST", url: "/orders", canonical: "/v1/orders" },
+  {
+    method: "GET",
+    url: "/orders/user/:address",
+    canonical: "/v1/orders/user/:address",
+  },
+  {
+    method: "GET",
+    url: "/trades/user/:address",
+    canonical: "/v1/trades/user/:address",
+  },
+  {
+    method: "GET",
+    url: "/positions/user/:address",
+    canonical: "/v1/wallets/:wallet/positions",
+    paramMap: { wallet: "address" },
+  },
+  { method: "GET", url: "/admin/markets", canonical: "/v1/admin/markets" },
+  {
+    method: "PATCH",
+    url: "/admin/markets/:id/status",
+    canonical: "/v1/admin/markets/:id/status",
+  },
+];
+
+function buildCanonicalPath(
+  template: string,
+  params: Record<string, string | string[] | undefined>,
+  query: string,
+  paramMap: Record<string, string> = {}
+) {
+  let path = template;
+  for (const key of Object.keys(paramMap)) {
+    const value = params[paramMap[key]];
+    if (typeof value === "string") {
+      path = path.replace(`:${key}`, value);
+    }
+  }
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === "string") {
+      path = path.replace(`:${key}`, value);
+    }
+  }
+  return query ? `${path}${query}` : path;
+}
+
+export function registerDeprecatedAliases(fastify: FastifyInstance) {
+  for (const route of legacyRoutes) {
+    fastify.route({
+      method: route.method,
+      url: route.url,
+      handler: async (request: FastifyRequest, reply: FastifyReply) => {
+        if (Date.now() >= DEPRECATION_SUNSET_MS) {
+          return reply.status(404).send({
+            error: `Route ${request.method} ${request.url} not found`,
+            requestId: request.id,
+            statusCode: 404,
+          });
+        }
+
+        const query = request.url.includes("?")
+          ? request.url.slice(request.url.indexOf("?"))
+          : "";
+        const canonical = buildCanonicalPath(
+          route.canonical,
+          request.params as Record<string, string>,
+          query,
+          route.paramMap
+        );
+
+        request.log.info(
+          {
+            event: "api.deprecated_path",
+            path: request.url,
+            clientIp: request.ip,
+          },
+          "Deprecated API path used"
+        );
+
+        reply
+          .status(308)
+          .header("Location", canonical)
+          .header("Link", `<${canonical}>; rel="alternate"`)
+          .header("Deprecation", DEPRECATION_HEADERS.Deprecation)
+          .header("Sunset", DEPRECATION_HEADERS.Sunset)
+          .send();
+      },
+    });
+  }
+}

--- a/src/api/routes/positions.test.ts
+++ b/src/api/routes/positions.test.ts
@@ -88,30 +88,34 @@ describe("Positions Route", () => {
     return app;
   };
 
-  it("should return 400 for invalid address on legacy endpoint", async () => {
+  it("should return 400 for invalid address on canonical endpoint", async () => {
     const app = await createTestServer();
     const response = await app.inject({
       method: "GET",
-      url: "/positions/user/0xInvalidAddress",
+      url: "/wallets/0xInvalidAddress/positions",
     });
     expect(response.statusCode).toBe(400);
   });
 
-  it("should return 200 and calculate correct payout structure on legacy endpoint", async () => {
+  it("should return 200 and calculate correct payout structure on canonical endpoint", async () => {
     const app = await createTestServer();
     const validAddress =
       "GINJ46CDSMNOSKETX3K5DU44435TGRWIQEM7ZVI3ON3BTOOFVJJHTWXO";
     const response = await app.inject({
       method: "GET",
-      url: `/positions/user/${validAddress}`,
+      url: `/wallets/${validAddress}/positions`,
     });
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
-    expect(Array.isArray(body)).toBe(true);
-    expect(body[0].potentialPayoutIfYes).toBe(50);
-    expect(body[0].potentialPayoutIfNo).toBe(10);
-    expect(body[0].netPosition).toBe(40);
-    expect(body[0].market.question).toBe("Will it rain?");
+    expect(body.success).toBe(true);
+    expect(body.data.wallet).toBe(validAddress);
+    expect(body.data.exposures[0]).toMatchObject({
+      marketId: "market-1",
+      marketQuestion: "Will it rain?",
+      yesShares: 50,
+      noShares: 10,
+      netExposure: 40,
+    });
   });
 
   it("should return wallet exposure rows with standardized success response", async () => {

--- a/src/api/routes/positions.ts
+++ b/src/api/routes/positions.ts
@@ -8,12 +8,6 @@ import { ValidationError } from "../middleware/errors.js";
 import { heavyReadLimiter } from "../middleware/rateLimiter.js";
 import { success } from "../middleware/responses.js";
 
-interface PositionResult {
-  yesShares: number;
-  noShares: number;
-  [key: string]: any;
-}
-
 interface WalletExposureRow {
   marketId: string;
   marketQuestion: string;
@@ -137,6 +131,7 @@ export default async function positionsRouter(server: FastifyInstance) {
   server.get(
     "/wallets/:wallet/positions",
     {
+      onRequest: [heavyReadLimiter],
       schema: {
         params: {
           type: "object",
@@ -273,51 +268,6 @@ export default async function positionsRouter(server: FastifyInstance) {
         pnlUnrealized,
         pnlTotal,
       });
-    }
-  );
-
-  // Heavy read: findMany with market JOIN — apply stricter limit.
-  server.get(
-    "/positions/user/:address",
-    {
-      onRequest: [heavyReadLimiter],
-      schema: {
-        params: {
-          type: "object",
-          required: ["address"],
-          properties: {
-            address: {
-              type: "string",
-              pattern: STELLAR_PUBLIC_KEY_REGEX.source,
-              description:
-                "Stellar public key (StrKey): starts with G and is 56 chars using [A-Z2-7]",
-            },
-          },
-        },
-      },
-    },
-    async (request, reply) => {
-      const { address } = request.params as { address: string };
-      const prisma = getPrismaClient();
-
-      const addressError = validateUserAddress(address);
-      if (addressError) {
-        throw new ValidationError(addressError);
-      }
-
-      const positions = await prisma.userPosition.findMany({
-        where: { userAddress: address },
-        include: { market: true },
-      });
-
-      const results = positions.map((p: PositionResult) => ({
-        ...p,
-        potentialPayoutIfYes: p.yesShares,
-        potentialPayoutIfNo: p.noShares,
-        netPosition: p.yesShares - p.noShares,
-      }));
-
-      reply.status(200).send(results);
     }
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,23 @@
 import Fastify, {
+  type FastifyServerOptions,
   type FastifyInstance,
   type FastifyRequest,
   type FastifyReply,
 } from "fastify";
+import { pathToFileURL } from "node:url";
 import { errorHandler } from "./api/middleware/errorHandler.js";
 import positionsRouter from "./api/routes/positions.js";
 import { NotFoundError, ValidationError } from "./api/middleware/errors.js";
 import { signingService } from "./services/signing.js";
 import "dotenv/config";
+import { getPrismaClient } from "./services/prisma.js";
 import { marketsRoutes } from "./api/routes/markets.js";
 import { ordersRoutes } from "./api/routes/orders.js";
 import { adminRoutes } from "./api/routes/admin.js";
 import { healthRoutes } from "./api/routes/health.js";
+import { readyRoute } from "./api/routes/ready.js";
+import { registerDeprecatedAliases } from "./api/routes/legacy.js";
+import { openApiSpec } from "./api/openapi.js";
 import { rateLimiter } from "./api/middleware/rateLimiter.js";
 import { requestLogger } from "./api/middleware/logger.js";
 import { requestIdMiddleware } from "./api/middleware/requestId.js";
@@ -22,116 +28,107 @@ import { corsPlugin } from "./api/middleware/cors.js";
 // Oversized requests are rejected with 413 Request Entity Too Large.
 const bodyLimit = Number(process.env.BODY_LIMIT_BYTES) || 65_536;
 
-interface RpcReachabilityResult {
-  url: string | null;
-  reachable: boolean;
-  error?: string;
+export interface BuildServerOptions {
+  logger?: FastifyServerOptions["logger"];
+  readyDeps?: Parameters<typeof readyRoute>[0];
+  registerTestRoutes?: boolean;
 }
 
-async function checkRpcReachability(
-  rpcUrl: string | undefined
-): Promise<RpcReachabilityResult> {
-  if (!rpcUrl) {
-    return {
-      url: null,
-      reachable: false,
-      error: "STELLAR_RPC_URL not configured",
-    };
-  }
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
-    const res = await fetch(rpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "getHealth",
-        params: [],
-      }),
-      signal: controller.signal,
-    }).finally(() => clearTimeout(timeout));
-    return { url: rpcUrl, reachable: res.ok || res.status < 500 };
-  } catch (err) {
-    return {
-      url: rpcUrl,
-      reachable: false,
-      error: err instanceof Error ? err.message : String(err),
-    };
-  }
-}
-
-const server: FastifyInstance = Fastify({
-  logger: true,
-  genReqId: () => crypto.randomUUID(), // Generate unique request IDs
-  bodyLimit,
-});
-
-// Register error handler (must be before routes)
-server.setErrorHandler(errorHandler);
-
-// CORS — must be registered before routes so preflight OPTIONS requests are handled
-server.register(corsPlugin);
-
-// Resolve/generate request ID before anything else touches request.id
-server.register(requestIdMiddleware);
-
-// Register request logger (before routes so every request is captured)
-server.register(requestLogger);
-
-// Apply rate limiting globally
-server.addHook("onRequest", rateLimiter);
-
-// Register API routes
-server.register(marketsRoutes);
-server.register(ordersRoutes);
-
-server.register(positionsRouter);
-server.register(adminRoutes);
-server.register(healthRoutes);
-
-server.get("/readiness", async (_req: FastifyRequest, reply: FastifyReply) => {
-  const rpcUrl = process.env.STELLAR_RPC_URL;
-  const rpcStatus = await checkRpcReachability(rpcUrl);
-  const allHealthy = rpcStatus.reachable;
-  reply.status(allHealthy ? 200 : 503);
+function createDefaultReadyDeps(): Parameters<typeof readyRoute>[0] {
   return {
-    status: allHealthy ? "ready" : "not_ready",
-    checks: {
-      stellarRpc: rpcStatus,
+    checkDatabase: async () => {
+      const prisma = getPrismaClient();
+      await prisma.$queryRaw`SELECT 1`;
+    },
+    getLastIndexedAt: async () => {
+      const prisma = getPrismaClient();
+      const cursor = await prisma.indexerCursor.findFirst({
+        orderBy: { updatedAt: "desc" },
+        select: { updatedAt: true },
+      });
+      return cursor ? cursor.updatedAt.getTime() : null;
     },
   };
-});
+}
 
-// Test routes for error handling
-server.get("/test/validation-error", async () => {
-  throw new ValidationError("Invalid input data", {
-    email: "Invalid email format",
-    password: "Password must be at least 8 characters",
+export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
+  const server: FastifyInstance = Fastify({
+    logger: options.logger ?? true,
+    genReqId: () => crypto.randomUUID(), // Generate unique request IDs
+    bodyLimit,
   });
-});
 
-server.get("/test/not-found", async () => {
-  throw new NotFoundError("Market not found");
-});
+  // Register error handler (must be before routes)
+  server.setErrorHandler(errorHandler);
 
-server.get("/test/server-error", async () => {
-  throw new Error("Something went wrong internally");
-});
+  // CORS — must be registered before routes so preflight OPTIONS requests are handled
+  server.register(corsPlugin);
 
-// Global 404 handler — must be registered after all routes
-// Throws through the error handler for consistent response format
-server.setNotFoundHandler((request: FastifyRequest, reply: FastifyReply) => {
-  const requestId = request.id;
-  reply.status(404).send({
-    error: `Route ${request.method} ${request.url} not found`,
-    requestId,
-    statusCode: 404,
+  // Resolve/generate request ID before anything else touches request.id
+  server.register(requestIdMiddleware);
+
+  // Register request logger (before routes so every request is captured)
+  server.register(requestLogger);
+
+  // Apply rate limiting globally
+  server.addHook("onRequest", rateLimiter);
+
+  // Register API routes under /v1
+  server.register(
+    async (v1) => {
+      await v1.register(marketsRoutes);
+      await v1.register(ordersRoutes);
+      await v1.register(positionsRouter);
+      await v1.register(adminRoutes);
+      await v1.register(healthRoutes);
+      await v1.register(
+        readyRoute(options.readyDeps ?? createDefaultReadyDeps())
+      );
+
+      v1.get("/openapi.json", async (_request, reply) => {
+        return reply.status(200).send(openApiSpec);
+      });
+    },
+    { prefix: "/v1" }
+  );
+
+  registerDeprecatedAliases(server);
+
+  if (options.registerTestRoutes !== false) {
+    // Test routes for error handling
+    server.get("/test/validation-error", async () => {
+      throw new ValidationError("Invalid input data", {
+        email: "Invalid email format",
+        password: "Password must be at least 8 characters",
+      });
+    });
+
+    server.get("/test/not-found", async () => {
+      throw new NotFoundError("Market not found");
+    });
+
+    server.get("/test/server-error", async () => {
+      throw new Error("Something went wrong internally");
+    });
+  }
+
+  // Global 404 handler — must be registered after all routes
+  // Throws through the error handler for consistent response format
+  server.setNotFoundHandler((request: FastifyRequest, reply: FastifyReply) => {
+    const requestId = request.id;
+    reply.status(404).send({
+      error: `Route ${request.method} ${request.url} not found`,
+      requestId,
+      statusCode: 404,
+    });
   });
-});
+
+  return server;
+}
 
 const start = async () => {
+  const server = buildServer();
+
   try {
     // Initialize signing service BEFORE starting server
     signingService.initialize();
@@ -148,4 +145,9 @@ const start = async () => {
   }
 };
 
-start();
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  start();
+}

--- a/tests/integration/api-versioning.test.ts
+++ b/tests/integration/api-versioning.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildServer } from "../../src/index.js";
+import { testUtils } from "../setup.js";
+import { openApiSpec } from "../../src/api/openapi.js";
+
+const wallet = testUtils.generateStellarAddress("GUSER");
+
+describe("Integration Tests: API versioning", () => {
+  let app: FastifyInstance;
+  let marketId: string;
+
+  beforeAll(async () => {
+    app = buildServer({
+      logger: false,
+      registerTestRoutes: false,
+      readyDeps: {
+        checkDatabase: async () => {},
+        getLastIndexedAt: async () => Date.now(),
+      },
+    });
+
+    await app.ready();
+  });
+
+  beforeEach(async () => {
+    const market = await testUtils.createTestMarket({
+      question: "API versioning market",
+      status: "ACTIVE",
+    });
+    marketId = market.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("serves public routes under /v1", async () => {
+    const requests = [
+      { method: "GET", url: "/v1/health", expected: 200 },
+      { method: "GET", url: "/v1/ready", expected: 200 },
+      { method: "GET", url: "/v1/markets", expected: 200 },
+      { method: "GET", url: `/v1/markets/${marketId}`, expected: 200 },
+      {
+        method: "GET",
+        url: `/v1/markets/${marketId}/orderbook`,
+        expected: 200,
+      },
+      { method: "GET", url: `/v1/orders/user/${wallet}`, expected: 200 },
+      { method: "GET", url: `/v1/trades/user/${wallet}`, expected: 200 },
+      {
+        method: "GET",
+        url: `/v1/wallets/${wallet}/positions`,
+        expected: 200,
+      },
+      { method: "GET", url: "/v1/openapi.json", expected: 200 },
+    ] as const;
+
+    for (const request of requests) {
+      const response = await app.inject(request);
+      expect(response.statusCode, `${request.method} ${request.url}`).toBe(
+        request.expected
+      );
+    }
+  });
+
+  it("keeps admin routes registered under /v1 behind auth", async () => {
+    const listResponse = await app.inject({
+      method: "GET",
+      url: "/v1/admin/markets",
+    });
+    const patchResponse = await app.inject({
+      method: "PATCH",
+      url: `/v1/admin/markets/${marketId}/status`,
+      payload: { status: "CANCELLED" },
+    });
+
+    expect(listResponse.statusCode).toBe(401);
+    expect(patchResponse.statusCode).toBe(401);
+  });
+
+  it("redirects legacy aliases with deprecation headers", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: `/positions/user/${wallet}?marketId=${marketId}`,
+    });
+
+    expect(response.statusCode).toBe(308);
+    expect(response.headers.location).toBe(
+      `/v1/wallets/${wallet}/positions?marketId=${marketId}`
+    );
+    expect(response.headers.deprecation).toBe("true");
+    expect(response.headers.sunset).toBe("2027-01-01T00:00:00Z");
+    expect(response.headers.link).toBe(
+      `</v1/wallets/${wallet}/positions?marketId=${marketId}>; rel="alternate"`
+    );
+  });
+
+  it("returns 404 for root paths that are not compatibility aliases", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/not-a-public-route",
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("mounts OpenAPI at /v1/openapi.json with only /v1 path keys", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/openapi.json",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const spec = JSON.parse(response.body);
+    expect(spec.paths).toEqual(openApiSpec.paths);
+    expect(
+      Object.keys(spec.paths).every((path) => path.startsWith("/v1/"))
+    ).toBe(true);
+  });
+
+  it("every OpenAPI path resolves through Fastify routing", async () => {
+    const checks = [
+      { method: "GET", url: "/v1/health", expected: [200] },
+      { method: "GET", url: "/v1/ready", expected: [200] },
+      { method: "GET", url: "/v1/markets", expected: [200] },
+      { method: "GET", url: `/v1/markets/${marketId}`, expected: [200] },
+      {
+        method: "GET",
+        url: `/v1/markets/${marketId}/orderbook`,
+        expected: [200],
+      },
+      {
+        method: "POST",
+        url: "/v1/orders",
+        payload: {
+          marketId,
+          userAddress: wallet,
+          side: "BUY",
+          outcome: "YES",
+          price: 0.5,
+          quantity: 1,
+        },
+        expected: [201],
+      },
+      { method: "GET", url: `/v1/orders/user/${wallet}`, expected: [200] },
+      { method: "GET", url: `/v1/trades/user/${wallet}`, expected: [200] },
+      {
+        method: "GET",
+        url: `/v1/wallets/${wallet}/positions`,
+        expected: [200],
+      },
+      { method: "GET", url: "/v1/admin/markets", expected: [401] },
+      {
+        method: "PATCH",
+        url: `/v1/admin/markets/${marketId}/status`,
+        payload: { status: "CANCELLED" },
+        expected: [401],
+      },
+    ] as const;
+
+    expect(Object.keys(openApiSpec.paths)).toHaveLength(checks.length);
+
+    for (const check of checks) {
+      const response = await app.inject(check);
+      expect(response.statusCode, `${check.method} ${check.url}`).not.toBe(404);
+      expect(check.expected).toContain(response.statusCode);
+    }
+  });
+});

--- a/tests/integration/health.test.ts
+++ b/tests/integration/health.test.ts
@@ -1,15 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import Fastify, { FastifyInstance } from "fastify";
+import { healthRoutes } from "../../src/api/routes/health.js";
 
-describe("GET /health", () => {
+describe("GET /v1/health", () => {
   let app: FastifyInstance;
 
   beforeAll(async () => {
     app = Fastify({ logger: false });
-    app.get("/health", async () => ({
-      status: "ok",
-      service: "vatix-backend",
-    }));
+    await app.register(healthRoutes, { prefix: "/v1" });
     await app.ready();
   });
 
@@ -18,20 +16,21 @@ describe("GET /health", () => {
   });
 
   it("returns HTTP 200", async () => {
-    const response = await app.inject({ method: "GET", url: "/health" });
+    const response = await app.inject({ method: "GET", url: "/v1/health" });
     expect(response.statusCode).toBe(200);
   });
 
   it("returns required payload fields", async () => {
-    const response = await app.inject({ method: "GET", url: "/health" });
+    const response = await app.inject({ method: "GET", url: "/v1/health" });
     const body = JSON.parse(response.body);
-    expect(body).toHaveProperty("status", "ok");
+    expect(body).toHaveProperty("status");
     expect(body).toHaveProperty("service", "vatix-backend");
+    expect(body).toHaveProperty("dependencies");
   });
 
   it("responds quickly (under 200ms)", async () => {
     const start = Date.now();
-    await app.inject({ method: "GET", url: "/health" });
+    await app.inject({ method: "GET", url: "/v1/health" });
     expect(Date.now() - start).toBeLessThan(200);
   });
 });

--- a/tests/integration/markets.test.ts
+++ b/tests/integration/markets.test.ts
@@ -11,7 +11,7 @@ describe("Integration Tests: GET /v1/markets", () => {
     // Create test server with real database
     app = Fastify({ logger: false });
     app.setErrorHandler(errorHandler);
-    await app.register(marketsRoutes);
+    await app.register(marketsRoutes, { prefix: "/v1" });
   });
 
   afterAll(async () => {
@@ -34,7 +34,7 @@ describe("Integration Tests: GET /v1/markets", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/markets",
+        url: "/v1/markets",
       });
 
       expect(response.statusCode).toBe(200);
@@ -59,7 +59,7 @@ describe("Integration Tests: GET /v1/markets", () => {
     it("should handle empty market list correctly", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/markets",
+        url: "/v1/markets",
       });
 
       expect(response.statusCode).toBe(200);
@@ -88,7 +88,7 @@ describe("Integration Tests: GET /v1/markets", () => {
       // Test ACTIVE filter
       const activeResponse = await app.inject({
         method: "GET",
-        url: "/markets?status=ACTIVE",
+        url: "/v1/markets?status=ACTIVE",
       });
 
       expect(activeResponse.statusCode).toBe(200);
@@ -100,7 +100,7 @@ describe("Integration Tests: GET /v1/markets", () => {
       // Test RESOLVED filter
       const resolvedResponse = await app.inject({
         method: "GET",
-        url: "/markets?status=RESOLVED",
+        url: "/v1/markets?status=RESOLVED",
       });
 
       expect(resolvedResponse.statusCode).toBe(200);
@@ -113,7 +113,7 @@ describe("Integration Tests: GET /v1/markets", () => {
     it("should return empty list for non-existent status", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/markets?status=CANCELLED",
+        url: "/v1/markets?status=CANCELLED",
       });
 
       expect(response.statusCode).toBe(200);
@@ -133,7 +133,7 @@ describe("Integration Tests: GET /v1/markets", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/markets",
+        url: "/v1/markets",
       });
 
       expect(response.statusCode).toBe(200);
@@ -182,7 +182,7 @@ describe("Integration Tests: GET /v1/markets", () => {
     it("should return 400 for invalid status value", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/markets?status=INVALID",
+        url: "/v1/markets?status=INVALID",
       });
 
       expect(response.statusCode).toBe(400);
@@ -191,7 +191,7 @@ describe("Integration Tests: GET /v1/markets", () => {
     it("should return 400 for limit below minimum", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/markets?limit=0",
+        url: "/v1/markets?limit=0",
       });
 
       expect(response.statusCode).toBe(400);
@@ -200,7 +200,7 @@ describe("Integration Tests: GET /v1/markets", () => {
     it("should return 400 for limit above maximum", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/markets?limit=101",
+        url: "/v1/markets?limit=101",
       });
 
       expect(response.statusCode).toBe(400);
@@ -209,7 +209,7 @@ describe("Integration Tests: GET /v1/markets", () => {
     it("should ignore unknown query parameters", async () => {
       const response = await app.inject({
         method: "GET",
-        url: "/markets?unknown=value",
+        url: "/v1/markets?unknown=value",
       });
 
       // Unknown parameters are silently ignored
@@ -229,7 +229,7 @@ describe("Integration Tests: GET /v1/markets", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/markets",
+        url: "/v1/markets",
       });
 
       expect(response.statusCode).toBe(200);
@@ -248,7 +248,7 @@ describe("Integration Tests: GET /v1/markets", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/markets",
+        url: "/v1/markets",
       });
 
       expect(response.statusCode).toBe(200);

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -21,7 +21,7 @@ import { settlementQueue } from "../../src/services/settlement-queue.js";
 const validAddress = testUtils.generateStellarAddress("GUSER");
 const makerAddress = testUtils.generateStellarAddress("GMAKER");
 
-describe("Integration Tests: POST /orders with Matching", () => {
+describe("Integration Tests: POST /v1/orders with Matching", () => {
   let app: FastifyInstance;
   const prisma = getTestPrismaClient();
 
@@ -29,7 +29,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     await acquireDatabaseLock();
     app = Fastify({ logger: false });
     app.setErrorHandler(errorHandler);
-    await app.register(ordersRoutes);
+    await app.register(ordersRoutes, { prefix: "/v1" });
 
     // Mock settlement queue to track calls
     vi.spyOn(settlementQueue, "enqueue").mockResolvedValue(undefined);
@@ -67,7 +67,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     // Taker: buy order at 0.5 (should match fully)
     const response = await app.inject({
       method: "POST",
-      url: "/orders",
+      url: "/v1/orders",
       payload: {
         marketId: market.id,
         userAddress: validAddress,
@@ -124,7 +124,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     // Taker: buy 100 at 0.5 (only 50 will match, 50 will rest)
     const response = await app.inject({
       method: "POST",
-      url: "/orders",
+      url: "/v1/orders",
       payload: {
         marketId: market.id,
         userAddress: validAddress,
@@ -168,7 +168,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     // No existing orders, so this should be OPEN
     const response = await app.inject({
       method: "POST",
-      url: "/orders",
+      url: "/v1/orders",
       payload: {
         marketId: market.id,
         userAddress: validAddress,
@@ -190,7 +190,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     // Order should be visible in orderbook API
     const ordersResponse = await app.inject({
       method: "GET",
-      url: `/orders/user/${validAddress}`,
+      url: `/v1/orders/user/${validAddress}`,
     });
     expect(ordersResponse.statusCode).toBe(200);
     const ordersBody = JSON.parse(ordersResponse.body);
@@ -214,7 +214,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     // Taker: buy 100 YES at 0.5
     await app.inject({
       method: "POST",
-      url: "/orders",
+      url: "/v1/orders",
       payload: {
         marketId: market.id,
         userAddress: validAddress,
@@ -266,7 +266,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     // Try to place a crossing buy order from the same user
     const response = await app.inject({
       method: "POST",
-      url: "/orders",
+      url: "/v1/orders",
       payload: {
         marketId: market.id,
         userAddress: validAddress,
@@ -298,7 +298,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     // Taker: buy 100 (1 trade)
     await app.inject({
       method: "POST",
-      url: "/orders",
+      url: "/v1/orders",
       payload: {
         marketId: market.id,
         userAddress: validAddress,
@@ -324,7 +324,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     // Create two buy orders concurrently at different prices
     const promise1 = app.inject({
       method: "POST",
-      url: "/orders",
+      url: "/v1/orders",
       payload: {
         marketId: market.id,
         userAddress: validAddress,
@@ -337,7 +337,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
 
     const promise2 = app.inject({
       method: "POST",
-      url: "/orders",
+      url: "/v1/orders",
       payload: {
         marketId: market.id,
         userAddress: makerAddress,
@@ -386,7 +386,7 @@ describe("Integration Tests: POST /orders with Matching", () => {
     // Place matching order (book should be re-hydrated)
     const response = await app.inject({
       method: "POST",
-      url: "/orders",
+      url: "/v1/orders",
       payload: {
         marketId: market.id,
         userAddress: validAddress,

--- a/tests/integration/positions.test.ts
+++ b/tests/integration/positions.test.ts
@@ -4,7 +4,7 @@ import positionsRouter from "../../src/api/routes/positions.js";
 import { errorHandler } from "../../src/api/middleware/errorHandler.js";
 import { testUtils } from "../setup.js";
 
-describe("Integration Tests: GET /v1/positions/:wallet", () => {
+describe("Integration Tests: GET /v1/wallets/:wallet/positions", () => {
   let app: FastifyInstance;
   let testWallet: string;
 
@@ -12,7 +12,7 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
     // Create test server with real database
     app = Fastify({ logger: false });
     app.setErrorHandler(errorHandler);
-    await app.register(positionsRouter);
+    await app.register(positionsRouter, { prefix: "/v1" });
   });
 
   afterAll(async () => {
@@ -40,18 +40,20 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/positions/user/${testWallet}`,
+        url: `/v1/wallets/${testWallet}/positions`,
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
 
-      expect(Array.isArray(body)).toBe(true);
-      expect(body).toHaveLength(1);
+      expect(body.success).toBe(true);
+      expect(body.data.wallet).toBe(testWallet);
+      expect(body.data.exposures).toHaveLength(1);
+      expect(body.data.count).toBe(1);
 
-      const position = body[0];
+      const position = body.data.exposures[0];
       expect(position.marketId).toBe(market.id);
-      expect(position.userAddress).toBe(testWallet);
+      expect(position.marketQuestion).toBe(market.question);
       expect(position.yesShares).toBe(150);
       expect(position.noShares).toBe(75);
       expect(position.lockedCollateral).toBe("2.25");
@@ -73,24 +75,26 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/positions/user/${testWallet}`,
+        url: `/v1/wallets/${testWallet}/positions`,
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
 
-      expect(body).toHaveLength(1);
-      const position = body[0];
+      expect(body.data.exposures).toHaveLength(1);
+      const position = body.data.exposures[0];
 
       // Verify calculated fields
-      expect(position.potentialPayoutIfYes).toBe(200);
-      expect(position.potentialPayoutIfNo).toBe(50);
-      expect(position.netPosition).toBe(150); // 200 - 50
+      expect(position.netExposure).toBe(150); // 200 - 50
+      expect(position.pnlRealized).toBeNull();
+      expect(position.pnlUnrealized).toBeNull();
 
       // Verify market data is included
-      expect(position.market).toBeDefined();
-      expect(position.market.id).toBe(market.id);
-      expect(position.market.question).toBe(market.question);
+      expect(position.marketId).toBe(market.id);
+      expect(position.marketQuestion).toBe(market.question);
+      expect(body.data.pnlRealized).toBe("0.00000000");
+      expect(body.data.pnlUnrealized).toBe("0.00000000");
+      expect(body.data.pnlTotal).toBe("0.00000000");
     });
 
     it("should handle multiple positions for same wallet", async () => {
@@ -114,25 +118,29 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/positions/user/${testWallet}`,
+        url: `/v1/wallets/${testWallet}/positions`,
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
 
-      expect(body).toHaveLength(2);
+      expect(body.data.exposures).toHaveLength(2);
 
       // Verify both positions are returned
-      const positionIds = body.map((p: any) => p.marketId);
+      const positionIds = body.data.exposures.map((p: any) => p.marketId);
       expect(positionIds).toContain(market1.id);
       expect(positionIds).toContain(market2.id);
 
       // Verify calculations
-      const pos1 = body.find((p: any) => p.marketId === market1.id);
-      const pos2 = body.find((p: any) => p.marketId === market2.id);
+      const pos1 = body.data.exposures.find(
+        (p: any) => p.marketId === market1.id
+      );
+      const pos2 = body.data.exposures.find(
+        (p: any) => p.marketId === market2.id
+      );
 
-      expect(pos1.netPosition).toBe(100);
-      expect(pos2.netPosition).toBe(-100);
+      expect(pos1.netExposure).toBe(100);
+      expect(pos2.netExposure).toBe(-100);
     });
   });
 
@@ -142,14 +150,15 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/positions/user/${emptyWallet}`,
+        url: `/v1/wallets/${emptyWallet}/positions`,
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
 
-      expect(Array.isArray(body)).toBe(true);
-      expect(body).toHaveLength(0);
+      expect(body.success).toBe(true);
+      expect(body.data.exposures).toEqual([]);
+      expect(body.data.count).toBe(0);
     });
   });
 
@@ -167,7 +176,7 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
       for (const invalidAddress of invalidAddresses) {
         const response = await app.inject({
           method: "GET",
-          url: `/positions/user/${invalidAddress}`,
+          url: `/v1/wallets/${encodeURIComponent(invalidAddress)}/positions`,
         });
 
         expect(response.statusCode).toBe(400);
@@ -188,13 +197,13 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/positions/user/${testWallet}`,
+        url: `/v1/wallets/${testWallet}/positions`,
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
 
-      const position = body[0];
+      const position = body.data.exposures[0];
 
       // Verify precision is maintained
       expect(
@@ -203,7 +212,7 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
           1.23456789
         )
       ).toBe(true);
-      expect(position.netPosition).toBe(-333); // 123 - 456
+      expect(position.netExposure).toBe(-333); // 123 - 456
 
       // Test precision assertion utility
       expect(testUtils.assertDecimalEqual(0.12345678, 0.12345678)).toBe(true);
@@ -223,15 +232,15 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/positions/user/${testWallet}`,
+        url: `/v1/wallets/${testWallet}/positions`,
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
 
-      expect(body).toHaveLength(1);
-      expect(body[0].isSettled).toBe(true);
-      expect(body[0].netPosition).toBe(100);
+      expect(body.data.exposures).toHaveLength(1);
+      expect(body.data.exposures[0].isSettled).toBe(true);
+      expect(body.data.exposures[0].netExposure).toBe(100);
     });
 
     it("should handle zero share positions", async () => {
@@ -245,18 +254,18 @@ describe("Integration Tests: GET /v1/positions/:wallet", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/positions/user/${testWallet}`,
+        url: `/v1/wallets/${testWallet}/positions`,
       });
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
 
-      expect(body).toHaveLength(1);
-      const position = body[0];
+      expect(body.data.exposures).toHaveLength(1);
+      const position = body.data.exposures[0];
       expect(position.yesShares).toBe(0);
       expect(position.noShares).toBe(0);
       expect(position.lockedCollateral).toBe("0");
-      expect(position.netPosition).toBe(0);
+      expect(position.netExposure).toBe(0);
     });
   });
 });

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { Client } from "pg";
 
 const TEST_DB_NAME = "vatix_integration_test";
@@ -8,6 +8,8 @@ const BASE_URL =
 const TEST_DB_URL = `${BASE_URL}/${TEST_DB_NAME}`;
 
 export async function setup() {
+  process.env.REDIS_URL ??= "redis://localhost:6379";
+
   // Create isolated test database
   const client = new Client({ connectionString: `${BASE_URL}/postgres` });
   await client.connect();
@@ -16,7 +18,11 @@ export async function setup() {
   await client.end();
 
   // Run migrations against the isolated DB
-  execSync("pnpm prisma migrate deploy", {
+  const prismaBin =
+    process.platform === "win32"
+      ? "node_modules/.bin/prisma.cmd"
+      : "node_modules/.bin/prisma";
+  execFileSync(prismaBin, ["migrate", "deploy"], {
     env: { ...process.env, DATABASE_URL: TEST_DB_URL },
     stdio: "pipe",
   });


### PR DESCRIPTION
## Summary

- Enforces the public API under `/v1/*`
- Adds legacy root-path redirects with `308`, deprecation headers, sunset handling, and structured logging
- Canonicalizes positions at `GET /v1/wallets/:wallet/positions`
- Updates OpenAPI, integration tests, README, docs, runbook, and changelog
- Fixes pre-commit hook to avoid pnpm/Corepack implicit install during commits

Closes #429

## Tests

- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/vitest run src/api/openapi.test.ts src/api/routes/legacy.test.ts src/api/routes/health.ts src/api/routes/positions.test.ts src/api/routes/ready.test.ts src/api/routes/markets.test.ts`
- `node_modules/.bin/vitest run --config vitest.integration.config.ts`
- `sh .husky/pre-commit`