### PR TITLE
fix(rate-limiting): audit and align per-route rate limits with endpoint risk tiers

### DIFF
--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -11,6 +11,7 @@ tighter controls without penalising cheap ones.
 | **Global**     | 100 req / 60 s | `RATE_LIMIT_MAX`, `RATE_LIMIT_WINDOW_MS`             | Every route (baseline)            |
 | **Heavy read** | 20 req / 60 s  | `RATE_LIMIT_HEAVY_MAX`, `RATE_LIMIT_HEAVY_WINDOW_MS` | Expensive read routes (see below) |
 | **Write**      | 10 req / 60 s  | `RATE_LIMIT_WRITE_MAX`, `RATE_LIMIT_WRITE_WINDOW_MS` | Mutation routes (see below)       |
+| **Admin**      | 30 req / 60 s  | `RATE_LIMIT_ADMIN_MAX`, `RATE_LIMIT_ADMIN_WINDOW_MS` | All admin routes (see below)      |
 
 Each tier maintains its own counter, so exhausting the heavy-read budget does
 not consume the global budget and vice versa.
@@ -19,33 +20,47 @@ not consume the global budget and vice versa.
 
 ### Heavy read endpoints
 
-These routes perform expensive database operations on every call:
+These routes perform expensive database operations on every call and are subject
+to the **heavy read** tier (20 req / 60 s per IP) in addition to the global baseline:
 
-| Route                                | Reason                                         |
-| ------------------------------------ | ---------------------------------------------- |
-| `GET /v1/markets`                    | Full-table scan; no cursor-based pagination    |
-| `GET /v1/orders/user/:address`       | Two parallel DB queries (`findMany` + `count`) |
-| `GET /v1/wallets/{wallet}/positions` | `findMany` with a `market` JOIN                |
-
-Limit: **20 req / 60 s** per IP.
+| Route                               | Reason                                                     |
+| ----------------------------------- | ---------------------------------------------------------- |
+| `GET /v1/markets`                   | Full-table scan; no cursor-based pagination                |
+| `GET /v1/markets/:id/orderbook`     | `findMany` on open orders for a market                     |
+| `GET /v1/orders/user/:address`      | Two parallel DB queries (`findMany` + `count`)             |
+| `GET /v1/trades/user/:address`      | Two DB queries (trades `findMany` + audit join)            |
+| `GET /v1/wallets/:wallet/positions` | `findMany` with a `market` JOIN; optional order-book query |
 
 ### Write endpoints
 
-Mutation routes carry the highest per-request cost (input validation, DB
-write, and future matching-engine work):
+Mutation routes carry the highest per-request cost (input validation, DB write,
+and matching-engine integration) and are subject to the **write** tier
+(10 req / 60 s per IP):
 
 | Route             | Reason                                              |
 | ----------------- | --------------------------------------------------- |
 | `POST /v1/orders` | Validation + DB write + matching-engine integration |
 
-Limit: **10 req / 60 s** per IP.
+### Admin endpoints
+
+Admin routes are privileged operations already gated behind API-key and
+admin-role checks. They are subject to the **admin** tier (30 req / 60 s per IP),
+which is stricter than the global baseline:
+
+| Route                                | Reason                                         |
+| ------------------------------------ | ---------------------------------------------- |
+| `GET /v1/admin/markets`              | Privileged full-table scan including cancelled |
+| `PATCH /v1/admin/markets/:id/status` | Privileged write — changes live market status  |
 
 ### Standard endpoints
 
-All other routes (e.g. `GET /v1/health`, admin routes) are covered only by the
-global baseline.
+All other routes are covered only by the global baseline (100 req / 60 s per IP):
 
-Limit: **100 req / 60 s** per IP.
+| Route                 | Notes                      |
+| --------------------- | -------------------------- |
+| `GET /v1/health`      | Lightweight liveness check |
+| `GET /v1/ready`       | Readiness check            |
+| `GET /v1/markets/:id` | Single-row point query     |
 
 ## Response format
 
