### PR TITLE
feat(indexer): persist collateral_deposited events to Postgres (#549)

### DIFF
--- a/apps/indexer/src/batchWriter.ts
+++ b/apps/indexer/src/batchWriter.ts
@@ -148,14 +148,17 @@ export class PrismaBatchWriter implements BatchWriter {
         },
       });
     } else {
-      // collateral_deposited — logged for audit; position accounting handled by a worker.
       const deposit = persisted as PersistedCollateralDeposit;
-      this.logger?.debug("collateral_deposited event recorded", {
-        eventId: deposit.eventId,
-        account: deposit.account,
-        marketId: deposit.marketId,
-        amountRaw: deposit.amountRaw.toString(),
-        ledger: deposit.ledger,
+      await (tx as any).collateralDeposit.create({
+        data: {
+          idempotencyKey: deposit.idempotencyKey,
+          eventId: deposit.eventId,
+          ledger: deposit.ledger,
+          contractId: deposit.contractId,
+          account: deposit.account,
+          marketId: deposit.marketId,
+          amountRaw: deposit.amountRaw.toString(),
+        },
       });
     }
 

--- a/prisma/migrations/20260626000001_add_collateral_deposits/migration.sql
+++ b/prisma/migrations/20260626000001_add_collateral_deposits/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "collateral_deposits" (
+    "id" TEXT NOT NULL,
+    "idempotency_key" VARCHAR(64) NOT NULL,
+    "event_id" TEXT NOT NULL,
+    "ledger" INTEGER NOT NULL,
+    "contract_id" TEXT NOT NULL,
+    "account" VARCHAR(56) NOT NULL,
+    "market_id" TEXT NOT NULL,
+    "amount_raw" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "collateral_deposits_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "collateral_deposits_idempotency_key_key" ON "collateral_deposits"("idempotency_key");
+
+-- CreateIndex
+CREATE INDEX "collateral_deposits_account_idx" ON "collateral_deposits"("account");
+
+-- CreateIndex
+CREATE INDEX "collateral_deposits_market_id_idx" ON "collateral_deposits"("market_id");
+
+-- CreateIndex
+CREATE INDEX "collateral_deposits_account_market_id_idx" ON "collateral_deposits"("account", "market_id");
+
+-- CreateIndex
+CREATE INDEX "collateral_deposits_ledger_idx" ON "collateral_deposits"("ledger");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -286,3 +286,24 @@ model OracleSourceAlias {
   @@index([canonicalSource])
   @@map("oracle_source_aliases")
 }
+
+/// Durable audit log of on-chain collateral_deposited events.
+/// Written atomically with IndexerProcessedEvent; amountRaw stored as text
+/// to preserve i128 precision. Position reconciliation reads this table.
+model CollateralDeposit {
+  id             String   @id @default(uuid())
+  idempotencyKey String   @unique @map("idempotency_key") @db.VarChar(64)
+  eventId        String   @map("event_id")
+  ledger         Int
+  contractId     String   @map("contract_id")
+  account        String   @db.VarChar(56)
+  marketId       String   @map("market_id")
+  amountRaw      String   @map("amount_raw")
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  @@index([account])
+  @@index([marketId])
+  @@index([account, marketId])
+  @@index([ledger])
+  @@map("collateral_deposits")
+}


### PR DESCRIPTION
batchWriter debug-logged deposits without durable storage. This adds an explicit audit table so every on-chain deposit survives restarts and replay is safe:

- Add CollateralDeposit model to schema.prisma with unique idempotencyKey, indexes on (account), (market_id), (account, market_id), and (ledger)
- Add migration 20260626000001_add_collateral_deposits
- batchWriter now creates a collateral_deposits row inside the same Prisma transaction as IndexerProcessedEvent, preserving atomicity and the replay-safe guarantee already in place for trades and resolutions
- amountRaw stored as TEXT to preserve full i128 precision

closes #549 