### PR TITLE
feat(positions): consolidate duplicate position endpoints under /v1, make PnL opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Key endpoints with comprehensive test coverage:
 - `GET /v1/health` - Liveness and dependency health summary
 - `GET /v1/ready` - Readiness check for serving traffic
 - `GET /v1/markets` - Market listing with pagination and filtering
-- `GET /v1/wallets/:wallet/positions` - Wallet position data with PnL calculations
+- `GET /v1/wallets/:wallet/positions` - Wallet position exposures; pass `?includePnl=true` for PnL calculations (response DTO: [docs/schema.md](docs/schema.md#api-response-dtos))
 - `POST /v1/orders` - Order placement
 - `GET /v1/orders/user/:address` - Wallet order history
 - `GET /v1/trades/user/:address` - Wallet trade history

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -157,3 +157,39 @@ Maps provider alias strings to canonical `OracleSource` enum values.
 | `alias`            | `String`       | Unique alias string        |
 | `canonical_source` | `OracleSource` | Canonical enum value       |
 | `created_at`       | `DateTime`     | Auto-set on insert         |
+
+## API Response DTOs
+
+### `GET /v1/wallets/:wallet/positions`
+
+This is the single canonical endpoint for wallet position data — it replaces
+the deprecated `/positions/user/:address` alias (see
+[docs/api-versioning.md](api-versioning.md)). PnL is opt-in via
+`?includePnl=true`; pricing requires an extra order-book query per market, so
+it's skipped by default.
+
+`WalletExposureRow`:
+
+| Field              | Type                 | Notes                                |
+| ------------------ | -------------------- | ------------------------------------ |
+| `marketId`         | `string`             |                                      |
+| `marketQuestion`   | `string`             |                                      |
+| `yesShares`        | `number`             |                                      |
+| `noShares`         | `number`             |                                      |
+| `netExposure`      | `number`             | `yesShares - noShares`               |
+| `lockedCollateral` | `string`             |                                      |
+| `isSettled`        | `boolean`            |                                      |
+| `updatedAt`        | `string` (date-time) |                                      |
+| `pnlRealized`      | `string \| null`     | Only present when `includePnl=true`. |
+| `pnlUnrealized`    | `string \| null`     | Only present when `includePnl=true`. |
+
+`WalletPositionsResponse`:
+
+| Field           | Type                  | Notes                                |
+| --------------- | --------------------- | ------------------------------------ |
+| `wallet`        | `string`              |                                      |
+| `exposures`     | `WalletExposureRow[]` |                                      |
+| `count`         | `number`              |                                      |
+| `pnlRealized`   | `string`              | Only present when `includePnl=true`. |
+| `pnlUnrealized` | `string`              | Only present when `includePnl=true`. |
+| `pnlTotal`      | `string`              | Only present when `includePnl=true`. |

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -273,7 +273,8 @@ export const openApiSpec = {
     "/v1/wallets/{wallet}/positions": {
       get: {
         summary: "Wallet positions",
-        description: "Retrieve position exposures for a wallet",
+        description:
+          "Retrieve position exposures for a wallet. Set includePnl=true to also compute realized/unrealized PnL (this is the canonical replacement for the deprecated /positions/user/:address endpoint).",
         tags: ["Positions"],
         parameters: [
           {
@@ -281,11 +282,28 @@ export const openApiSpec = {
             in: "path",
             required: true,
             schema: { type: "string" },
+            description:
+              "Stellar public key (StrKey): starts with G and is 56 chars using [A-Z2-7]",
+          },
+          {
+            name: "includePnl",
+            in: "query",
+            required: false,
+            schema: { type: "boolean", default: false },
+            description:
+              "When true, computes and includes realized/unrealized PnL per position and in the response summary.",
           },
         ],
         responses: {
           "200": {
             description: "Wallet positions",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/WalletPositionsResponse",
+                },
+              },
+            },
           },
         },
       },
@@ -359,6 +377,50 @@ export const openApiSpec = {
           },
           requestId: {
             type: "string",
+          },
+        },
+      },
+      WalletExposureRow: {
+        type: "object",
+        properties: {
+          marketId: { type: "string" },
+          marketQuestion: { type: "string" },
+          yesShares: { type: "number" },
+          noShares: { type: "number" },
+          netExposure: { type: "number" },
+          lockedCollateral: { type: "string" },
+          isSettled: { type: "boolean" },
+          updatedAt: { type: "string", format: "date-time" },
+          pnlRealized: {
+            type: ["string", "null"],
+            description: "Present only when includePnl=true.",
+          },
+          pnlUnrealized: {
+            type: ["string", "null"],
+            description: "Present only when includePnl=true.",
+          },
+        },
+      },
+      WalletPositionsResponse: {
+        type: "object",
+        properties: {
+          wallet: { type: "string" },
+          exposures: {
+            type: "array",
+            items: { $ref: "#/components/schemas/WalletExposureRow" },
+          },
+          count: { type: "number" },
+          pnlRealized: {
+            type: "string",
+            description: "Present only when includePnl=true.",
+          },
+          pnlUnrealized: {
+            type: "string",
+            description: "Present only when includePnl=true.",
+          },
+          pnlTotal: {
+            type: "string",
+            description: "Present only when includePnl=true.",
           },
         },
       },

