### PR TITLE
feat: add GET /v1/wallets/:wallet/positions/:marketId sub-route (#556)

### DIFF
--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -279,6 +279,53 @@ export const openApiSpec = {
         },
       },
     },
+    "/v1/wallets/{wallet}/positions/{marketId}": {
+      get: {
+        summary: "Single market position",
+        description:
+          "Retrieve the position exposure for a wallet in a specific market. Returns 404 if no position exists.",
+        tags: ["Positions"],
+        parameters: [
+          {
+            name: "wallet",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+            description:
+              "Stellar public key (StrKey): starts with G and is 56 chars using [A-Z2-7]",
+          },
+          {
+            name: "marketId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+            description: "Market ID to fetch position for",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Single market position",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    wallet: { type: "string" },
+                    marketId: { type: "string" },
+                    position: {
+                      $ref: "#/components/schemas/WalletExposureRow",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "404": {
+            description: "No position found for the given wallet and market",
+          },
+        },
+      },
+    },
     "/v1/admin/markets": {
       get: {
         summary: "Admin market listing",

--- a/src/api/routes/positions.ts
+++ b/src/api/routes/positions.ts
@@ -4,7 +4,7 @@ import {
   STELLAR_PUBLIC_KEY_REGEX,
   validateUserAddress,
 } from "../../matching/validation.js";
-import { ValidationError } from "../middleware/errors.js";
+import { NotFoundError, ValidationError } from "../middleware/errors.js";
 import { heavyReadLimiter } from "../middleware/rateLimiter.js";
 import { success } from "../middleware/responses.js";
 
@@ -315,6 +315,85 @@ export default async function positionsRouter(server: FastifyInstance) {
       }
 
       success(reply, response);
+    }
+  );
+
+  server.get<{
+    Params: { wallet: string; marketId: string };
+  }>(
+    "/wallets/:wallet/positions/:marketId",
+    {
+      onRequest: [heavyReadLimiter],
+      schema: {
+        params: {
+          type: "object",
+          required: ["wallet", "marketId"],
+          properties: {
+            wallet: {
+              type: "string",
+              pattern: STELLAR_PUBLIC_KEY_REGEX.source,
+              description:
+                "Stellar public key (StrKey): starts with G and is 56 chars using [A-Z2-7]",
+            },
+            marketId: {
+              type: "string",
+              description: "Market ID to fetch position for",
+            },
+          },
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{
+        Params: { wallet: string; marketId: string };
+      }>,
+      reply: FastifyReply
+    ) => {
+      const { wallet, marketId } = request.params;
+      const prisma = getPrismaClient();
+
+      const addressError = validateUserAddress(wallet);
+      if (addressError) {
+        throw new ValidationError(addressError);
+      }
+
+      const position = await prisma.userPosition.findFirst({
+        where: { userAddress: wallet, marketId },
+        include: {
+          market: {
+            select: {
+              id: true,
+              question: true,
+              outcome: true,
+              status: true,
+            },
+          },
+        },
+      });
+
+      if (!position) {
+        throw new NotFoundError(
+          `No position found for wallet in market ${marketId}`
+        );
+      }
+
+      const market = position.market as any;
+      const lockedCollateral = position.lockedCollateral.toString();
+
+      const exposure: WalletExposureRow = {
+        marketId: market.id,
+        marketQuestion: market.question,
+        yesShares: position.yesShares,
+        noShares: position.noShares,
+        netExposure: position.yesShares - position.noShares,
+        lockedCollateral,
+        isSettled: position.isSettled,
+        updatedAt: position.updatedAt,
+      };
+
+      request.log.info({ wallet, marketId }, "wallet market position fetched");
+
+      success(reply, { wallet, marketId, position: exposure });
     }
   );
 }


### PR DESCRIPTION
Consolidates position routes under the wallet path by adding a per-market lookup endpoint. Returns the single WalletExposureRow for a wallet in a given market, or 404 if no position exists. Spec updated with the new path and response schema.

closes #556 