### PR TITLE
feat(oracle): invoke resolve_market on-chain via Stellar SDK

### DIFF
--- a/apps/workers/src/oracle/main.ts
+++ b/apps/workers/src/oracle/main.ts
@@ -36,10 +36,31 @@ async function bootstrap(): Promise<void> {
     logger,
   });
 
+  const rpcUrl = process.env.STELLAR_RPC_URL;
+  const contractId =
+    process.env.MARKET_CONTRACT_ID ?? process.env.INDEXER_CONTRACT_ID;
+  const networkPassphrase = process.env.SOROBAN_NETWORK_PASSPHRASE;
+  const signerSecret = process.env.ORACLE_SECRET_KEY;
+
+  const stellar =
+    rpcUrl && contractId && networkPassphrase && signerSecret
+      ? { rpcUrl, contractId, networkPassphrase, signerSecret }
+      : undefined;
+
+  if (!stellar) {
+    logger.warn(
+      "Oracle Stellar config incomplete — resolve_market calls disabled. " +
+        "Set STELLAR_RPC_URL, MARKET_CONTRACT_ID, SOROBAN_NETWORK_PASSPHRASE, " +
+        "and ORACLE_SECRET_KEY to enable on-chain submission.",
+      { component: "oracle-worker" }
+    );
+  }
+
   const worker = new SubmissionWorker(queue, prisma, {
     submissionMaxRetries: config.submissionMaxRetries,
     consumerName: `oracle-worker-${Date.now()}`,
     logger,
+    stellar,
   });
 
   // Initialize the queue (idempotent)

--- a/apps/workers/src/oracle/submission-worker.ts
+++ b/apps/workers/src/oracle/submission-worker.ts
@@ -7,6 +7,14 @@
  * @module apps/workers/src/oracle/submission-worker
  */
 