--- a/src/api/routes/positions.test.ts
+++ b/src/api/routes/positions.test.ts
@@ -141,12 +141,30 @@ describe("Positions Route", () => {
     });
   });
 
-  it("should include pnlRealized on settled positions", async () => {
+  it("should omit PnL fields by default (includePnl not set)", async () => {
     const app = await createTestServer();
     const wallet = "GINJ46CDSMNOSKETX3K5DU44435TGRWIQEM7ZVI3ON3BTOOFVJJHTWXO";
     const response = await app.inject({
       method: "GET",
       url: `/wallets/${wallet}/positions`,
+    });
+    const { data } = JSON.parse(response.body);
+
+    expect(data.pnlRealized).toBeUndefined();
+    expect(data.pnlUnrealized).toBeUndefined();
+    expect(data.pnlTotal).toBeUndefined();
+    for (const exposure of data.exposures) {
+      expect(exposure.pnlRealized).toBeUndefined();
+      expect(exposure.pnlUnrealized).toBeUndefined();
+    }
+  });
+
+  it("should include pnlRealized on settled positions when includePnl=true", async () => {
+    const app = await createTestServer();
+    const wallet = "GINJ46CDSMNOSKETX3K5DU44435TGRWIQEM7ZVI3ON3BTOOFVJJHTWXO";
+    const response = await app.inject({
+      method: "GET",
+      url: `/wallets/${wallet}/positions?includePnl=true`,
     });
     const { data } = JSON.parse(response.body);
 
@@ -156,12 +174,12 @@ describe("Positions Route", () => {
     expect(settled.pnlUnrealized).toBeNull();
   });
 
-  it("should include pnlUnrealized on open positions using mid-price", async () => {
+  it("should include pnlUnrealized on open positions using mid-price when includePnl=true", async () => {
     const app = await createTestServer();
     const wallet = "GINJ46CDSMNOSKETX3K5DU44435TGRWIQEM7ZVI3ON3BTOOFVJJHTWXO";
     const response = await app.inject({
       method: "GET",
-      url: `/wallets/${wallet}/positions`,
+      url: `/wallets/${wallet}/positions?includePnl=true`,
     });
     const { data } = JSON.parse(response.body);
 
@@ -173,12 +191,12 @@ describe("Positions Route", () => {
     expect(open.pnlRealized).toBeNull();
   });
 
-  it("should return correct pnlTotal, pnlRealized, pnlUnrealized summary", async () => {
+  it("should return correct pnlTotal, pnlRealized, pnlUnrealized summary when includePnl=true", async () => {
     const app = await createTestServer();
     const wallet = "GINJ46CDSMNOSKETX3K5DU44435TGRWIQEM7ZVI3ON3BTOOFVJJHTWXO";
     const response = await app.inject({
       method: "GET",
-      url: `/wallets/${wallet}/positions`,
+      url: `/wallets/${wallet}/positions?includePnl=true`,
     });
     const { data } = JSON.parse(response.body);
 
@@ -188,7 +206,7 @@ describe("Positions Route", () => {
     expect(data.pnlTotal).toBe("46.50000000");
   });
 
-  it("should return 200 with empty list and zero totals for new wallet (empty state)", async () => {
+  it("should return 200 with empty list and zero totals for new wallet (empty state, includePnl=true)", async () => {
     const { getPrismaClient } = await import("../../services/prisma");
     const prisma = getPrismaClient() as any;
     prisma.userPosition.findMany.mockResolvedValueOnce([]);
@@ -198,7 +216,7 @@ describe("Positions Route", () => {
     const wallet = "GINJ46CDSMNOSKETX3K5DU44435TGRWIQEM7ZVI3ON3BTOOFVJJHTWXO";
     const response = await app.inject({
       method: "GET",
-      url: `/wallets/${wallet}/positions`,
+      url: `/wallets/${wallet}/positions?includePnl=true`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -211,7 +229,7 @@ describe("Positions Route", () => {
     expect(body.data.pnlTotal).toBe("0.00000000");
   });
 
-  it("should return null pnlUnrealized when no open orders exist to price position", async () => {
+  it("should return null pnlUnrealized when no open orders exist to price position (includePnl=true)", async () => {
     const { getPrismaClient } = await import("../../services/prisma");
     const prisma = getPrismaClient() as any;
     prisma.userPosition.findMany.mockResolvedValueOnce([mockPositions[0]]);
@@ -221,12 +239,27 @@ describe("Positions Route", () => {
     const wallet = "GINJ46CDSMNOSKETX3K5DU44435TGRWIQEM7ZVI3ON3BTOOFVJJHTWXO";
     const response = await app.inject({
       method: "GET",
-      url: `/wallets/${wallet}/positions`,
+      url: `/wallets/${wallet}/positions?includePnl=true`,
     });
 
     const { data } = JSON.parse(response.body);
     expect(data.exposures[0].pnlUnrealized).toBeNull();
     expect(data.pnlUnrealized).toBe("0.00000000");
+  });
+
+  it("should not query the order book when includePnl is not set", async () => {
+    const { getPrismaClient } = await import("../../services/prisma");
+    const prisma = getPrismaClient() as any;
+    prisma.order.groupBy.mockClear();
+
+    const app = await createTestServer();
+    const wallet = "GINJ46CDSMNOSKETX3K5DU44435TGRWIQEM7ZVI3ON3BTOOFVJJHTWXO";
+    await app.inject({
+      method: "GET",
+      url: `/wallets/${wallet}/positions`,
+    });
+
+    expect(prisma.order.groupBy).not.toHaveBeenCalled();
   });
 
   it("should return 400 for invalid wallet identifier on wallet exposure endpoint", async () => {

--- a/src/api/routes/positions.ts
+++ b/src/api/routes/positions.ts
@@ -1,4 +1,4 @@
-import { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { getPrismaClient } from "../../services/prisma.js";
 import {
   STELLAR_PUBLIC_KEY_REGEX,
@@ -19,24 +19,39 @@ interface WalletExposureRow {
   updatedAt: Date;
   /** Realized PnL for settled positions (unit: shares * price, i.e. collateral units).
    *  Derived from market.outcome and locked collateral at settlement.
+   *  Only present when the request opts in via ?includePnl=true.
    *  Null when position is not yet settled. */
-  pnlRealized: string | null;
+  pnlRealized?: string | null;
   /** Unrealized PnL for open positions.
    *  Pricing source: best-bid mid-price from open orders on this market snapshot.
+   *  Only present when the request opts in via ?includePnl=true.
    *  Null when position is settled or no open orders exist to price the position. */
-  pnlUnrealized: string | null;
+  pnlUnrealized?: string | null;
 }
 
 interface WalletPositionsResponse {
   wallet: string;
   exposures: WalletExposureRow[];
   count: number;
-  /** Sum of pnlRealized across all settled positions. Currency: collateral units (8 decimal places). */
-  pnlRealized: string;
-  /** Sum of pnlUnrealized across all open positions that could be priced. Currency: collateral units (8 decimal places). */
-  pnlUnrealized: string;
-  /** Total PnL = pnlRealized + pnlUnrealized. Currency: collateral units (8 decimal places). */
-  pnlTotal: string;
+  /** Sum of pnlRealized across all settled positions. Currency: collateral units (8 decimal places).
+   *  Only present when the request opts in via ?includePnl=true. */
+  pnlRealized?: string;
+  /** Sum of pnlUnrealized across all open positions that could be priced. Currency: collateral units (8 decimal places).
+   *  Only present when the request opts in via ?includePnl=true. */
+  pnlUnrealized?: string;
+  /** Total PnL = pnlRealized + pnlUnrealized. Currency: collateral units (8 decimal places).
+   *  Only present when the request opts in via ?includePnl=true. */
+  pnlTotal?: string;
+}
+
+interface GetWalletPositionsParams {
+  wallet: string;
+}
+
+interface GetWalletPositionsQuery {
+  /** Opt into PnL calculation. Defaults to false — PnL pricing requires an
+   *  extra order-book query per market, so it's skipped unless requested. */
+  includePnl?: boolean;
 }
 
 /**
@@ -128,7 +143,10 @@ function addFixedPoint(a: string, b: string): string {
 }
 
 export default async function positionsRouter(server: FastifyInstance) {
-  server.get(
+  server.get<{
+    Params: GetWalletPositionsParams;
+    Querystring: GetWalletPositionsQuery;
+  }>(
     "/wallets/:wallet/positions",
     {
       onRequest: [heavyReadLimiter],
@@ -145,10 +163,27 @@ export default async function positionsRouter(server: FastifyInstance) {
             },
           },
         },
+        querystring: {
+          type: "object",
+          properties: {
+            includePnl: {
+              type: "boolean",
+              description:
+                "When true, computes and includes realized/unrealized PnL per position and in the response summary. Defaults to false.",
+            },
+          },
+        },
       },
     },
-    async (request, reply) => {
-      const { wallet } = request.params as { wallet: string };
+    async (
+      request: FastifyRequest<{
+        Params: GetWalletPositionsParams;
+        Querystring: GetWalletPositionsQuery;
+      }>,
+      reply: FastifyReply
+    ) => {
+      const { wallet } = request.params;
+      const { includePnl = false } = request.query;
       const prisma = getPrismaClient();
 
       const addressError = validateUserAddress(wallet);
@@ -171,10 +206,11 @@ export default async function positionsRouter(server: FastifyInstance) {
         orderBy: { updatedAt: "desc" },
       });
 
-      // Fetch best bid/ask per market for unrealized PnL pricing
+      // Fetch best bid/ask per market for unrealized PnL pricing — skipped
+      // unless PnL was requested, since it's an extra query per market.
       const marketIds = [...new Set(positions.map((p) => p.marketId))];
       const orderGroups =
-        marketIds.length > 0
+        includePnl && marketIds.length > 0
           ? await (prisma as any).order.groupBy({
               by: ["marketId", "side"],
               where: {
@@ -212,6 +248,22 @@ export default async function positionsRouter(server: FastifyInstance) {
       const exposures: WalletExposureRow[] = positions.map((position) => {
         const market = position.market as any;
         const lockedCollateral = position.lockedCollateral.toString();
+
+        const base: WalletExposureRow = {
+          marketId: market.id,
+          marketQuestion: market.question,
+          yesShares: position.yesShares,
+          noShares: position.noShares,
+          netExposure: position.yesShares - position.noShares,
+          lockedCollateral,
+          isSettled: position.isSettled,
+          updatedAt: position.updatedAt,
+        };
+
+        if (!includePnl) {
+          return base;
+        }
+
         let pnlRealized: string | null = null;
         let pnlUnrealized: string | null = null;
 
@@ -232,42 +284,37 @@ export default async function positionsRouter(server: FastifyInstance) {
           );
         }
 
-        return {
-          marketId: market.id,
-          marketQuestion: market.question,
-          yesShares: position.yesShares,
-          noShares: position.noShares,
-          netExposure: position.yesShares - position.noShares,
-          lockedCollateral,
-          isSettled: position.isSettled,
-          updatedAt: position.updatedAt,
-          pnlRealized,
-          pnlUnrealized,
-        };
+        return { ...base, pnlRealized, pnlUnrealized };
       });
 
-      const ZERO = "0.00000000";
-      const pnlRealized = exposures
-        .filter((e) => e.pnlRealized !== null)
-        .reduce((acc, e) => addFixedPoint(acc, e.pnlRealized!), ZERO);
-      const pnlUnrealized = exposures
-        .filter((e) => e.pnlUnrealized !== null)
-        .reduce((acc, e) => addFixedPoint(acc, e.pnlUnrealized!), ZERO);
-      const pnlTotal = addFixedPoint(pnlRealized, pnlUnrealized);
-
       request.log.info(
-        { wallet, positionCount: exposures.length },
+        { wallet, positionCount: exposures.length, includePnl },
         "wallet positions fetched"
       );
 
-      success(reply, {
+      const response: WalletPositionsResponse = {
         wallet,
         exposures,
         count: exposures.length,
-        pnlRealized,
-        pnlUnrealized,
-        pnlTotal,
-      });
+      };
+
+      if (includePnl) {
+        const ZERO = "0.00000000";
+        response.pnlRealized = exposures
+          .filter((e) => e.pnlRealized !== null && e.pnlRealized !== undefined)
+          .reduce((acc, e) => addFixedPoint(acc, e.pnlRealized!), ZERO);
+        response.pnlUnrealized = exposures
+          .filter(
+            (e) => e.pnlUnrealized !== null && e.pnlUnrealized !== undefined
+          )
+          .reduce((acc, e) => addFixedPoint(acc, e.pnlUnrealized!), ZERO);
+        response.pnlTotal = addFixedPoint(
+          response.pnlRealized,
+          response.pnlUnrealized
+        );
+      }
+
+      success(reply, response);
     }
   );
 }

--- a/tests/integration/positions.test.ts
+++ b/tests/integration/positions.test.ts
@@ -60,7 +60,37 @@ describe("Integration Tests: GET /v1/wallets/:wallet/positions", () => {
       expect(position.isSettled).toBe(false);
     });
 
-    it("should calculate PnL fields and totals correctly", async () => {
+    it("should omit PnL fields by default (includePnl not set)", async () => {
+      const market = await testUtils.createTestMarket({
+        question: "PnL omitted by default test",
+      });
+
+      await testUtils.createTestPosition(market.id, testWallet, {
+        yesShares: 200,
+        noShares: 50,
+        lockedCollateral: 3.75,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/v1/wallets/${testWallet}/positions`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+
+      expect(body.data.exposures).toHaveLength(1);
+      const position = body.data.exposures[0];
+
+      expect(position.netExposure).toBe(150); // 200 - 50
+      expect(position.pnlRealized).toBeUndefined();
+      expect(position.pnlUnrealized).toBeUndefined();
+      expect(body.data.pnlRealized).toBeUndefined();
+      expect(body.data.pnlUnrealized).toBeUndefined();
+      expect(body.data.pnlTotal).toBeUndefined();
+    });
+
+    it("should calculate PnL fields and totals correctly when includePnl=true", async () => {
       // Create test market
       const market = await testUtils.createTestMarket({
         question: "PnL calculation test",
@@ -75,7 +105,7 @@ describe("Integration Tests: GET /v1/wallets/:wallet/positions", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: `/v1/wallets/${testWallet}/positions`,
+        url: `/v1/wallets/${testWallet}/positions?includePnl=true`,
       });
 
       expect(response.statusCode).toBe(200);


### PR DESCRIPTION
## Summary
- Closes #453
- The canonical `GET /v1/wallets/:wallet/positions` endpoint now accepts an optional `?includePnl=true` query param. By default, the response omits `pnlRealized`/`pnlUnrealized`/`pnlTotal` and skips the extra order-book pricing query; passing `includePnl=true` computes and includes them, matching the prior always-on PnL behavior.
- This merges the two previously-duplicate position lookups into a single canonical handler — the legacy `/positions/user/:address` route already 308-redirects to this canonical endpoint (from the recent v1-prefix work), and now correctly returns the "simple" (no-PnL) shape by default since it never forwards `includePnl`.
- Updated OpenAPI spec (query parameter + `WalletExposureRow`/`WalletPositionsResponse` schemas), README, and `docs/schema.md` to document the single response DTO.
- Updated unit (`src/api/routes/positions.test.ts`) and integration (`tests/integration/positions.test.ts`) tests to cover both the default and `includePnl=true` response shapes, including a test asserting the order-book query is skipped by default.

## Test plan
- [x] `pnpm exec tsc --noEmit` — passes
- [x] `pnpm exec prettier --check .` — passes
- [x] `pnpm test:run` — 850/850 unit tests pass
- [x] `pnpm test:integration` — 37/37 integration tests pass (against local Postgres/Redis containers matching CI)
- [x] `pnpm test:coverage` — passes (non-blocking, matches CI step)
- [x] `pnpm build` — passes