### PR TITLE
feat(workers): migrate oracle and settlement consumers to BullMQ (#551)

### DIFF
--- a/apps/workers/src/oracle/main.ts
+++ b/apps/workers/src/oracle/main.ts
@@ -1,8 +1,8 @@
 /**
- * Oracle Submission Worker Entrypoint
+ * Oracle Submission Worker Entrypoint — BullMQ (ADR 001)
  *
- * Bootstraps the oracle submission worker that consumes from the Redis queue
- * and submits signed resolutions on-chain.
+ * Replaces the RedisSubmissionQueue polling loop with a BullMQ Worker.
+ * Retry/backoff/DLQ are now handled by BullMQ via DEFAULT_JOB_OPTIONS.
  *
  * @module apps/workers/src/oracle/main
  */
@@ -15,39 +15,124 @@ import {
 } from "../../../../src/services/prisma.js";
 import { redis } from "../../../../src/services/redis.js";
 import { loadOracleWorkerConfig } from "../../../../packages/shared/src/config.js";
-import { RedisSubmissionQueue } from "./redis-submission-queue.js";
-import { SubmissionWorker } from "./submission-worker.js";
+import {
+  BullMQSubmissionQueue,
+  createOracleSubmissionWorker,
+} from "./bullmq-submission-queue.js";
+import type { SubmissionQueueItem } from "../../../oracle/submission-queue.js";
+import {
+  verifyResolutionReport,
+  type SignedResolutionReport,
+} from "../../../oracle/signature-helper.js";
+import {
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc as StellarRpc,
+  xdr,
+} from "@stellar/stellar-sdk";
+import { createHash } from "crypto";
 import type { ShutdownHandler, ShutdownSignal } from "../finalization/types.js";
+
+interface OracleStellarConfig {
+  rpcUrl: string;
+  contractId: string;
+  networkPassphrase: string;
+  signerSecret: string;
+}
+
+async function submitOnChain(
+  report: SignedResolutionReport,
+  oracleAddress: string,
+  stellar: OracleStellarConfig,
+  logger: ReturnType<typeof createLogger>
+): Promise<void> {
+  const { rpcUrl, contractId, networkPassphrase, signerSecret } = stellar;
+
+  logger.debug("Invoking resolve_market on-chain", {
+    marketId: report.payload.marketId,
+    oracleAddress,
+    outcome: report.payload.outcome,
+    contractId,
+  });
+
+  const keypair = Keypair.fromSecret(signerSecret);
+  const server = new StellarRpc.Server(rpcUrl);
+  const contract = new Contract(contractId);
+  const sourceAccount = await server.getAccount(keypair.publicKey());
+
+  const args: xdr.ScVal[] = [
+    nativeToScVal(report.payload.marketId, { type: "string" }),
+    nativeToScVal(report.payload.outcome === true, { type: "bool" }),
+    nativeToScVal(Buffer.from(report.signature, "base64"), { type: "bytes" }),
+    nativeToScVal(report.publicKey, { type: "address" }),
+  ];
+
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: "100",
+    networkPassphrase,
+  })
+    .addOperation(contract.call("resolve_market", ...args))
+    .setTimeout(30)
+    .build();
+
+  const preparedTx = await server.prepareTransaction(tx);
+  preparedTx.sign(keypair);
+  const sendResult = await server.sendTransaction(preparedTx);
+
+  if (sendResult.status === "ERROR") {
+    throw new Error(
+      `resolve_market submission failed: status=ERROR hash=${sendResult.hash}`
+    );
+  }
+
+  logger.info("resolve_market submitted, awaiting confirmation", {
+    marketId: report.payload.marketId,
+    hash: sendResult.hash,
+  });
+
+  const MAX_POLL = 30;
+  for (let i = 0; i < MAX_POLL; i++) {
+    await new Promise((r) => setTimeout(r, 1_000));
+    const txStatus = await server.getTransaction(sendResult.hash);
+    if (txStatus.status === StellarRpc.Api.GetTransactionStatus.SUCCESS) {
+      logger.info("resolve_market confirmed on-chain", {
+        marketId: report.payload.marketId,
+        hash: sendResult.hash,
+        ledger: txStatus.ledger,
+      });
+      return;
+    }
+    if (txStatus.status === StellarRpc.Api.GetTransactionStatus.FAILED) {
+      throw new Error(
+        `resolve_market transaction failed on-chain: hash=${sendResult.hash}`
+      );
+    }
+  }
+
+  throw new Error(
+    `resolve_market not confirmed after ${MAX_POLL}s: hash=${sendResult.hash}`
+  );
+}
 
 async function bootstrap(): Promise<void> {
   const config = loadOracleWorkerConfig();
   const logger = createLogger(config.logLevel);
   const prisma = getPrismaClient();
 
-  logger.info("Oracle submission worker starting", {
-    pollIntervalMs: config.submissionPollIntervalMs,
-    maxRetries: config.submissionMaxRetries,
-    visibilityTimeoutMs: config.submissionVisibilityTimeoutMs,
-  });
-
-  const queue = new RedisSubmissionQueue({
-    redisClient: redis,
-    visibilityTimeoutMs: config.submissionVisibilityTimeoutMs,
-    logger,
-  });
-
-  const rpcUrl = process.env.STELLAR_RPC_URL;
-  const contractId =
-    process.env.MARKET_CONTRACT_ID ?? process.env.INDEXER_CONTRACT_ID;
-  const networkPassphrase = process.env.SOROBAN_NETWORK_PASSPHRASE;
-  const signerSecret = process.env.ORACLE_SECRET_KEY;
-
-  const stellar =
-    rpcUrl && contractId && networkPassphrase && signerSecret
+  const stellarConfig: OracleStellarConfig | undefined = (() => {
+    const rpcUrl = process.env.STELLAR_RPC_URL;
+    const contractId =
+      process.env.MARKET_CONTRACT_ID ?? process.env.INDEXER_CONTRACT_ID;
+    const networkPassphrase = process.env.SOROBAN_NETWORK_PASSPHRASE;
+    const signerSecret = process.env.ORACLE_SECRET_KEY;
+    return rpcUrl && contractId && networkPassphrase && signerSecret
       ? { rpcUrl, contractId, networkPassphrase, signerSecret }
       : undefined;
+  })();
 
-  if (!stellar) {
+  if (!stellarConfig) {
     logger.warn(
       "Oracle Stellar config incomplete — resolve_market calls disabled. " +
         "Set STELLAR_RPC_URL, MARKET_CONTRACT_ID, SOROBAN_NETWORK_PASSPHRASE, " +
@@ -56,49 +141,80 @@ async function bootstrap(): Promise<void> {
     );
   }
 
-  const worker = new SubmissionWorker(queue, prisma, {
-    submissionMaxRetries: config.submissionMaxRetries,
-    consumerName: `oracle-worker-${Date.now()}`,
-    logger,
-    stellar,
+  logger.info("Oracle submission worker starting (BullMQ)", {
+    component: "oracle-worker",
   });
 
-  // Initialize the queue (idempotent)
-  await queue.initialize();
+  const bullWorker = createOracleSubmissionWorker(
+    async (item: SubmissionQueueItem) => {
+      const { request, result } = item;
 
-  // Run immediately, then poll at configured interval
-  async function runWorker(): Promise<void> {
-    try {
-      const submission = await queue.dequeue(
-        worker["consumerName"],
-        config.submissionPollIntervalMs
-      );
+      const report: SignedResolutionReport = {
+        payload: {
+          marketId: request.marketId,
+          outcome: result.outcome,
+          timestamp: new Date().toISOString(),
+        },
+        signature: result.signature || "",
+        publicKey: result.publicKey || "",
+      };
 
-      if (submission) {
-        try {
-          await worker.processSubmission(submission);
-        } catch (error) {
-          // Errors are logged by processSubmission
-          // Continue polling for next item
-        }
+      if (!verifyResolutionReport(report)) {
+        throw new Error(
+          `Signature verification failed for market ${request.marketId}`
+        );
       }
-    } catch (error) {
-      logger.error("Unexpected error in worker loop", {
-        error: error instanceof Error ? error.message : String(error),
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
 
-  // Start continuous polling
-  await runWorker();
-  const timer = setInterval(
-    () => void runWorker(),
-    config.submissionPollIntervalMs
+      if (stellarConfig) {
+        await submitOnChain(report, request.oracleAddress, stellarConfig, logger);
+      } else {
+        logger.warn(
+          "No Stellar config — resolve_market call skipped (off-chain only)",
+          { marketId: request.marketId, oracleAddress: request.oracleAddress }
+        );
+      }
+
+      const payloadHash = createHash("sha256")
+        .update(JSON.stringify(report.payload))
+        .digest("hex");
+
+      await prisma.oracleReport.create({
+        data: {
+          payloadHash,
+          source: request.oracleAddress,
+          confidence: 1.0,
+          marketId: request.marketId,
+          candidateResolution: result.outcome,
+          createdAt: new Date(report.payload.timestamp),
+        },
+      });
+
+      await prisma.resolutionCandidate.upsert({
+        where: {
+          idempotencyKey: `${request.marketId}:${request.oracleAddress}`,
+        },
+        create: {
+          marketId: request.marketId,
+          proposedOutcome: result.outcome,
+          source: request.oracleAddress,
+          operatorAddress: request.oracleAddress,
+          idempotencyKey: `${request.marketId}:${request.oracleAddress}`,
+        },
+        update: {
+          proposedOutcome: result.outcome,
+        },
+      });
+
+      logger.info("Oracle submission processed", {
+        marketId: request.marketId,
+        component: "oracle-worker",
+      });
+    },
+    logger
   );
 
   const VALID_SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
-  const SHUTDOWN_TIMEOUT_MS = 30_000; // 30 seconds
+  const SHUTDOWN_TIMEOUT_MS = 30_000;
 
   let isShuttingDown = false;
   const shutdown: ShutdownHandler = async (signal: ShutdownSignal) => {
@@ -127,10 +243,6 @@ async function bootstrap(): Promise<void> {
       status: "initiated",
     });
 
-    // Stop polling for new jobs
-    clearInterval(timer);
-
-    // Set hard timeout to force exit if shutdown hangs
     const timeoutHandle = setTimeout(() => {
       logger.error("Shutdown timeout exceeded, forcing exit", {
         signal,
@@ -141,7 +253,7 @@ async function bootstrap(): Promise<void> {
     }, SHUTDOWN_TIMEOUT_MS);
 
     try {
-      // Clean up resources
+      await bullWorker.close();
       await disconnectPrisma();
       await redis.disconnect();
       clearTimeout(timeoutHandle);
@@ -168,6 +280,11 @@ async function bootstrap(): Promise<void> {
 
   process.on("SIGINT", () => void shutdown("SIGINT"));
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
+
+  // Keep process alive; BullMQ worker is event-driven (no polling loop needed)
+  logger.info("Oracle worker ready — listening for BullMQ jobs", {
+    component: "oracle-worker",
+  });
 }
 
 void bootstrap().catch((error) => {

--- a/apps/workers/src/settlement/consumer.ts
+++ b/apps/workers/src/settlement/consumer.ts
@@ -1,4 +1,16 @@
+/**
+ * Settlement Worker Entrypoint — BullMQ (ADR 001)
+ *
+ * Replaces the raw Redis Streams polling loop with a BullMQ Worker that
+ * provides unified retry/backoff/DLQ via DEFAULT_JOB_OPTIONS.
+ *
+ * The SettlementWorker.process() handler is unchanged — BullMQ job data is
+ * mapped to the existing QueueJob shape so all unit tests continue to pass.
+ *
+ * @module apps/workers/src/settlement/consumer
+ */
 import "dotenv/config";
+import { Worker, type Job } from "bullmq";
 import { redis } from "../../../../src/services/redis.js";
 import { createLogger } from "../../../indexer/src/logger.js";
 import { disconnectPrisma } from "../../../../src/services/prisma.js";
@@ -7,124 +19,28 @@ import {
   type SettlementStellarConfig,
 } from "./settlement-worker.js";
 import type { QueueJob } from "../consumers/queue-consumer.js";
+import { redisConnectionFromEnv } from "../shared/queue-config.js";
 
-const STREAM_KEY = (): string => {
-  const queueName = process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades";
-  const keyPrefix = process.env.REDIS_KEY_PREFIX ?? "vatix:";
-  return `${keyPrefix}${queueName}`;
+const QUEUE_NAME = (): string => {
+  const name = process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades";
+  const prefix = process.env.REDIS_KEY_PREFIX ?? "vatix:";
+  return `${prefix}${name}`;
 };
 
-const CONSUMER_GROUP = "settlement-worker";
-const POLL_INTERVAL_MS = 5_000;
 const MAX_ATTEMPTS = 3;
 const PROCESSING_TIMEOUT_MS = 30_000;
 const IDEMPOTENCY_TTL_SECONDS = 86_400;
-
-function parseStreamFields(fields: string[]): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (let i = 0; i < fields.length - 1; i += 2) {
-    result[fields[i]] = fields[i + 1];
-  }
-  return result;
-}
-
-async function initConsumerGroup(
-  streamKey: string,
-  logger: ReturnType<typeof createLogger>
-): Promise<void> {
-  try {
-    await redis.xgroup("CREATE", streamKey, CONSUMER_GROUP, "$", {
-      MKSTREAM: true,
-    });
-    logger.info("Settlement consumer group initialized", {
-      stream: streamKey,
-      group: CONSUMER_GROUP,
-    });
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    if (msg.includes("BUSYGROUP")) {
-      logger.info("Settlement consumer group already exists", {
-        stream: streamKey,
-        group: CONSUMER_GROUP,
-      });
-    } else {
-      throw error;
-    }
-  }
-}
-
-async function pollMessages(
-  streamKey: string,
-  consumerName: string,
-  worker: SettlementWorker,
-  attemptTracker: Map<string, number>,
-  logger: ReturnType<typeof createLogger>
-): Promise<void> {
-  let messages: Array<[string, Array<[string, string[]]>]> | null = null;
-
-  try {
-    messages = await redis.xreadgroup(
-      CONSUMER_GROUP,
-      consumerName,
-      streamKey,
-      ">",
-      { COUNT: 10, BLOCK: 1000 }
-    );
-  } catch (error) {
-    logger.error("Settlement consumer read error", {
-      event: "settlement.consumer_error",
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return;
-  }
-
-  if (!messages || messages.length === 0) {
-    return;
-  }
-
-  const [, msgList] = messages[0];
-
-  for (const [streamId, rawFields] of msgList) {
-    const attempts = (attemptTracker.get(streamId) ?? 0) + 1;
-    attemptTracker.set(streamId, attempts);
-
-    const payload = parseStreamFields(rawFields);
-    const job: QueueJob = {
-      id: streamId,
-      payload,
-      attempts,
-    };
-
-    try {
-      await worker.process(job);
-      await redis.xack(streamKey, CONSUMER_GROUP, streamId);
-      attemptTracker.delete(streamId);
-    } catch {
-      // Leave unacknowledged so Redis redelivers it on next poll
-      logger.warn("Settlement job will be retried", {
-        streamId,
-        attempts,
-        maxAttempts: MAX_ATTEMPTS,
-      });
-    }
-  }
-}
 
 async function bootstrap(): Promise<void> {
   const logLevel = (process.env.LOG_LEVEL ?? "info") as Parameters<
     typeof createLogger
   >[0];
   const logger = createLogger(logLevel);
-  const streamKey = STREAM_KEY();
-  const consumerName = `settlement-consumer-${process.pid}`;
-  const attemptTracker = new Map<string, number>();
+  const queueName = QUEUE_NAME();
 
-  logger.info("Settlement worker started", {
-    stream: streamKey,
-    group: CONSUMER_GROUP,
+  logger.info("Settlement worker started (BullMQ)", {
+    queue: queueName,
   });
-
-  await initConsumerGroup(streamKey, logger);
 
   const rpcUrl = process.env.STELLAR_RPC_URL;
   const contractId = process.env.SETTLEMENT_CONTRACT_ID;
@@ -145,43 +61,58 @@ async function bootstrap(): Promise<void> {
     );
   }
 
-  const worker = new SettlementWorker(redis, logger, {
+  const settlementWorker = new SettlementWorker(redis, logger, {
     maxAttempts: MAX_ATTEMPTS,
     processingTimeoutMs: PROCESSING_TIMEOUT_MS,
     idempotencyTtlSeconds: IDEMPOTENCY_TTL_SECONDS,
     stellar,
   });
 
-  await pollMessages(streamKey, consumerName, worker, attemptTracker, logger);
-
-  const timer = setInterval(
-    () =>
-      void pollMessages(
-        streamKey,
-        consumerName,
-        worker,
-        attemptTracker,
-        logger
-      ),
-    POLL_INTERVAL_MS
+  const worker = new Worker<Record<string, unknown>>(
+    queueName,
+    async (job: Job<Record<string, unknown>>) => {
+      const queueJob: QueueJob = {
+        id: job.id ?? job.name,
+        payload: job.data,
+        attempts: job.attemptsMade + 1,
+      };
+      await settlementWorker.process(queueJob);
+    },
+    {
+      connection: redisConnectionFromEnv(),
+      concurrency: 1,
+    }
   );
 
-  const VALID_SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+  worker.on("completed", (job) => {
+    logger.info("Settlement job completed", {
+      jobId: job.id,
+      component: "settlement-worker",
+    });
+  });
 
+  worker.on("failed", (job, err) => {
+    logger.error("Settlement job failed", {
+      jobId: job?.id,
+      attempts: job?.attemptsMade,
+      error: err.message,
+      component: "settlement-worker",
+    });
+  });
+
+  const VALID_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
   let isShuttingDown = false;
+
   const shutdown = async (signal: string): Promise<void> => {
     if (
       typeof signal !== "string" ||
-      signal.trim() === "" ||
-      !VALID_SHUTDOWN_SIGNALS.includes(
-        signal as (typeof VALID_SHUTDOWN_SIGNALS)[number]
-      )
+      !VALID_SIGNALS.includes(signal as (typeof VALID_SIGNALS)[number])
     ) {
       logger.warn("Graceful shutdown called with invalid signal", {
         signal,
         statusCode: 400,
         component: "settlement-worker",
-        validSignals: [...VALID_SHUTDOWN_SIGNALS],
+        validSignals: [...VALID_SIGNALS],
       });
       return;
     }
@@ -195,9 +126,8 @@ async function bootstrap(): Promise<void> {
       status: "initiated",
     });
 
-    clearInterval(timer);
-
     try {
+      await worker.close();
       await disconnectPrisma();
       await redis.disconnect();
       logger.info("Settlement worker shutdown complete", {
@@ -219,8 +149,9 @@ async function bootstrap(): Promise<void> {
     }
   };
 
-  process.on("SIGINT", () => void shutdown("SIGINT"));
-  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  for (const sig of VALID_SIGNALS) {
+    process.on(sig, () => void shutdown(sig));
+  }
 }
 
 void bootstrap().catch((error) => {


### PR DESCRIPTION
ADR 001 selected BullMQ over raw Redis Streams but both consumer entrypoints still used the legacy implementation. This aligns them:

settlement/consumer.ts:
- Replace Redis Streams xreadgroup polling loop with a BullMQ Worker
- SettlementWorker.process() is unchanged; BullMQ Job mapped to existing QueueJob shape (id, payload, attempts) for full unit-test compatibility
- Retry/backoff/DLQ now come from DEFAULT_JOB_OPTIONS (3 attempts, exponential 1s backoff, failed jobs retained)
- Stellar config loaded at startup; graceful shutdown via worker.close()

oracle/main.ts:
- Replace RedisSubmissionQueue + polling timer with createOracleSubmissionWorker
- Submission logic (signature verify, resolve_market on-chain, OracleReport + ResolutionCandidate upsert) inlined in the BullMQ handler so the handler can throw cleanly on any failure and let BullMQ drive retry
- RedisSubmissionQueue and SubmissionWorker are no longer imported
- SIGINT/SIGTERM/SIGHUP shutdown now drains the BullMQ worker cleanly

closes #551 