+import {
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc as StellarRpc,
+  xdr,
+} from "@stellar/stellar-sdk";
 import { PrismaClient } from "../../../../src/generated/prisma/client/index.js";
 import type { ILogger } from "../../../../packages/shared/src/logger.js";
 import {
@@ -19,10 +27,18 @@ import {
 } from "./redis-submission-queue.js";
 import type { SubmissionQueueItem } from "../../../oracle/submission-queue.js";
 
+export interface OracleStellarConfig {
+  rpcUrl: string;
+  contractId: string;
+  networkPassphrase: string;
+  signerSecret: string;
+}
+
 export interface SubmissionWorkerConfig {
   submissionMaxRetries: number;
   consumerName: string;
   logger: ILogger;
+  stellar?: OracleStellarConfig;
 }
 
 /**
@@ -34,6 +50,7 @@ export class SubmissionWorker {
   private logger: ILogger;
   private queue: RedisSubmissionQueue;
   private prisma: PrismaClient;
+  private stellarConfig?: OracleStellarConfig;
 
   constructor(
     queue: RedisSubmissionQueue,
@@ -45,6 +62,7 @@ export class SubmissionWorker {
     this.maxRetries = config.submissionMaxRetries;
     this.consumerName = config.consumerName;
     this.logger = config.logger;
+    this.stellarConfig = config.stellar;
   }
 
   /**
@@ -74,7 +92,7 @@ export class SubmissionWorker {
         throw new Error("Signature verification failed");
       }
 
-      // Submit on-chain (placeholder - integrate Stellar SDK)
+      // Submit on-chain via Stellar SDK
       await this.submitOnChain(report, request.oracleAddress);
 
       // Update database on success
@@ -153,15 +171,14 @@ export class SubmissionWorker {
   }
 
   /**
-   * Submit the signed report on-chain (placeholder).
-   * In production, this integrates with Stellar SDK.
+   * Submit the signed resolution on-chain by invoking resolve_market on the
+   * Soroban contract. Falls back to a warn-only path when stellar config is
+   * absent (e.g. in local dev without chain access).
    */
   private async submitOnChain(
     report: SignedResolutionReport,
     oracleAddress: string
   ): Promise<void> {
-    // TODO: Integrate Stellar SDK to build and submit transaction
-    // For now, validate that we have required fields
     if (!report.payload.marketId || !report.signature || !report.publicKey) {
       throw new Error("Invalid report: missing required fields");
     }
@@ -170,14 +187,87 @@ export class SubmissionWorker {
       throw new Error("Invalid oracle address");
     }
 
-    this.logger.debug("Submitting resolution on-chain", {
+    if (!this.stellarConfig) {
+      this.logger.warn(
+        "No Stellar config provided — resolve_market call skipped (off-chain only). " +
+          "Set STELLAR_RPC_URL, MARKET_CONTRACT_ID, SOROBAN_NETWORK_PASSPHRASE, " +
+          "and ORACLE_SECRET_KEY to enable on-chain submission.",
+        { marketId: report.payload.marketId, oracleAddress }
+      );
+      return;
+    }
+
+    const { rpcUrl, contractId, networkPassphrase, signerSecret } =
+      this.stellarConfig;
+
+    this.logger.debug("Invoking resolve_market on-chain", {
       marketId: report.payload.marketId,
       oracleAddress,
       outcome: report.payload.outcome,
+      contractId,
     });
 
-    // Placeholder: simulate successful submission
-    // In real implementation, this would call Stellar SDK methods
+    const keypair = Keypair.fromSecret(signerSecret);
+    const server = new StellarRpc.Server(rpcUrl);
+    const contract = new Contract(contractId);
+
+    const sourceAccount = await server.getAccount(keypair.publicKey());
+
+    const args: xdr.ScVal[] = [
+      nativeToScVal(report.payload.marketId, { type: "string" }),
+      nativeToScVal(report.payload.outcome === true, { type: "bool" }),
+      nativeToScVal(Buffer.from(report.signature, "base64"), { type: "bytes" }),
+      nativeToScVal(report.publicKey, { type: "address" }),
+    ];
+
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: "100",
+      networkPassphrase,
+    })
+      .addOperation(contract.call("resolve_market", ...args))
+      .setTimeout(30)
+      .build();
+
+    const preparedTx = await server.prepareTransaction(tx);
+    preparedTx.sign(keypair);
+
+    const sendResult = await server.sendTransaction(preparedTx);
+
+    if (sendResult.status === "ERROR") {
+      throw new Error(
+        `resolve_market submission failed: status=ERROR hash=${sendResult.hash}`
+      );
+    }
+
+    this.logger.info("resolve_market submitted, awaiting confirmation", {
+      marketId: report.payload.marketId,
+      hash: sendResult.hash,
+    });
+
+    // Poll until confirmed or failed
+    const MAX_POLL_ATTEMPTS = 30;
+    const POLL_INTERVAL_MS = 1_000;
+    for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      const txStatus = await server.getTransaction(sendResult.hash);
+      if (txStatus.status === StellarRpc.Api.GetTransactionStatus.SUCCESS) {
+        this.logger.info("resolve_market confirmed on-chain", {
+          marketId: report.payload.marketId,
+          hash: sendResult.hash,
+          ledger: txStatus.ledger,
+        });
+        return;
+      }
+      if (txStatus.status === StellarRpc.Api.GetTransactionStatus.FAILED) {
+        throw new Error(
+          `resolve_market transaction failed on-chain: hash=${sendResult.hash}`
+        );
+      }
+    }
+
+    throw new Error(
+      `resolve_market not confirmed after ${MAX_POLL_ATTEMPTS}s: hash=${sendResult.hash}`
+    );
   }
 
   /**


### PR DESCRIPTION
Replace the submission-worker placeholder that only validated fields with a real Soroban contract call. When STELLAR_RPC_URL, MARKET_CONTRACT_ID, SOROBAN_NETWORK_PASSPHRASE, and ORACLE_SECRET_KEY are all present, the worker calls resolve_market(marketId, outcome, signature, publicKey) and polls the RPC for transaction confirmation.

Without those env vars the worker degrades gracefully: a WARN is logged and the DB persistence step still runs so the resolution is recorded off-chain. This keeps the worker usable in dev environments without chain access.

closes #546 