### PR TITLE
feat: protect admin market routes with API key middleware

### DIFF
--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -65,8 +65,12 @@ export const openApiSpec = {
                     dependencies: {
                       type: "object",
                       properties: {
-                        database: { $ref: "#/components/schemas/DependencyResult" },
-                        indexFreshness: { $ref: "#/components/schemas/DependencyResult" },
+                        database: {
+                          $ref: "#/components/schemas/DependencyResult",
+                        },
+                        indexFreshness: {
+                          $ref: "#/components/schemas/DependencyResult",
+                        },
                       },
                     },
                   },
@@ -85,8 +89,12 @@ export const openApiSpec = {
                     dependencies: {
                       type: "object",
                       properties: {
-                        database: { $ref: "#/components/schemas/DependencyResult" },
-                        indexFreshness: { $ref: "#/components/schemas/DependencyResult" },
+                        database: {
+                          $ref: "#/components/schemas/DependencyResult",
+                        },
+                        indexFreshness: {
+                          $ref: "#/components/schemas/DependencyResult",
+                        },
                       },
                     },
                   },
@@ -363,11 +371,19 @@ export const openApiSpec = {
     "/v1/admin/markets": {
       get: {
         summary: "Admin market listing",
-        description: "List markets for admin users",
+        description:
+          "List all markets including CANCELLED ones. Requires API key and admin token.",
         tags: ["Admin"],
+        security: [{ ApiKeyAuth: [], BearerAuth: [] }],
         responses: {
           "200": {
             description: "Admin market list",
+          },
+          "401": {
+            description: "Missing or invalid API key",
+          },
+          "403": {
+            description: "Invalid admin token",
           },
         },
       },
@@ -375,8 +391,10 @@ export const openApiSpec = {
     "/v1/admin/markets/{id}/status": {
       patch: {
         summary: "Update market status",
-        description: "Admin endpoint to change market status",
+        description:
+          "Admin endpoint to change market status. Requires API key and admin token.",
         tags: ["Admin"],
+        security: [{ ApiKeyAuth: [], BearerAuth: [] }],
         parameters: [
           {
             name: "id",
@@ -409,11 +427,33 @@ export const openApiSpec = {
           "400": {
             description: "Invalid request",
           },
+          "401": {
+            description: "Missing or invalid API key",
+          },
+          "403": {
+            description: "Invalid admin token",
+          },
+          "404": {
+            description: "Market not found",
+          },
         },
       },
     },
   },
   components: {
+    securitySchemes: {
+      ApiKeyAuth: {
+        type: "apiKey",
+        in: "header",
+        name: "x-api-key",
+        description: "API key required for all admin endpoints",
+      },
+      BearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        description: "Admin token required for all admin endpoints",
+      },
+    },
     schemas: {
       Error: {
         type: "object",

--- a/src/api/routes/admin.ts
+++ b/src/api/routes/admin.ts
@@ -2,7 +2,9 @@ import type { FastifyInstance } from "fastify";
 import { getPrismaClient } from "../../services/prisma.js";
 import { requireAdmin } from "../middleware/adminGuard.js";
 import { requireApiKey } from "../middleware/apiKeyAuth.js";
+import { MarketNotFoundError } from "../middleware/errors.js";
 import { adminLimiter } from "../middleware/rateLimiter.js";
+import { success } from "../middleware/responses.js";
 
 export async function adminRoutes(fastify: FastifyInstance) {
   const prisma = getPrismaClient();
@@ -13,11 +15,11 @@ export async function adminRoutes(fastify: FastifyInstance) {
   fastify.addHook("onRequest", requireAdmin);
 
   // GET /admin/markets - list all markets including cancelled
-  fastify.get("/admin/markets", async () => {
+  fastify.get("/admin/markets", async (_request, reply) => {
     const markets = await prisma.market.findMany({
       orderBy: { createdAt: "desc" },
     });
-    return { markets, count: markets.length };
+    success(reply, { markets, count: markets.length });
   });
 
   // PATCH /admin/markets/:id/status - update market status
@@ -46,13 +48,17 @@ export async function adminRoutes(fastify: FastifyInstance) {
       const { id } = request.params;
       const { status } = request.body;
 
+      const existing = await prisma.market.findUnique({ where: { id } });
+      if (!existing) {
+        throw new MarketNotFoundError(id);
+      }
+
       const market = await prisma.market.update({
         where: { id },
         data: { status: status as any },
       });
 
-      reply.code(200);
-      return { market };
+      success(reply, { market });
     }
   );
 }

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -42,52 +42,85 @@ describe("Admin routes — auth guard matrix", () => {
     resetRateLimits();
   });
 
-  it("returns 401 when no auth headers are present", async () => {
-    const res = await app.inject({ method: "GET", url: "/v1/admin/markets" });
-    expect(res.statusCode).toBe(401);
-  });
+  const guardedEndpoints: Array<{
+    method: "GET" | "PATCH";
+    url: string;
+    payload?: object;
+  }> = [
+    { method: "GET", url: "/v1/admin/markets" },
+    {
+      method: "PATCH",
+      url: "/v1/admin/markets/00000000-0000-0000-0000-000000000000/status",
+      payload: { status: "CANCELLED" },
+    },
+  ];
 
-  it("returns 401 when only x-api-key is present (no Bearer token)", async () => {
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/admin/markets",
-      headers: { "x-api-key": API_KEY },
-    });
-    expect(res.statusCode).toBe(401);
-  });
+  it.each(guardedEndpoints)(
+    "returns 401 when no auth headers are present ($method $url)",
+    async ({ method, url, payload }) => {
+      const res = await app.inject({
+        method,
+        url,
+        ...(payload ? { payload } : {}),
+      });
+      expect(res.statusCode).toBe(401);
+    }
+  );
 
-  it("returns 401 when only Bearer token is present (no API key)", async () => {
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/admin/markets",
-      headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
-    });
-    expect(res.statusCode).toBe(401);
-  });
+  it.each(guardedEndpoints)(
+    "returns 401 when only x-api-key is present ($method $url)",
+    async ({ method, url, payload }) => {
+      const res = await app.inject({
+        method,
+        url,
+        headers: { "x-api-key": API_KEY },
+        ...(payload ? { payload } : {}),
+      });
+      expect(res.statusCode).toBe(401);
+    }
+  );
 
-  it("returns 401 for a wrong API key", async () => {
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/admin/markets",
-      headers: {
-        "x-api-key": "wrong-key",
-        authorization: `Bearer ${ADMIN_TOKEN}`,
-      },
-    });
-    expect(res.statusCode).toBe(401);
-  });
+  it.each(guardedEndpoints)(
+    "returns 401 when only Bearer token is present ($method $url)",
+    async ({ method, url, payload }) => {
+      const res = await app.inject({
+        method,
+        url,
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+        ...(payload ? { payload } : {}),
+      });
+      expect(res.statusCode).toBe(401);
+    }
+  );
 
-  it("returns 403 for a wrong admin token", async () => {
-    const res = await app.inject({
-      method: "GET",
-      url: "/v1/admin/markets",
-      headers: {
-        "x-api-key": API_KEY,
-        authorization: "Bearer wrong-token",
-      },
-    });
-    expect(res.statusCode).toBe(403);
-  });
+  it.each(guardedEndpoints)(
+    "returns 401 for a wrong API key ($method $url)",
+    async ({ method, url, payload }) => {
+      const res = await app.inject({
+        method,
+        url,
+        headers: {
+          "x-api-key": "wrong-key",
+          authorization: `Bearer ${ADMIN_TOKEN}`,
+        },
+        ...(payload ? { payload } : {}),
+      });
+      expect(res.statusCode).toBe(401);
+    }
+  );
+
+  it.each(guardedEndpoints)(
+    "returns 403 for a wrong admin token ($method $url)",
+    async ({ method, url, payload }) => {
+      const res = await app.inject({
+        method,
+        url,
+        headers: { "x-api-key": API_KEY, authorization: "Bearer wrong-token" },
+        ...(payload ? { payload } : {}),
+      });
+      expect(res.statusCode).toBe(403);
+    }
+  );
 });
 
 describe("GET /v1/admin/markets", () => {
@@ -121,11 +154,12 @@ describe("GET /v1/admin/markets", () => {
     expect(res.statusCode).toBe(200);
 
     const body = JSON.parse(res.body);
-    expect(typeof body.count).toBe("number");
-    expect(Array.isArray(body.markets)).toBe(true);
-    expect(body.count).toBeGreaterThanOrEqual(2);
+    expect(body.success).toBe(true);
+    expect(typeof body.data.count).toBe("number");
+    expect(Array.isArray(body.data.markets)).toBe(true);
+    expect(body.data.count).toBeGreaterThanOrEqual(2);
 
-    const statuses = body.markets.map((m: any) => m.status);
+    const statuses = body.data.markets.map((m: any) => m.status);
     expect(statuses).toContain("ACTIVE");
     expect(statuses).toContain("CANCELLED");
   });
@@ -162,8 +196,9 @@ describe("PATCH /v1/admin/markets/:id/status", () => {
     expect(res.statusCode).toBe(200);
 
     const body = JSON.parse(res.body);
-    expect(body.market.id).toBe(market.id);
-    expect(body.market.status).toBe("CANCELLED");
+    expect(body.success).toBe(true);
+    expect(body.data.market.id).toBe(market.id);
+    expect(body.data.market.status).toBe("CANCELLED");
   });
 
   it("returns 400 for an invalid status enum value", async () => {
@@ -180,13 +215,15 @@ describe("PATCH /v1/admin/markets/:id/status", () => {
     expect(res.statusCode).toBe(400);
   });
 
-  it("returns 400 or 404 for an unknown market ID", async () => {
+  it("returns 404 for an unknown market ID", async () => {
     const res = await authed(
       app,
       "PATCH",
       "/v1/admin/markets/00000000-0000-0000-0000-000000000000/status",
       { status: "CANCELLED" }
     );
-    expect([400, 404, 500]).toContain(res.statusCode);
+    expect(res.statusCode).toBe(404);
+    const body = JSON.parse(res.body);
+    expect(body.code).toBe("market_not_found");
   });
 });


### PR DESCRIPTION
## Protect admin market routes with API key middleware

Closes #567

## Summary

- `PATCH /admin/markets/:id/status` now returns 404 (with `code: market_not_found`) instead of 500 when the market ID doesn't exist
- Both admin routes now use the standard `success()` response envelope
- Auth guard matrix tests extended to cover PATCH in addition to GET
- OpenAPI spec updated with `ApiKeyAuth`/`BearerAuth` security schemes and 401/403/404 responses on admin endpoints

## Test plan

- [ ] `pnpm exec vitest run src/api/middleware/apiKeyAuth.test.ts` — middleware unit tests pass
- [ ] Integration tests in `tests/integration/admin.test.ts` cover all 5 auth failure cases for both GET and PATCH
- [ ] PATCH with unknown market ID returns 404, not 500
