### PR TITLE
feat(indexer): wire market_created parser into ingestion loop (#548)

### DIFF
--- a/apps/indexer/src/batchWriter.ts
+++ b/apps/indexer/src/batchWriter.ts
@@ -3,6 +3,7 @@ import type {
   PersistedTrade,
   PersistedResolution,
   PersistedCollateralDeposit,
+  PersistedMarketCreated,
   DuplicateEventLogger,
 } from "./idempotency.js";
 import { insertIfNew } from "./idempotency.js";
@@ -13,7 +14,8 @@ import type { PrismaClient } from "../../../src/generated/prisma/client/index.js
 export type BatchRecord =
   | { kind: "trade"; data: PersistedTrade }
   | { kind: "resolution"; data: PersistedResolution }
-  | { kind: "collateral_deposited"; data: PersistedCollateralDeposit };
+  | { kind: "collateral_deposited"; data: PersistedCollateralDeposit }
+  | { kind: "market_created"; data: PersistedMarketCreated };
 
 export interface BatchWriteError {
   record: BatchRecord;
@@ -60,7 +62,7 @@ export class PrismaBatchWriter implements BatchWriter {
         try {
           const result = await insertIfNew(
             record.data,
-            async (persisted) => this.persistRecord(tx, record, persisted),
+            async (persisted) => this.persistRecord(tx, record, persisted as PersistedTrade | PersistedResolution | PersistedCollateralDeposit | PersistedMarketCreated),
             { logger: duplicateLogger }
           );
 
@@ -96,8 +98,8 @@ export class PrismaBatchWriter implements BatchWriter {
       "$connect" | "$disconnect" | "$on" | "$transaction" | "$extends"
     >,
     record: BatchRecord,
-    persisted: PersistedTrade | PersistedResolution | PersistedCollateralDeposit
-  ): Promise<PersistedTrade | PersistedResolution | PersistedCollateralDeposit | null> {
+    persisted: PersistedTrade | PersistedResolution | PersistedCollateralDeposit | PersistedMarketCreated
+  ): Promise<PersistedTrade | PersistedResolution | PersistedCollateralDeposit | PersistedMarketCreated | null> {
     const existing = await tx.indexerProcessedEvent.findUnique({
       where: { idempotencyKey: persisted.idempotencyKey },
     });
@@ -147,7 +149,7 @@ export class PrismaBatchWriter implements BatchWriter {
           idempotencyKey: resolution.idempotencyKey,
         },
       });
-    } else {
+    } else if (record.kind === "collateral_deposited") {
       // collateral_deposited — logged for audit; position accounting handled by a worker.
       const deposit = persisted as PersistedCollateralDeposit;
       this.logger?.debug("collateral_deposited event recorded", {
@@ -156,6 +158,24 @@ export class PrismaBatchWriter implements BatchWriter {
         marketId: deposit.marketId,
         amountRaw: deposit.amountRaw.toString(),
         ledger: deposit.ledger,
+      });
+    } else {
+      const market = persisted as PersistedMarketCreated;
+      await tx.market.upsert({
+        where: { id: market.marketId },
+        create: {
+          id: market.marketId,
+          question: market.question,
+          endTime: new Date(market.endTime),
+          oracleAddress: market.oracleAddress,
+          status: market.status,
+        },
+        update: {
+          question: market.question,
+          endTime: new Date(market.endTime),
+          oracleAddress: market.oracleAddress,
+          status: market.status,
+        },
       });
     }
 

--- a/apps/indexer/src/idempotency.ts
+++ b/apps/indexer/src/idempotency.ts
@@ -4,6 +4,7 @@ import type {
   NormalizedTrade,
   NormalizedResolution,
   NormalizedCollateralDeposit,
+  NormalizedMarketCreated,
 } from "./types.js";
 
 /**
@@ -100,6 +101,11 @@ export interface PersistedCollateralDeposit extends NormalizedCollateralDeposit 
   idempotencyKey: string;
 }
 
+/** A NormalizedMarketCreated stamped with its idempotency key, ready for storage. */
+export interface PersistedMarketCreated extends NormalizedMarketCreated {
+  idempotencyKey: string;
+}
+
 export function withIdempotencyKey(trade: NormalizedTrade): PersistedTrade;
 export function withIdempotencyKey(
   resolution: NormalizedResolution
@@ -108,8 +114,11 @@ export function withIdempotencyKey(
   deposit: NormalizedCollateralDeposit
 ): PersistedCollateralDeposit;
 export function withIdempotencyKey(
-  record: NormalizedTrade | NormalizedResolution | NormalizedCollateralDeposit
-): PersistedTrade | PersistedResolution | PersistedCollateralDeposit {
+  market: NormalizedMarketCreated
+): PersistedMarketCreated;
+export function withIdempotencyKey(
+  record: NormalizedTrade | NormalizedResolution | NormalizedCollateralDeposit | NormalizedMarketCreated
+): PersistedTrade | PersistedResolution | PersistedCollateralDeposit | PersistedMarketCreated {
   const { key } = generateIdempotencyKey({
     id: record.eventId,
     contractId: record.contractId,

--- a/apps/indexer/src/ingestion.ts
+++ b/apps/indexer/src/ingestion.ts
@@ -6,11 +6,13 @@ import type { EventFetcher } from "./eventFetcher.js";
 import { parseTradeEvents } from "./tradeParser.js";
 import { parseResolutionEvents } from "./resolutionParser.js";
 import { parseCollateralDepositedEvents } from "./collateralDepositedParser.js";
+import { parseMarketCreatedEvents } from "./marketCreatedParser.js";
 import { withIdempotencyKey } from "./idempotency.js";
 import {
   TradeParseError,
   ResolutionParseError,
   CollateralDepositedParseError,
+  MarketCreatedParseError,
 } from "./types.js";
 
 export interface IngestionLoop {
@@ -200,6 +202,7 @@ export class PollingIngestionLoop implements IngestionLoop {
       parseResolutionEvents(events);
     const { deposits, errors: depositErrors } =
       parseCollateralDepositedEvents(events);
+    const { markets, errors: marketErrors } = parseMarketCreatedEvents(events);
 
     for (const error of tradeErrors) {
       this.logger.warn("Trade parse error — skipping event", {
@@ -225,7 +228,21 @@ export class PollingIngestionLoop implements IngestionLoop {
       });
     }
 
+    for (const error of marketErrors) {
+      this.logger.warn("Market created parse error — skipping event", {
+        eventId: error.eventId,
+        error: error.message,
+        parseErrorType: MarketCreatedParseError.name,
+      });
+    }
+
     const records: BatchRecord[] = [
+      ...markets.map(
+        (market): BatchRecord => ({
+          kind: "market_created",
+          data: withIdempotencyKey(market),
+        })
+      ),
       ...trades.map(
         (trade): BatchRecord => ({
           kind: "trade",
@@ -252,6 +269,7 @@ export class PollingIngestionLoop implements IngestionLoop {
       startLedger,
       endLedger,
       eventsFetched: events.length,
+      marketsParsed: markets.length,
       tradesParsed: trades.length,
       resolutionsParsed: resolutions.length,
       collateralDepositsParsed: deposits.length,

--- a/apps/indexer/src/marketCreatedParser.ts
+++ b/apps/indexer/src/marketCreatedParser.ts
@@ -1,0 +1,119 @@
+import { xdr, scValToNative } from "@stellar/stellar-sdk";
+import type { RawChainEvent } from "./types.js";
+import { MarketCreatedParseError } from "./types.js";
+import type { NormalizedMarketCreated } from "./types.js";
+import { parseMarketCreatedEvent } from "../market-created-parser.js";
+
+const MARKET_CREATED_TOPIC = "market_created";
+
+function decodeScVal(xdrBase64: string): unknown {
+  return scValToNative(xdr.ScVal.fromXDR(xdrBase64, "base64"));
+}
+
+function isMarketCreatedEvent(topicsXdr: string[]): boolean {
+  if (topicsXdr.length === 0) return false;
+  try {
+    return decodeScVal(topicsXdr[0]) === MARKET_CREATED_TOPIC;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeEndTime(raw: unknown): number | string | undefined {
+  if (typeof raw === "bigint") return Number(raw);
+  if (typeof raw === "number") return raw;
+  if (typeof raw === "string") return raw;
+  return undefined;
+}
+
+/**
+ * Parse a single RawChainEvent into a NormalizedMarketCreated.
+ *
+ * Expected on-chain value: ScvMap {
+ *   market_id: str, question: str, end_time: u64,
+ *   oracle_address: str, status: str
+ * }
+ *
+ * @throws MarketCreatedParseError on wrong topic or malformed payload.
+ */
+export function parseMarketCreatedChainEvent(
+  event: RawChainEvent
+): NormalizedMarketCreated {
+  if (!isMarketCreatedEvent(event.topicsXdr)) {
+    throw new MarketCreatedParseError(
+      `Event topic is not "${MARKET_CREATED_TOPIC}"`,
+      event.id
+    );
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = decodeScVal(event.valueXdr);
+  } catch (err) {
+    throw new MarketCreatedParseError(
+      "Failed to decode event value XDR",
+      event.id,
+      err
+    );
+  }
+
+  if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) {
+    throw new MarketCreatedParseError("Event value is not an ScvMap", event.id);
+  }
+
+  const map = decoded as Record<string, unknown>;
+
+  const rawEvent = {
+    id: typeof map.market_id === "string" ? map.market_id : String(map.market_id ?? ""),
+    question: typeof map.question === "string" ? map.question : undefined,
+    endTime: normalizeEndTime(map.end_time),
+    oracleAddress: typeof map.oracle_address === "string" ? map.oracle_address : undefined,
+    status: typeof map.status === "string" ? map.status : undefined,
+  };
+
+  const result = parseMarketCreatedEvent(rawEvent);
+  if (!result.success || !result.data) {
+    throw new MarketCreatedParseError(
+      result.error ?? "Unknown parse error",
+      event.id
+    );
+  }
+
+  return {
+    eventId: event.id,
+    ledger: event.ledger,
+    ledgerClosedAt: event.ledgerClosedAt,
+    contractId: event.contractId,
+    marketId: result.data.id,
+    question: result.data.question,
+    endTime: result.data.endTime,
+    oracleAddress: result.data.oracleAddress,
+    status: result.data.status,
+  };
+}
+
+/**
+ * Parse a batch of raw events, skipping non-market-created events silently.
+ */
+export function parseMarketCreatedEvents(events: RawChainEvent[]): {
+  markets: NormalizedMarketCreated[];
+  errors: MarketCreatedParseError[];
+} {
+  const markets: NormalizedMarketCreated[] = [];
+  const errors: MarketCreatedParseError[] = [];
+
+  for (const event of events) {
+    if (!isMarketCreatedEvent(event.topicsXdr)) continue;
+    try {
+      markets.push(parseMarketCreatedChainEvent(event));
+    } catch (err) {
+      errors.push(
+        err instanceof MarketCreatedParseError
+          ? err
+          : new MarketCreatedParseError(String(err), event.id, err)
+      );
+    }
+  }
+
+  return { markets, errors };
+}

--- a/apps/indexer/src/types.ts
+++ b/apps/indexer/src/types.ts
@@ -97,6 +97,40 @@ export class CollateralDepositedParseError extends Error {
   }
 }
 
+// ─── Market created types ────────────────────────────────────────────────────
+
+export type MarketCreatedStatus = "ACTIVE" | "RESOLVED" | "CANCELLED";
+
+/**
+ * Normalized record produced from a market_created chain event.
+ * The marketId is the on-chain identifier and is expected to match Market.id.
+ */
+export interface NormalizedMarketCreated {
+  eventId: string;
+  ledger: number;
+  ledgerClosedAt: string;
+  contractId: string;
+  /** On-chain market identifier — used as Market.id in Postgres. */
+  marketId: string;
+  question: string;
+  /** ISO-8601 timestamp when the market closes. */
+  endTime: string;
+  /** Stellar oracle address (56-char base32). */
+  oracleAddress: string;
+  status: MarketCreatedStatus;
+}
+
+export class MarketCreatedParseError extends Error {
+  constructor(
+    message: string,
+    public readonly eventId: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "MarketCreatedParseError";
+  }
+}
+
 // ─── Fetcher types ───────────────────────────────────────────────────────────
 
 export interface LedgerWindow {


### PR DESCRIPTION
The market-created-parser existed as a standalone utility but was never called by the ingestion pipeline. This wires it end-to-end:

- Add NormalizedMarketCreated + MarketCreatedParseError to types.ts
- Create marketCreatedParser.ts that decodes XDR chain events and delegates field validation to the existing parseMarketCreatedEvent
- Extend idempotency.ts with PersistedMarketCreated + withIdempotencyKey overload so the event gets a deterministic SHA-256 idempotency key
- Add market_created kind to BatchRecord; batchWriter upserts the Market row by on-chain marketId so chain-originated markets land in Postgres
- ingestion.ts now calls parseMarketCreatedEvents on every tick and maps results into the batch; markets are written before trades so FK deps are satisfied in the same transaction

closes #548