### PR TITLE
feat(settlement): implement on-chain settle_trade via Stellar SDK

### DIFF
--- a/apps/workers/src/settlement/consumer.ts
+++ b/apps/workers/src/settlement/consumer.ts
@@ -2,7 +2,10 @@ import "dotenv/config";
 import { redis } from "../../../../src/services/redis.js";
 import { createLogger } from "../../../indexer/src/logger.js";
 import { disconnectPrisma } from "../../../../src/services/prisma.js";
-import { SettlementWorker } from "./settlement-worker.js";
+import {
+  SettlementWorker,
+  type SettlementStellarConfig,
+} from "./settlement-worker.js";
 import type { QueueJob } from "../consumers/queue-consumer.js";
 
 const STREAM_KEY = (): string => {
@@ -123,10 +126,30 @@ async function bootstrap(): Promise<void> {
 
   await initConsumerGroup(streamKey, logger);
 
+  const rpcUrl = process.env.STELLAR_RPC_URL;
+  const contractId = process.env.SETTLEMENT_CONTRACT_ID;
+  const networkPassphrase = process.env.SOROBAN_NETWORK_PASSPHRASE;
+  const signerSecret = process.env.STELLAR_SECRET_KEY;
+
+  const stellar: SettlementStellarConfig | undefined =
+    rpcUrl && contractId && networkPassphrase && signerSecret
+      ? { rpcUrl, contractId, networkPassphrase, signerSecret }
+      : undefined;
+
+  if (!stellar) {
+    logger.warn(
+      "Stellar config incomplete — on-chain settlement disabled. " +
+        "Set STELLAR_RPC_URL, SETTLEMENT_CONTRACT_ID, SOROBAN_NETWORK_PASSPHRASE, " +
+        "and STELLAR_SECRET_KEY to enable.",
+      { component: "settlement-worker" }
+    );
+  }
+
   const worker = new SettlementWorker(redis, logger, {
     maxAttempts: MAX_ATTEMPTS,
     processingTimeoutMs: PROCESSING_TIMEOUT_MS,
     idempotencyTtlSeconds: IDEMPOTENCY_TTL_SECONDS,
+    stellar,
   });
 
   await pollMessages(streamKey, consumerName, worker, attemptTracker, logger);

--- a/apps/workers/src/settlement/settlement-worker.ts
+++ b/apps/workers/src/settlement/settlement-worker.ts
@@ -1,3 +1,11 @@
+import {
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc as StellarRpc,
+  xdr,
+} from "@stellar/stellar-sdk";
 import type { ILogger } from "../../../../packages/shared/src/logger.js";
 import {
   processJob,
@@ -23,6 +31,14 @@ export interface SettlementWorkerConfig {
   maxAttempts: number;
   processingTimeoutMs: number;
   idempotencyTtlSeconds: number;
+  stellar?: SettlementStellarConfig;
+}
+
+export interface SettlementStellarConfig {
+  rpcUrl: string;
+  contractId: string;
+  networkPassphrase: string;
+  signerSecret: string;
 }
 
 export interface SettlementRedisClient {
@@ -35,6 +51,7 @@ export class SettlementWorker {
   private readonly idempotencyTtlSeconds: number;
   private readonly logger: ILogger;
   private readonly redisClient: SettlementRedisClient;
+  private readonly stellarConfig?: SettlementStellarConfig;
 
   constructor(
     redisClient: SettlementRedisClient,
@@ -44,6 +61,7 @@ export class SettlementWorker {
     this.redisClient = redisClient;
     this.logger = logger;
     this.idempotencyTtlSeconds = config.idempotencyTtlSeconds;
+    this.stellarConfig = config.stellar;
     this.consumerConfig = {
       queueName: "settlement",
       maxAttempts: config.maxAttempts,
@@ -93,7 +111,14 @@ export class SettlementWorker {
       quantity: payload.quantity,
     });
 
-    // TODO: Implement actual on-chain settlement execution
+    if (this.stellarConfig) {
+      await this.executeOnChain(payload);
+    } else {
+      this.logger.warn(
+        "No Stellar config provided — settlement recorded off-chain only",
+        { tradeId, marketId: payload.marketId }
+      );
+    }
 
     await this.redisClient.set(idempotencyKey, "1", this.idempotencyTtlSeconds);
 
@@ -101,5 +126,82 @@ export class SettlementWorker {
       tradeId,
       marketId: payload.marketId,
     });
+  }
+
+  private async executeOnChain(payload: SettlementJobPayload): Promise<void> {
+    const { rpcUrl, contractId, networkPassphrase, signerSecret } =
+      this.stellarConfig!;
+
+    const keypair = Keypair.fromSecret(signerSecret);
+    const server = new StellarRpc.Server(rpcUrl);
+    const contract = new Contract(contractId);
+
+    const sourceAccount = await server.getAccount(keypair.publicKey());
+
+    const outcomeScVal = nativeToScVal(payload.outcome === "YES", {
+      type: "bool",
+    });
+    const args: xdr.ScVal[] = [
+      nativeToScVal(payload.tradeId, { type: "string" }),
+      nativeToScVal(payload.marketId, { type: "string" }),
+      outcomeScVal,
+      nativeToScVal(payload.buyerAddress, { type: "address" }),
+      nativeToScVal(payload.sellerAddress, { type: "address" }),
+      nativeToScVal(BigInt(Math.round(Number(payload.price) * 1e7)), {
+        type: "i128",
+      }),
+      nativeToScVal(BigInt(payload.quantity), { type: "i128" }),
+    ];
+
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: "100",
+      networkPassphrase,
+    })
+      .addOperation(contract.call("settle_trade", ...args))
+      .setTimeout(30)
+      .build();
+
+    const preparedTx = await server.prepareTransaction(tx);
+    preparedTx.sign(keypair);
+
+    const sendResult = await server.sendTransaction(preparedTx);
+
+    if (sendResult.status === "ERROR") {
+      throw new Error(
+        `settle_trade submission failed: status=ERROR hash=${sendResult.hash}`
+      );
+    }
+
+    this.logger.info("settle_trade submitted, awaiting confirmation", {
+      tradeId: payload.tradeId,
+      hash: sendResult.hash,
+    });
+
+    // Poll until the transaction is confirmed or fails
+    const MAX_POLL_ATTEMPTS = 30;
+    const POLL_INTERVAL_MS = 1_000;
+    for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      const txStatus = await server.getTransaction(sendResult.hash);
+      if (
+        txStatus.status === StellarRpc.Api.GetTransactionStatus.SUCCESS
+      ) {
+        this.logger.info("settle_trade confirmed on-chain", {
+          tradeId: payload.tradeId,
+          hash: sendResult.hash,
+          ledger: txStatus.ledger,
+        });
+        return;
+      }
+      if (txStatus.status === StellarRpc.Api.GetTransactionStatus.FAILED) {
+        throw new Error(
+          `settle_trade transaction failed on-chain: hash=${sendResult.hash}`
+        );
+      }
+    }
+
+    throw new Error(
+      `settle_trade not confirmed after ${MAX_POLL_ATTEMPTS}s: hash=${sendResult.hash}`
+    );
   }
 }


### PR DESCRIPTION
Replace the TODO placeholder in SettlementWorker.handleJob with a real Soroban contract invocation. When STELLAR_RPC_URL, SETTLEMENT_CONTRACT_ID, SOROBAN_NETWORK_PASSPHRASE, and STELLAR_SECRET_KEY are all set, the worker calls settle_trade(tradeId, marketId, outcome, buyerAddress, sellerAddress, price, quantity) on the contract and polls until the transaction is confirmed or fails.

Without those env vars the worker degrades gracefully: trades are acknowledged and the idempotency key is set, but no on-chain call is made, and a WARN is logged so the gap is visible in monitoring.

closes #545 