@@ -86,6 +101,17 @@ Changes take effect on the next server start. The in-memory store resets on
 restart; for distributed deployments consider replacing the store with a shared
 Redis backend.
 
+| Env var                      | Tier       | Default |
+| ---------------------------- | ---------- | ------- |
+| `RATE_LIMIT_MAX`             | Global     | `100`   |
+| `RATE_LIMIT_WINDOW_MS`       | Global     | `60000` |
+| `RATE_LIMIT_HEAVY_MAX`       | Heavy read | `20`    |
+| `RATE_LIMIT_HEAVY_WINDOW_MS` | Heavy read | `60000` |
+| `RATE_LIMIT_WRITE_MAX`       | Write      | `10`    |
+| `RATE_LIMIT_WRITE_WINDOW_MS` | Write      | `60000` |
+| `RATE_LIMIT_ADMIN_MAX`       | Admin      | `30`    |
+| `RATE_LIMIT_ADMIN_WINDOW_MS` | Admin      | `60000` |
+
 ## Integrator notes
 
 - Read `RateLimit-Remaining` on every response to track your remaining quota
@@ -97,3 +123,5 @@ Redis backend.
 - Heavy and write limits are intentionally lower than the global limit. If your
   integration requires higher throughput on these routes, contact the platform
   team to discuss dedicated rate-limit tiers.
+- Admin limits are enforced before the API-key and admin-role checks, so
+  unauthenticated probes against admin routes still consume the admin quota.

--- a/src/api/middleware/rateLimiter.test.ts
+++ b/src/api/middleware/rateLimiter.test.ts
@@ -4,6 +4,7 @@ import {
   rateLimiter,
   heavyReadLimiter,
   writeLimiter,
+  adminLimiter,
   clearRateLimitStores,
 } from "./rateLimiter.js";
 
