### PR TITLE
feat: Redis readiness check, settlement queue test, /v1 guard, auth headers in OpenAPI (#552 #553 #554 #555)

### DIFF
--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -146,8 +146,27 @@ export const openApiSpec = {
     "/v1/orders": {
       post: {
         summary: "Create an order",
-        description: "Submit a new order to the prediction market",
+        description:
+          "Submit a new order to the prediction market. Requires Stellar wallet ownership proof via Ed25519 signature headers.",
         tags: ["Orders"],
+        parameters: [
+          {
+            name: "x-signature",
+            in: "header",
+            required: true,
+            description:
+              "Base64-encoded Ed25519 signature of the canonical request body JSON (keys sorted alphabetically) combined with x-timestamp, signed by the private key of userAddress.",
+            schema: { type: "string" },
+          },
+          {
+            name: "x-timestamp",
+            in: "header",
+            required: true,
+            description:
+              "Unix timestamp in milliseconds (string). Must be within ±5 minutes of server time to prevent replay attacks.",
+            schema: { type: "string" },
+          },
+        ],
         requestBody: {
           required: true,
           content: {
@@ -196,7 +215,11 @@ export const openApiSpec = {
             description: "Order created",
           },
           "400": {
-            description: "Invalid request",
+            description: "Invalid request body or market not active",
+          },
+          "401": {
+            description:
+              "Missing, expired, or invalid x-signature / x-timestamp headers",
           },
         },
       },

--- a/src/api/routes/ready.test.ts
+++ b/src/api/routes/ready.test.ts
@@ -16,6 +16,7 @@ function buildServer(deps: ReadyDeps) {
 
 const freshDeps: ReadyDeps = {
   checkDatabase: async () => {},
+  checkRedis: async () => {},
   getLastIndexedAt: async () => NOW - 1000, // 1 second old — fresh
   now: () => NOW,
 };
@@ -110,6 +111,9 @@ describe("GET /v1/ready", () => {
     const server = buildServer({
       checkDatabase: async () => {
         throw new Error("db down");
+      },
+      checkRedis: async () => {
+        throw new Error("redis down");
       },
       getLastIndexedAt: async () => {
         throw new Error("index down");

--- a/src/api/routes/ready.ts
+++ b/src/api/routes/ready.ts
@@ -42,6 +42,7 @@ export interface ReadyResponse {
   ready: boolean;
   dependencies: {
     database: DependencyResult;
+    redis: DependencyResult;
     indexFreshness: DependencyResult;
   };
 }
@@ -51,8 +52,10 @@ export interface ReadyResponse {
  * in tests without touching real infrastructure.
  */
 export interface ReadyDeps {
-  /** Returns true if the database is reachable. Throws on failure. */
+  /** Throws if the database is unreachable. */
   checkDatabase(): Promise<void>;
+  /** Throws if the Redis instance is unreachable. */
+  checkRedis(): Promise<void>;
   /**
    * Returns the timestamp (ms since epoch) of the most recent indexed
    * event, or null if no events have been indexed yet.
@@ -71,17 +74,22 @@ export function readyRoute(deps: ReadyDeps) {
     fastify.get("/ready", async (_request, reply) => {
       const now = deps.now ? deps.now() : Date.now();
 
-      const [dbResult, indexResult] = await Promise.all([
+      const [dbResult, redisResult, indexResult] = await Promise.all([
         checkDb(deps),
+        checkRedis(deps),
         checkIndexFreshness(deps, now),
       ]);
 
-      const ready = dbResult.status === "ok" && indexResult.status === "ok";
+      const ready =
+        dbResult.status === "ok" &&
+        redisResult.status === "ok" &&
+        indexResult.status === "ok";
 
       const body: ReadyResponse = {
         ready,
         dependencies: {
           database: dbResult,
+          redis: redisResult,
           indexFreshness: indexResult,
         },
       };
@@ -94,6 +102,18 @@ export function readyRoute(deps: ReadyDeps) {
 async function checkDb(deps: ReadyDeps): Promise<DependencyResult> {
   try {
     await deps.checkDatabase();
+    return { status: "ok" };
+  } catch (err) {
+    return {
+      status: "error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function checkRedis(deps: ReadyDeps): Promise<DependencyResult> {
+  try {
+    await deps.checkRedis();
     return { status: "ok" };
   } catch (err) {
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { requestLogger } from "./api/middleware/logger.js";
 import { requestIdMiddleware } from "./api/middleware/requestId.js";
 import { config } from "./config.js";
 import { corsPlugin } from "./api/middleware/cors.js";
+import { redis } from "./services/redis.js";
 
 // Default: 64 KB. Override via BODY_LIMIT_BYTES env var.
 // Oversized requests are rejected with 413 Request Entity Too Large.
@@ -39,6 +40,10 @@ function createDefaultReadyDeps(): Parameters<typeof readyRoute>[0] {
     checkDatabase: async () => {
       const prisma = getPrismaClient();
       await prisma.$queryRaw`SELECT 1`;
+    },
+    checkRedis: async () => {
+      const ok = await redis.healthCheck();
+      if (!ok) throw new Error("Redis PING did not return PONG");
     },
     getLastIndexedAt: async () => {
       const prisma = getPrismaClient();
@@ -86,6 +91,18 @@ export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
   // Register API routes under /v1
   server.register(
     async (v1) => {
+      // Guard: any plugin within this scope must not hardcode a /v1 prefix on
+      // its own routes — the parent scope already adds it, which would produce
+      // double-prefixed paths like /v1/v1/markets.
+      v1.addHook("onRoute", (routeOptions) => {
+        if (routeOptions.url.startsWith("/v1")) {
+          throw new Error(
+            `Plugin registered route "${routeOptions.url}" with a /v1 prefix ` +
+              `inside the /v1-scoped block — remove the prefix from the plugin.`
+          );
+        }
+      });
+
       await v1.register(marketsRoutes);
       await v1.register(ordersRoutes);
       await v1.register(positionsRouter);

--- a/tests/integration/api-versioning.test.ts
+++ b/tests/integration/api-versioning.test.ts
@@ -16,6 +16,7 @@ describe("Integration Tests: API versioning", () => {
       registerTestRoutes: false,
       readyDeps: {
         checkDatabase: async () => {},
+        checkRedis: async () => {},
         getLastIndexedAt: async () => Date.now(),
       },
     });

--- a/tests/integration/settlement-queue.test.ts
+++ b/tests/integration/settlement-queue.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Integration test: settlement queue producer → Redis stream.
+ *
+ * Verifies that placing a matched order writes a settlement job to the correct
+ * Redis stream key with all required payload fields — without mocking enqueue.
+ * This catches regressions where the stream key, field names, or payload shape
+ * drift from what the downstream consumer expects.
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
+import type { FastifyInstance } from "fastify";
+import { Keypair } from "@stellar/stellar-sdk";
+import Redis from "ioredis";
+import { ordersRoutes } from "../../src/api/routes/orders.js";
+import { buildSignableMessage } from "../../src/api/middleware/stellarAuth.js";
+import { buildTestApp, resetRateLimits } from "./helpers/build-test-app.js";
+import { testUtils } from "../setup.js";
+import {
+  acquireDatabaseLock,
+  releaseDatabaseLock,
+} from "../helpers/test-database.js";
+import { matchingService } from "../../src/matching/matching-service.js";
+
+const STREAM_KEY =
+  `${process.env.REDIS_KEY_PREFIX ?? "vatix:"}` +
+  `${process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades"}`;
+
+const buyerKeypair = Keypair.random();
+const sellerKeypair = Keypair.random();
+const buyerAddress = buyerKeypair.publicKey();
+const sellerAddress = sellerKeypair.publicKey();
+
+function authHeaders(
+  keypair: Keypair,
+  body: {
+    marketId: string;
+    userAddress: string;
+    side: string;
+    outcome: string;
+    price: number;
+    quantity: number;
+  }
+): Record<string, string> {
+  const timestamp = Date.now();
+  const sig = keypair
+    .sign(buildSignableMessage({ ...body, timestamp }))
+    .toString("base64");
+  return { "x-signature": sig, "x-timestamp": String(timestamp) };
+}
+
+describe("Settlement queue: producer writes to Redis stream on trade match", () => {
+  let app: FastifyInstance;
+  let redisClient: Redis;
+
+  beforeAll(async () => {
+    await acquireDatabaseLock();
+    app = await buildTestApp({ plugins: [ordersRoutes] });
+
+    redisClient = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+      lazyConnect: false,
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await redisClient.quit();
+    await releaseDatabaseLock();
+  });
+
+  beforeEach(async () => {
+    resetRateLimits();
+    (matchingService as any).books?.clear();
+    (matchingService as any).locks?.clear();
+    vi.restoreAllMocks();
+    // Trim stream so each test starts with a clean slate for this key.
+    await redisClient.xtrim(STREAM_KEY, "MAXLEN", 0);
+  });
+
+  it("writes a settlement job to the stream when a trade is matched", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    // Seed a resting SELL order for the seller.
+    const sellPayload = {
+      marketId: market.id,
+      userAddress: sellerAddress,
+      side: "SELL" as const,
+      outcome: "YES" as const,
+      price: 0.5,
+      quantity: 10,
+    };
+    await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      headers: authHeaders(sellerKeypair, sellPayload),
+      payload: sellPayload,
+    });
+
+    // Place a crossing BUY — this should produce a trade and enqueue a job.
+    const buyPayload = {
+      marketId: market.id,
+      userAddress: buyerAddress,
+      side: "BUY" as const,
+      outcome: "YES" as const,
+      price: 0.5,
+      quantity: 10,
+    };
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      headers: authHeaders(buyerKeypair, buyPayload),
+      payload: buyPayload,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.trades).toHaveLength(1);
+
+    // The enqueue is fire-and-forget; give the microtask queue a tick to flush.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const entries = await redisClient.xrange(STREAM_KEY, "-", "+");
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+
+    // Parse the most recent entry's fields into an object.
+    const [, fields] = entries[entries.length - 1];
+    const job: Record<string, string> = {};
+    for (let i = 0; i < fields.length; i += 2) {
+      job[fields[i]] = fields[i + 1];
+    }
+
+    expect(job.tradeId).toBeTruthy();
+    expect(job.marketId).toBe(market.id);
+    expect(job.outcome).toBe("YES");
+    expect(job.buyerAddress).toBe(buyerAddress);
+    expect(job.sellerAddress).toBe(sellerAddress);
+    expect(Number(job.price)).toBeCloseTo(0.5);
+    expect(Number(job.quantity)).toBe(10);
+    expect(job.buyOrderId).toBeTruthy();
+    expect(job.sellOrderId).toBeTruthy();
+    expect(Number(job.timestamp)).toBeGreaterThan(0);
+  });
+
+  it("does not write to the stream when no match occurs", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    const buyPayload = {
+      marketId: market.id,
+      userAddress: buyerAddress,
+      side: "BUY" as const,
+      outcome: "YES" as const,
+      price: 0.3,
+      quantity: 5,
+    };
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      headers: authHeaders(buyerKeypair, buyPayload),
+      payload: buyPayload,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(JSON.parse(res.body).trades).toHaveLength(0);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const entries = await redisClient.xrange(STREAM_KEY, "-", "+");
+    expect(entries).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary


---

### closes #552 — Add Redis dependency to `/v1/ready` readiness probe

**Problem:** `createDefaultReadyDeps()` in `index.ts` only checked Postgres and indexer freshness. A Redis outage left the pod reporting ready while writes to audit streams and the settlement queue silently failed.

**Changes:**
- `src/api/routes/ready.ts` — `ReadyDeps` gains a required `checkRedis(): Promise<void>` method; `ReadyResponse.dependencies` gains a `redis` field; the route handler runs `checkRedis` in parallel with the existing checks and fails 503 if Redis is down.
- `src/index.ts` — `createDefaultReadyDeps()` now calls `redis.healthCheck()` (PING/PONG) for the Redis check; imports the `redis` singleton.
- `src/api/routes/ready.test.ts` and `tests/integration/api-versioning.test.ts` — stub `checkRedis: async () => {}` added so existing suites continue to pass.

---

### closes #553 — Integration test: settlement queue producer → Redis stream

**Problem:** `orders.test.ts` always mocked `settlementQueue.enqueue`, so regressions in the stream key name (`vatix:settlement-trades`), field names, or payload shape were invisible.

**Changes:**
- `tests/integration/settlement-queue.test.ts` — two tests that place real orders against a live Fastify + Postgres instance **without** mocking `enqueue`:
  1. **Match path**: places a crossing BUY against a seeded SELL, waits for the microtask queue to flush, then reads from `vatix:settlement-trades` via raw ioredis and asserts all nine payload fields (`tradeId`, `marketId`, `outcome`, `buyerAddress`, `sellerAddress`, `buyOrderId`, `sellOrderId`, `price`, `quantity`, `timestamp`).
  2. **No-match path**: places a non-crossing BUY and asserts the stream stays empty.

---

### closes #554 — Enforce `/v1` route prefix on all Fastify plugins

**Problem:** Nothing prevented a plugin from accidentally hardcoding `/v1/markets` on its own routes; within the `/v1`-scoped registration block this would produce a double-prefixed path (`/v1/v1/markets`) that silently registers and then fails at runtime.

**Changes:**
- `src/index.ts` — an `onRoute` hook added **inside** the `/v1`-scoped `server.register(async (v1) => { ... }, { prefix: "/v1" })` block. It throws at `server.ready()` time if any child plugin registers a URL that already starts with `/v1`, catching the double-prefix bug before the process accepts traffic.

---

### closes #555 — Document Stellar wallet signature verification in OpenAPI spec

**Problem:** `verifyStellarSignature` was wired as a preHandler on `POST /v1/orders` but the OpenAPI spec did not document the required `x-signature` / `x-timestamp` headers or the 401 response, so Swagger UI, code generators, and contract tests had no visibility into the auth contract.

**Changes:**
- `src/api/openapi.ts` — `POST /v1/orders` now includes:
  - `parameters` array with `x-signature` (required header, base64 Ed25519 sig over sorted-key canonical JSON + timestamp) and `x-timestamp` (required header, Unix ms string, ±5 min replay window).
  - `401` response entry describing missing/expired/invalid auth.

---

## Test plan

- [ ] `GET /v1/ready` returns 503 with `dependencies.redis.status: "error"` when Redis is unreachable
- [ ] `GET /v1/ready` returns 200 with `dependencies.redis.status: "ok"` when Redis is up
- [ ] `pnpm test:integration tests/integration/settlement-queue.test.ts` passes with live Redis
- [ ] Server startup throws if a plugin in the `/v1` scope registers a URL beginning with `/v1`
- [ ] `GET /v1/openapi.json` includes `x-signature` and `x-timestamp` parameters on `POST /v1/orders`
- [ ] No regressions in `orders.test.ts`, `api-versioning.test.ts`, or `ready.test.ts`