### PR TITLE
feat: implement minimal tasks min-025 through min-028

### DIFF
--- a/src/api/middleware/index.ts
+++ b/src/api/middleware/index.ts
@@ -1,1 +1,2 @@
 export { OrderBook } from "../../matching/orderbook.js";
+export { buildSignableMessage, verifyStellarSignature } from "./stellarAuth.js";

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -251,6 +251,7 @@ class RedisService {
     if (this.client) {
       await this.client.quit();
       this.client = null;
+      this.retryCount = 0;
       console.info({ service: "redis" }, "Redis disconnected gracefully");
     }
   }

--- a/tests/helpers/test-database.ts
+++ b/tests/helpers/test-database.ts
@@ -146,6 +146,7 @@ export async function cleanDatabase(client?: PrismaClient): Promise<void> {
   const prisma = client ?? getTestPrismaClient();
 
   // Delete in order respecting foreign key constraints
+  await prisma.trade.deleteMany();
   await prisma.order.deleteMany();
   await prisma.userPosition.deleteMany();
   await prisma.market.deleteMany();

--- a/tests/matching/hydration.test.ts
+++ b/tests/matching/hydration.test.ts
@@ -116,4 +116,16 @@ describe("#449 — hydrateAllActiveMarkets (restart simulation)", () => {
     const books: Map<string, unknown> = (matchingService as any).books;
     expect(books.size).toBe(0);
   });
+
+  it("creates empty books for outcomes with no resting orders", async () => {
+    process.env.WARM_MARKETS_ON_STARTUP = "true";
+    await matchingService.hydrateAllActiveMarkets();
+
+    const book = (matchingService as any).books.get("market-1:NO");
+    expect(book).toBeDefined();
+
+    const depth = book.getDepth(10);
+    expect(depth.bids).toHaveLength(0);
+    expect(depth.asks).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

- **[middleware] min-028** — Export `buildSignableMessage` and `verifyStellarSignature` from `src/api/middleware/index.ts` so the signing helper is accessible through the middleware scope barrel
- **[redis] min-027** — Reset `retryCount` to `0` in `RedisService.disconnect()` to prevent stale retry state carrying over into subsequent reconnections
- **[prisma] min-026** — Add `prisma.trade.deleteMany()` before order deletion in `cleanDatabase()` so FK references from the `trades` table are cleared first
- **[matching] min-025** — Add integration test case `"creates empty books for outcomes with no resting orders"` to `hydration.test.ts`, covering the `hydrateBook` path for outcomes that return no open orders

## Related Issues

Closes #497
Closes #496
Closes #495
Closes #494

## Test plan

- [ ] `pnpm test` passes — existing hydration tests still green, new test case passes
- [ ] `cleanDatabase()` now safely handles test suites that produce matched trades
- [ ] Middleware index exports verified by importing `buildSignableMessage` from `src/api/middleware`
- [ ] Redis disconnect no longer leaves `retryCount` in a stale state after reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)