@@ -326,6 +327,105 @@ describe("quota headers", () => {
 
     expect(res.headers["ratelimit-limit"]).toBe("10");
     expect(res.headers["ratelimit-remaining"]).toBe("9");
+    await s.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Admin rate limiter
+// ---------------------------------------------------------------------------
+
+describe("adminLimiter", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearRateLimitStores();
+  });
+
+  it("allows requests under the admin limit", async () => {
+    vi.stubEnv("RATE_LIMIT_ADMIN_MAX", "5");
+    vi.stubEnv("RATE_LIMIT_ADMIN_WINDOW_MS", "60000");
+
+    const s = buildServer(adminLimiter);
+    const res = await s.inject({ method: "GET", url: "/test" });
+    expect(res.statusCode).toBe(200);
+    await s.close();
+  });
+
+  it("returns 429 when admin limit is exceeded", async () => {
+    vi.stubEnv("RATE_LIMIT_ADMIN_MAX", "2");
+    vi.stubEnv("RATE_LIMIT_ADMIN_WINDOW_MS", "60000");
+
+    const s = Fastify({ logger: false });
+    s.get("/admin/markets", { onRequest: [adminLimiter] }, async () => ({
+      ok: true,
+    }));
+
+    await exhaust(s, 2, "GET", "/admin/markets");
+    const res = await s.inject({ method: "GET", url: "/admin/markets" });
+
+    expect(res.statusCode).toBe(429);
+    const body = JSON.parse(res.body);
+    expect(body.code).toBe("RATE_LIMITED");
+    expect(body.retryAfter).toBeGreaterThan(0);
+    await s.close();
+  });
+
+  it("returns 429 with Retry-After header on admin overflow", async () => {
+    vi.stubEnv("RATE_LIMIT_ADMIN_MAX", "1");
+    vi.stubEnv("RATE_LIMIT_ADMIN_WINDOW_MS", "60000");
+
+    const s = buildServer(adminLimiter);
+    await s.inject({ method: "GET", url: "/test" });
+    const res = await s.inject({ method: "GET", url: "/test" });
+
+    expect(res.statusCode).toBe(429);
+    expect(res.headers["retry-after"]).toBeDefined();
+    await s.close();
+  });
+
+  it("uses RATE_LIMIT_ADMIN_MAX env var", async () => {
+    vi.stubEnv("RATE_LIMIT_ADMIN_MAX", "3");
+    vi.stubEnv("RATE_LIMIT_ADMIN_WINDOW_MS", "60000");
+
+    const s = buildServer(adminLimiter);
+    await exhaust(s, 3, "GET");
+    const res = await s.inject({ method: "GET", url: "/test" });
+    expect(res.statusCode).toBe(429);
+    await s.close();
+  });
+
+  it("exposes its own limit in quota headers", async () => {
+    vi.stubEnv("RATE_LIMIT_ADMIN_MAX", "30");
+    vi.stubEnv("RATE_LIMIT_ADMIN_WINDOW_MS", "60000");
+
+    const s = buildServer(adminLimiter);
+    const res = await s.inject({ method: "GET", url: "/test" });
+
+    expect(res.headers["ratelimit-limit"]).toBe("30");
+    expect(res.headers["ratelimit-remaining"]).toBe("29");
+    await s.close();
+  });
+
+  it("admin counter is isolated from global counter", async () => {
+    vi.stubEnv("RATE_LIMIT_ADMIN_MAX", "1");
+    vi.stubEnv("RATE_LIMIT_ADMIN_WINDOW_MS", "60000");
+    vi.stubEnv("RATE_LIMIT_MAX", "100");
+
+    const s = Fastify({ logger: false });
+    s.get("/admin/markets", { onRequest: [adminLimiter] }, async () => ({
+      ok: true,
+    }));
+    s.get("/markets", { onRequest: [rateLimiter] }, async () => ({ ok: true }));
+
+    // Exhaust admin tier
+    await s.inject({ method: "GET", url: "/admin/markets" });
+    const adminRes = await s.inject({ method: "GET", url: "/admin/markets" });
+    expect(adminRes.statusCode).toBe(429);
+
+    // Global tier should be unaffected
+    const globalRes = await s.inject({ method: "GET", url: "/markets" });
+    expect(globalRes.statusCode).toBe(200);
+
     await s.close();
   });
 });

--- a/src/api/middleware/rateLimiter.ts
+++ b/src/api/middleware/rateLimiter.ts
@@ -187,3 +187,22 @@ export const writeLimiter: RateLimiterMiddleware = (request, reply, done) => {
     10
   );
 };
+
+/**
+ * Admin rate limiter — applied to all admin routes.
+ * Stricter than the global baseline; admin operations are privileged and
+ * already gated behind API-key + admin-role checks.
+ * Limit: 30 req / 60 s (configurable via RATE_LIMIT_ADMIN_MAX / RATE_LIMIT_ADMIN_WINDOW_MS).
+ */
+export const adminLimiter: RateLimiterMiddleware = (request, reply, done) => {
+  applyLimit(
+    request,
+    reply,
+    done,
+    "admin",
+    "RATE_LIMIT_ADMIN_WINDOW_MS",
+    "RATE_LIMIT_ADMIN_MAX",
+    60_000,
+    30
+  );
+};

--- a/src/api/routes/admin.ts
+++ b/src/api/routes/admin.ts
@@ -2,11 +2,13 @@ import type { FastifyInstance } from "fastify";
 import { getPrismaClient } from "../../services/prisma.js";
 import { requireAdmin } from "../middleware/adminGuard.js";
 import { requireApiKey } from "../middleware/apiKeyAuth.js";
