### PR TITLE
feat(infra): add settlement-worker Docker target and compose service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@
 #   docker build --target indexer -t vatix-indexer .
 #   docker build --target finalization-worker -t vatix-finalization-worker .
 #   docker build --target oracle-worker -t vatix-oracle-worker .
+#   docker build --target settlement-worker -t vatix-settlement-worker .
 
 ARG NODE_VERSION=22-bookworm-slim
 
@@ -101,3 +102,9 @@ CMD ["node_modules/.bin/tsx", "apps/workers/src/finalization/main.ts"]
 # ---------------------------------------------------------------------------
 FROM runtime AS oracle-worker
 CMD ["node_modules/.bin/tsx", "apps/workers/src/oracle/main.ts"]
+
+# ---------------------------------------------------------------------------
+# settlement-worker — Redis-stream settlement queue consumer
+# ---------------------------------------------------------------------------
+FROM runtime AS settlement-worker
+CMD ["node_modules/.bin/tsx", "apps/workers/src/settlement/consumer.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,24 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  settlement-worker:
+    build:
+      context: .
+      target: settlement-worker
+    container_name: vatix-settlement-worker
+    profiles: ["app", "workers", "settlement-worker"]
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/vatix
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
   # One-off migration runner — not part of any long-running profile.
   # Usage: docker compose --profile tools run --rm migrate
   migrate:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "workers:submission:start": "tsx apps/workers/src/oracle/main.ts",
     "workers:oracle:dev": "tsx watch apps/workers/src/oracle/main.ts",
     "workers:oracle:start": "tsx apps/workers/src/oracle/main.ts",
+    "workers:settlement:dev": "tsx watch apps/workers/src/settlement/consumer.ts",
+    "workers:settlement:start": "tsx apps/workers/src/settlement/consumer.ts",
     "build": "tsc",
     "start": "tsx src/index.ts",
     "test": "vitest",


### PR DESCRIPTION
Add a settlement-worker build target to the Dockerfile and a matching service definition in docker-compose.yml (profiles: app, workers, settlement-worker). Add workers:settlement:dev and workers:settlement:start npm scripts so the consumer can be started locally with a single command.

The consumer.ts bootstrap already contained the full polling loop, graceful shutdown, and Redis Stream consumer-group setup; this change wires it into the container runtime so it runs alongside the other workers in Docker.

closes #544 