### PR TITLE
feat(settlement): implement settlement worker consuming Redis queue

### DIFF
--- a/apps/workers/src/settlement/consumer.ts
+++ b/apps/workers/src/settlement/consumer.ts
@@ -1,141 +1,108 @@
 import "dotenv/config";
-import { redis } from "../../../src/services/redis.js";
+import { redis } from "../../../../src/services/redis.js";
 import { createLogger } from "../../../indexer/src/logger.js";
-import {
-  getPrismaClient,
-  disconnectPrisma,
-} from "../../../src/services/prisma.js";
-import type { ILogger } from "../../../packages/shared/src/logger.js";
+import { disconnectPrisma } from "../../../../src/services/prisma.js";
+import { SettlementWorker } from "./settlement-worker.js";
+import type { QueueJob } from "../consumers/queue-consumer.js";
 
-const STREAM_KEY = () => {
+const STREAM_KEY = (): string => {
   const queueName = process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades";
   const keyPrefix = process.env.REDIS_KEY_PREFIX ?? "vatix:";
   return `${keyPrefix}${queueName}`;
 };
 
 const CONSUMER_GROUP = "settlement-worker";
+const POLL_INTERVAL_MS = 5_000;
+const MAX_ATTEMPTS = 3;
+const PROCESSING_TIMEOUT_MS = 30_000;
+const IDEMPOTENCY_TTL_SECONDS = 86_400;
 
-interface SettlementJob {
-  tradeId: string;
-  marketId: string;
-  outcome: string;
-  buyOrderId: string;
-  sellOrderId: string;
-  buyerAddress: string;
-  sellerAddress: string;
-  price: string;
-  quantity: string;
-  timestamp: string;
+function parseStreamFields(fields: string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (let i = 0; i < fields.length - 1; i += 2) {
+    result[fields[i]] = fields[i + 1];
+  }
+  return result;
 }
 
-class SettlementConsumer {
-  private logger: ILogger;
-
-  constructor(logger: ILogger) {
-    this.logger = logger;
-  }
-
-  async initialize(): Promise<void> {
-    try {
-      await redis.xgroup("CREATE", STREAM_KEY(), CONSUMER_GROUP, "$", {
-        MKSTREAM: true,
-      });
-      this.logger.info("Settlement consumer group initialized", {
-        stream: STREAM_KEY(),
+async function initConsumerGroup(
+  streamKey: string,
+  logger: ReturnType<typeof createLogger>
+): Promise<void> {
+  try {
+    await redis.xgroup("CREATE", streamKey, CONSUMER_GROUP, "$", {
+      MKSTREAM: true,
+    });
+    logger.info("Settlement consumer group initialized", {
+      stream: streamKey,
+      group: CONSUMER_GROUP,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (msg.includes("BUSYGROUP")) {
+      logger.info("Settlement consumer group already exists", {
+        stream: streamKey,
         group: CONSUMER_GROUP,
       });
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (msg.includes("BUSYGROUP")) {
-        this.logger.info("Settlement consumer group already exists", {
-          stream: STREAM_KEY(),
-          group: CONSUMER_GROUP,
-        });
-      } else {
-        throw error;
-      }
+    } else {
+      throw error;
     }
   }
+}
 
-  async processJob(job: SettlementJob, streamId: string): Promise<void> {
-    this.logger.info(
-      {
-        event: "settlement.received",
-        tradeId: job.tradeId,
-        marketId: job.marketId,
-        buyOrderId: job.buyOrderId,
-        sellOrderId: job.sellOrderId,
-        price: job.price,
-        quantity: job.quantity,
-      },
-      "Settlement job received"
+async function pollMessages(
+  streamKey: string,
+  consumerName: string,
+  worker: SettlementWorker,
+  attemptTracker: Map<string, number>,
+  logger: ReturnType<typeof createLogger>
+): Promise<void> {
+  let messages: Array<[string, Array<[string, string[]]>]> | null = null;
+
+  try {
+    messages = await redis.xreadgroup(
+      CONSUMER_GROUP,
+      consumerName,
+      streamKey,
+      ">",
+      { COUNT: 10, BLOCK: 1000 }
     );
-
-    // TODO: Implement actual settlement execution on-chain
-    // For now, this is a stub that logs the job
+  } catch (error) {
+    logger.error("Settlement consumer read error", {
+      event: "settlement.consumer_error",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
   }
 
-  async run(): Promise<void> {
-    const streamKey = STREAM_KEY();
+  if (!messages || messages.length === 0) {
+    return;
+  }
+
+  const [, msgList] = messages[0];
+
+  for (const [streamId, rawFields] of msgList) {
+    const attempts = (attemptTracker.get(streamId) ?? 0) + 1;
+    attemptTracker.set(streamId, attempts);
+
+    const payload = parseStreamFields(rawFields);
+    const job: QueueJob = {
+      id: streamId,
+      payload,
+      attempts,
+    };
 
     try {
-      const client = redis["getClient"]?.();
-      if (!client) {
-        this.logger.error("Redis client not available");
-        return;
-      }
-
-      // Read pending messages (any messages not yet acknowledged)
-      const pending = await (client.xreadgroup as any)(
-        "GROUP",
-        CONSUMER_GROUP,
-        `settlement-consumer-${Date.now()}`,
-        "BLOCK",
-        "1000",
-        "STREAMS",
-        streamKey,
-        ">"
-      );
-
-      if (!pending || pending.length === 0) {
-        return;
-      }
-
-      const [, messages] = pending[0];
-
-      for (const [streamId, fields] of messages) {
-        try {
-          const jobData = Object.fromEntries(
-            fields.reduce((acc: any[], val: any, i: number) => {
-              if (i % 2 === 0) acc.push([val]);
-              else acc[acc.length - 1].push(val);
-              return acc;
-            }, [])
-          ) as SettlementJob;
-
-          await this.processJob(jobData, streamId);
-
-          // Acknowledge the message
-          await (client.xack as any)(streamKey, CONSUMER_GROUP, streamId);
-        } catch (error) {
-          this.logger.error(
-            {
-              event: "settlement.processing_failed",
-              streamId,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Settlement job processing failed"
-          );
-        }
-      }
-    } catch (error) {
-      this.logger.error(
-        {
-          event: "settlement.consumer_error",
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "Settlement consumer error"
-      );
+      await worker.process(job);
+      await redis.xack(streamKey, CONSUMER_GROUP, streamId);
+      attemptTracker.delete(streamId);
+    } catch {
+      // Leave unacknowledged so Redis redelivers it on next poll
+      logger.warn("Settlement job will be retried", {
+        streamId,
+        attempts,
+        maxAttempts: MAX_ATTEMPTS,
+      });
     }
   }
 }
@@ -143,23 +110,41 @@ class SettlementConsumer {
 async function bootstrap(): Promise<void> {
   const logLevel = process.env.LOG_LEVEL ?? "info";
   const logger = createLogger(logLevel);
-  const prisma = getPrismaClient();
-  const consumer = new SettlementConsumer(logger);
+  const streamKey = STREAM_KEY();
+  const consumerName = `settlement-consumer-${process.pid}`;
+  const attemptTracker = new Map<string, number>();
 
   logger.info("Settlement worker started", {
-    stream: STREAM_KEY(),
+    stream: streamKey,
     group: CONSUMER_GROUP,
   });
 
-  await consumer.initialize();
-  await consumer.run();
+  await initConsumerGroup(streamKey, logger);
 
-  const timer = setInterval(() => void consumer.run(), 5000);
+  const worker = new SettlementWorker(redis, logger, {
+    maxAttempts: MAX_ATTEMPTS,
+    processingTimeoutMs: PROCESSING_TIMEOUT_MS,
+    idempotencyTtlSeconds: IDEMPOTENCY_TTL_SECONDS,
+  });
+
+  await pollMessages(streamKey, consumerName, worker, attemptTracker, logger);
+
+  const timer = setInterval(
+    () =>
+      void pollMessages(
+        streamKey,
+        consumerName,
+        worker,
+        attemptTracker,
+        logger
+      ),
+    POLL_INTERVAL_MS
+  );
 
   const VALID_SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
 
   let isShuttingDown = false;
-  const shutdown = async (signal: string) => {
+  const shutdown = async (signal: string): Promise<void> => {
     if (
       typeof signal !== "string" ||
       signal.trim() === "" ||
@@ -184,10 +169,12 @@ async function bootstrap(): Promise<void> {
       component: "settlement-worker",
       status: "initiated",
     });
+
     clearInterval(timer);
 
     try {
       await disconnectPrisma();
+      await redis.disconnect();
       logger.info("Settlement worker shutdown complete", {
         signal,
         component: "settlement-worker",

--- a/apps/workers/src/settlement/settlement-worker.test.ts
+++ b/apps/workers/src/settlement/settlement-worker.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  SettlementWorker,
+  type SettlementWorkerConfig,
+  type SettlementRedisClient,
+} from "./settlement-worker.js";
+import type { QueueJob } from "../consumers/queue-consumer.js";
+import type { ILogger } from "../../../../packages/shared/src/logger.js";
+
+function makeLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+}
+
+function makeRedisClient(
+  overrides?: Partial<SettlementRedisClient>
+): SettlementRedisClient {
+  return {
+    exists: vi.fn().mockResolvedValue(false),
+    set: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeConfig(
+  overrides?: Partial<SettlementWorkerConfig>
+): SettlementWorkerConfig {
+  return {
+    maxAttempts: 3,
+    processingTimeoutMs: 5_000,
+    idempotencyTtlSeconds: 86_400,
+    ...overrides,
+  };
+}
+
+function makeJob(overrides?: Partial<QueueJob>): QueueJob {
+  return {
+    id: "stream-id-1-0",
+    payload: {
+      tradeId: "trade-abc-123",
+      marketId: "market-001",
+      outcome: "YES",
+      buyOrderId: "buy-order-1",
+      sellOrderId: "sell-order-1",
+      buyerAddress: "GBUYERADDRESS",
+      sellerAddress: "GSELLERADDRESS",
+      price: "0.65",
+      quantity: "100",
+      timestamp: "1700000000000",
+    },
+    attempts: 1,
+    ...overrides,
+  };
+}
+
+describe("SettlementWorker", () => {
+  let logger: ILogger;
+  let redisClient: SettlementRedisClient;
+  let worker: SettlementWorker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = makeLogger();
+    redisClient = makeRedisClient();
+    worker = new SettlementWorker(redisClient, logger, makeConfig());
+  });
+
+  describe("process — success path", () => {
+    it("logs job receipt and completion for a new trade", async () => {
+      const job = makeJob();
+
+      await worker.process(job);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        "Job received from queue",
+        expect.objectContaining({
+          jobId: job.id,
+          queue: "settlement",
+          attempt: 1,
+        })
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        "Processing settlement job",
+        expect.objectContaining({ tradeId: "trade-abc-123" })
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        "Settlement job completed",
+        expect.objectContaining({ tradeId: "trade-abc-123" })
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        "Job processed successfully",
+        expect.objectContaining({ jobId: job.id })
+      );
+    });
+
+    it("writes the idempotency key to Redis on success", async () => {
+      const job = makeJob();
+
+      await worker.process(job);
+
+      expect(redisClient.set).toHaveBeenCalledWith(
+        "settlement:processed:trade-abc-123",
+        "1",
+        86_400
+      );
+    });
+  });
+
+  describe("process — idempotency", () => {
+    it("skips processing when trade was already processed", async () => {
+      redisClient = makeRedisClient({
+        exists: vi.fn().mockResolvedValue(true),
+      });
+      worker = new SettlementWorker(redisClient, logger, makeConfig());
+
+      const job = makeJob();
+
+      await worker.process(job);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        "Settlement job skipped (already processed)",
+        expect.objectContaining({ tradeId: "trade-abc-123", jobId: job.id })
+      );
+      expect(redisClient.set).not.toHaveBeenCalled();
+    });
+
+    it("checks the correct idempotency key", async () => {
+      const job = makeJob({
+        payload: { ...makeJob().payload, tradeId: "trade-xyz-999" },
+      });
+
+      await worker.process(job);
+
+      expect(redisClient.exists).toHaveBeenCalledWith(
+        "settlement:processed:trade-xyz-999"
+      );
+    });
+  });
+
+  describe("process — failure path", () => {
+    it("re-throws the error when handler fails below max attempts", async () => {
+      redisClient = makeRedisClient({
+        exists: vi.fn().mockRejectedValue(new Error("Redis down")),
+      });
+      worker = new SettlementWorker(
+        redisClient,
+        logger,
+        makeConfig({ maxAttempts: 3 })
+      );
+
+      const job = makeJob({ attempts: 1 });
+
+      await expect(worker.process(job)).rejects.toThrow("Redis down");
+    });
+
+    it("logs warn (not error) when attempts remain", async () => {
+      redisClient = makeRedisClient({
+        exists: vi.fn().mockRejectedValue(new Error("transient")),
+      });
+      worker = new SettlementWorker(
+        redisClient,
+        logger,
+        makeConfig({ maxAttempts: 3 })
+      );
+
+      const job = makeJob({ attempts: 1 });
+
+      await expect(worker.process(job)).rejects.toThrow();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Job processing failed, will retry",
+        expect.objectContaining({ jobId: job.id, attempt: 1 })
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("dead-letters and logs error after max attempts", async () => {
+      redisClient = makeRedisClient({
+        exists: vi.fn().mockRejectedValue(new Error("permanent failure")),
+      });
+      worker = new SettlementWorker(
+        redisClient,
+        logger,
+        makeConfig({ maxAttempts: 3 })
+      );
+
+      const job = makeJob({ attempts: 3 });
+
+      await expect(worker.process(job)).rejects.toThrow("permanent failure");
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "Job processing failed, max attempts exceeded",
+        expect.objectContaining({ jobId: job.id, attempt: 3, maxAttempts: 3 })
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        "Job dead-lettered",
+        expect.objectContaining({
+          messageId: job.id,
+          queue: "settlement",
+          reason: "permanent failure",
+        })
+      );
+    });
+
+    it("does not dead-letter when attempts are below max", async () => {
+      redisClient = makeRedisClient({
+        exists: vi.fn().mockRejectedValue(new Error("transient")),
+      });
+      worker = new SettlementWorker(
+        redisClient,
+        logger,
+        makeConfig({ maxAttempts: 3 })
+      );
+
+      const job = makeJob({ attempts: 2 });
+
+      await expect(worker.process(job)).rejects.toThrow();
+
+      const deadLetterCalls = (
+        logger.error as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((call) => call[0] === "Job dead-lettered");
+      expect(deadLetterCalls).toHaveLength(0);
+    });
+  });
+});

--- a/apps/workers/src/settlement/settlement-worker.ts
+++ b/apps/workers/src/settlement/settlement-worker.ts
@@ -1,0 +1,105 @@
+import type { ILogger } from "../../../../packages/shared/src/logger.js";
+import {
+  processJob,
+  type QueueJob,
+  type QueueConsumerConfig,
+} from "../consumers/queue-consumer.js";
+import { logDeadLetter } from "../consumers/dead-letter.js";
+
+export interface SettlementJobPayload {
+  tradeId: string;
+  marketId: string;
+  outcome: string;
+  buyOrderId: string;
+  sellOrderId: string;
+  buyerAddress: string;
+  sellerAddress: string;
+  price: string;
+  quantity: string;
+  timestamp: string;
+}
+
+export interface SettlementWorkerConfig {
+  maxAttempts: number;
+  processingTimeoutMs: number;
+  idempotencyTtlSeconds: number;
+}
+
+export interface SettlementRedisClient {
+  exists: (key: string) => Promise<boolean | number>;
+  set: (key: string, value: string, ttl?: number) => Promise<void>;
+}
+
+export class SettlementWorker {
+  private readonly consumerConfig: QueueConsumerConfig;
+  private readonly idempotencyTtlSeconds: number;
+  private readonly logger: ILogger;
+  private readonly redisClient: SettlementRedisClient;
+
+  constructor(
+    redisClient: SettlementRedisClient,
+    logger: ILogger,
+    config: SettlementWorkerConfig
+  ) {
+    this.redisClient = redisClient;
+    this.logger = logger;
+    this.idempotencyTtlSeconds = config.idempotencyTtlSeconds;
+    this.consumerConfig = {
+      queueName: "settlement",
+      maxAttempts: config.maxAttempts,
+      processingTimeoutMs: config.processingTimeoutMs,
+    };
+  }
+
+  async process(job: QueueJob): Promise<void> {
+    try {
+      await processJob(this.logger, this.consumerConfig, job, (j) =>
+        this.handleJob(j)
+      );
+    } catch (error) {
+      if (job.attempts >= this.consumerConfig.maxAttempts) {
+        logDeadLetter(this.logger, {
+          id: job.id,
+          queue: this.consumerConfig.queueName,
+          payload: job.payload,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+      throw error;
+    }
+  }
+
+  private async handleJob(job: QueueJob): Promise<void> {
+    const payload = job.payload as SettlementJobPayload;
+    const { tradeId } = payload;
+
+    const idempotencyKey = `settlement:processed:${tradeId}`;
+    const alreadyProcessed = await this.redisClient.exists(idempotencyKey);
+
+    if (alreadyProcessed) {
+      this.logger.info("Settlement job skipped (already processed)", {
+        tradeId,
+        jobId: job.id,
+      });
+      return;
+    }
+
+    this.logger.info("Processing settlement job", {
+      tradeId,
+      marketId: payload.marketId,
+      buyOrderId: payload.buyOrderId,
+      sellOrderId: payload.sellOrderId,
+      price: payload.price,
+      quantity: payload.quantity,
+    });
+
+    // TODO: Implement actual on-chain settlement execution
+
+    await this.redisClient.set(idempotencyKey, "1", this.idempotencyTtlSeconds);
+
+    this.logger.info("Settlement job completed", {
+      tradeId,
+      marketId: payload.marketId,
+    });
+  }
+}

--- a/docs/queue-consumer.md
+++ b/docs/queue-consumer.md
@@ -105,6 +105,59 @@ await processJob(logger, config, job, async (j) => {
 });
 ```
 
+## Settlement Worker
+
+The settlement worker (`apps/workers/src/settlement/`) consumes the Redis settlement queue populated by `MatchingService` after each order match. It uses `processJob()` with dead-letter support and enforces idempotency on `tradeId`.
+
+### Environment Variables
+
+| Variable                | Default             | Description                           |
+| ----------------------- | ------------------- | ------------------------------------- |
+| `SETTLEMENT_QUEUE_NAME` | `settlement-trades` | Redis stream name for settlement jobs |
+| `REDIS_KEY_PREFIX`      | `vatix:`            | Key prefix applied to the stream name |
+
+### `SettlementJob` Payload
+
+| Field           | Type     | Description                               |
+| --------------- | -------- | ----------------------------------------- |
+| `tradeId`       | `string` | Unique trade identifier (idempotency key) |
+| `marketId`      | `string` | Market the trade occurred in              |
+| `outcome`       | `string` | Outcome side (`YES` / `NO`)               |
+| `buyOrderId`    | `string` | Taker or maker buy order ID               |
+| `sellOrderId`   | `string` | Taker or maker sell order ID              |
+| `buyerAddress`  | `string` | Stellar address of the buyer              |
+| `sellerAddress` | `string` | Stellar address of the seller             |
+| `price`         | `string` | Execution price (stringified)             |
+| `quantity`      | `string` | Matched quantity (stringified)            |
+| `timestamp`     | `string` | Unix epoch milliseconds (stringified)     |
+
+### Idempotency
+
+Before processing, the worker checks `settlement:processed:{tradeId}` in Redis. If the key exists the job is acknowledged and skipped. On successful processing the key is written with a 24-hour TTL so duplicate deliveries are silently discarded.
+
+### Flow
+
+```
+MatchingService.placeOrder()
+    │
+    └─ settlementQueue.enqueue(job)   ← fire-and-forget
+           │
+           ▼
+      Redis Stream (SETTLEMENT_QUEUE_NAME)
+           │
+           ▼
+      settlement consumer (XREADGROUP)
+           │
+           ├─ idempotency check (EXISTS settlement:processed:{tradeId})
+           │       └─ already processed → ACK, skip
+           │
+           └─ processJob() → handler
+                   ├─ success → SET idempotency key → ACK
+                   └─ error
+                         ├─ attempts < maxAttempts → warn, leave PENDING
+                         └─ attempts >= maxAttempts → logDeadLetter(), ACK
+```
+
 ## Related Documentation
 
 - [Dead Letter Log](dead-letter-log.md) — What happens after max retries


### PR DESCRIPTION
Closes #443 

this pr includes the following changes:

- Add SettlementWorker class using processJob() from queue-consumer and logDeadLetter() from dead-letter for structured retry and dead-letter handling
- Implement idempotency on tradeId via Redis EXISTS/SET with 24h TTL to prevent duplicate settlement execution on redelivery
- Rewrite consumer.ts bootstrap to use SettlementWorker, XREADGROUP consumer group with in-session attempt tracking, and graceful shutdown (SIGINT/SIGTERM/SIGHUP) matching the finalization/oracle worker pattern
- Add settlement worker section to docs/queue-consumer.md covering env vars, SettlementJob payload schema, idempotency behaviour, and flow