+import { adminLimiter } from "../middleware/rateLimiter.js";
 
 export async function adminRoutes(fastify: FastifyInstance) {
   const prisma = getPrismaClient();
 
-  // All routes in this plugin require both API key and admin role
+  // All routes in this plugin require API key, admin role, and the admin rate limit tier.
+  fastify.addHook("onRequest", adminLimiter);
   fastify.addHook("onRequest", requireApiKey);
   fastify.addHook("onRequest", requireAdmin);
 

--- a/src/api/routes/markets.ts
+++ b/src/api/routes/markets.ts
@@ -157,6 +157,7 @@ export async function marketsRoutes(fastify: FastifyInstance) {
   fastify.get<{ Params: GetMarketParams }>(
     "/markets/:id/orderbook",
     {
+      onRequest: [heavyReadLimiter],
       schema: {
         params: {
           type: "object",

--- a/src/api/routes/orders.ts
+++ b/src/api/routes/orders.ts
@@ -92,6 +92,7 @@ export async function ordersRoutes(fastify: FastifyInstance) {
   }>(
     "/trades/user/:address",
     {
+      onRequest: [heavyReadLimiter],
       schema: {
         params: {
           type: "object",


### PR DESCRIPTION
Closes #450

## Summary

Audited every route in the API against the three rate-limit tiers and fixed three gaps:

- **`GET /v1/trades/user/:address`** had a "Heavy read" comment but was missing the `heavyReadLimiter` — only the global 100 req/min baseline was firing. Fixed.
- **`GET /v1/markets/:id/orderbook`** performs a `findMany` across all open orders for a market with no per-route limiter. Added `heavyReadLimiter`.
- **Admin routes (`GET /v1/admin/markets`, `PATCH /v1/admin/markets/:id/status`)** had zero rate limiting despite being privileged operations. Added a new `adminLimiter` tier (30 req/60 s, stricter than global) applied plugin-wide.

## Changes

### `src/api/middleware/rateLimiter.ts`
- Added `adminLimiter` export — 30 req / 60 s default, configurable via `RATE_LIMIT_ADMIN_MAX` / `RATE_LIMIT_ADMIN_WINDOW_MS`, isolated in its own `"admin"` tier store.

### `src/api/routes/admin.ts`
- Imported `adminLimiter` and registered it as the first `onRequest` plugin-level hook (fires before `requireApiKey` / `requireAdmin`, so unauthenticated probes still consume the admin quota).

### `src/api/routes/orders.ts`
- Added `onRequest: [heavyReadLimiter]` to `GET /trades/user/:address`.

### `src/api/routes/markets.ts`
- Added `onRequest: [heavyReadLimiter]` to `GET /markets/:id/orderbook`.

### `docs/rate-limiting.md`
- Rewrote the route-classification tables to include all routes (previously `trades`, `orderbook`, and all admin routes were missing).
- Added **Admin** tier to the tiers table with env vars and default limits.
- Added a full env-var reference table covering all four tiers.
- Added an integrator note explaining that admin limits fire before auth checks.

### `src/api/middleware/rateLimiter.test.ts`
- Added 6 new unit tests for `adminLimiter`:
  - Allows requests under the limit
  - Returns 429 with `RATE_LIMITED` code when limit is exceeded
  - Returns 429 with `Retry-After` header on overflow
  - Respects `RATE_LIMIT_ADMIN_MAX` env var
  - Exposes correct quota headers (`RateLimit-Limit`, `RateLimit-Remaining`)
  - Admin counter is isolated from the global counter (tier isolation)

## Test plan

- [x] All 27 unit tests pass (`vitest run src/api/middleware/rateLimiter.test.ts --config vitest.unit.config.ts`)
- [x] TypeScript compiles cleanly (pre-commit `tsc-files --noEmit` hook passed)
- [x] Prettier formatting applied by pre-commit hook
- [ ] Verify integration tests pass in CI (requires DB)
- [ ] Manually confirm admin routes return 429 after 30 requests in a 60s window
- [ ] Manually confirm `/trades/user/:address` returns 429 after 20 requests in a 60s window

