### PR TITLE
feat: add per-book Mutex to MatchingService

### DIFF
--- a/src/matching/index.ts
+++ b/src/matching/index.ts
@@ -1,3 +1,4 @@
+export { Mutex } from "./mutex.js";
 export { OrderBook, Order as BookOrder, DepthLevel } from "./orderbook.js";
 export {
   matchOrder,

--- a/src/matching/matching-service.ts
+++ b/src/matching/matching-service.ts
@@ -8,6 +8,7 @@ import {
   type MatchingOrder,
   type Trade,
 } from "./engine.js";
+import { Mutex } from "./mutex.js";
 import { auditService } from "../services/audit.js";
 import { settlementQueue } from "../services/settlement-queue.js";
 import { redis } from "../services/redis.js";
@@ -30,28 +31,19 @@ export function getHydratedMarketsCount(): number {
 
 class MatchingService {
   private books: Map<string, OrderBook> = new Map();
-  private locks: Map<string, Promise<void>> = new Map();
+  private mutexes: Map<string, Mutex> = new Map();
 
   private getBookKey(marketId: string, outcome: Outcome): string {
     return `${marketId}:${outcome}`;
   }
 
-  private async serialize<T>(key: string, fn: () => Promise<T>): Promise<T> {
-    const prev = this.locks.get(key) ?? Promise.resolve();
-    let release!: () => void;
-    const next = new Promise<void>((r) => {
-      release = r;
-    });
-    this.locks.set(key, next);
-
-    try {
-      return await prev.then(() => fn());
-    } finally {
-      release();
-      if (this.locks.get(key) === next) {
-        this.locks.delete(key);
-      }
+  private getOrCreateMutex(key: string): Mutex {
+    let mutex = this.mutexes.get(key);
+    if (!mutex) {
+      mutex = new Mutex();
+      this.mutexes.set(key, mutex);
     }
+    return mutex;
   }
 
   private async hydrateBook(
@@ -161,7 +153,7 @@ class MatchingService {
   async placeOrder(input: OrderInput): Promise<PlaceOrderResult> {
     const bookKey = this.getBookKey(input.marketId, input.outcome);
 
-    return this.serialize(bookKey, async () => {
+    return this.getOrCreateMutex(bookKey).run(async () => {
       const prisma = getPrismaClient();
       const book = await this.getOrHydrateBook(input.marketId, input.outcome);
 

--- a/src/matching/mutex.test.ts
+++ b/src/matching/mutex.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi } from "vitest";
+import { Mutex } from "./mutex.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns a promise and a function to resolve it externally. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** Flushes the microtask queue so promise continuations can run. */
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Mutex", () => {
+  it("runs a single callback and returns its value", async () => {
+    const mutex = new Mutex();
+    const result = await mutex.run(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("serialises concurrent calls — second waits for first to finish", async () => {
+    const mutex = new Mutex();
+    const log: string[] = [];
+
+    const { promise: blocker, resolve: unblock } = deferred();
+
+    // First call: holds the mutex until `unblock()` is called.
+    const first = mutex.run(async () => {
+      log.push("first:start");
+      await blocker;
+      log.push("first:end");
+    });
+
+    // Second call: queues behind the first.
+    const second = mutex.run(async () => {
+      log.push("second:start");
+    });
+
+    // Let microtasks settle — first should have started, second is waiting.
+    await tick();
+    expect(log).toEqual(["first:start"]);
+
+    // Release the first caller.
+    unblock();
+    await Promise.all([first, second]);
+
+    expect(log).toEqual(["first:start", "first:end", "second:start"]);
+  });
+
+  it("releases the mutex even when the callback throws", async () => {
+    const mutex = new Mutex();
+    const log: string[] = [];
+
+    await expect(
+      mutex.run(async () => {
+        log.push("threw");
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+
+    // Mutex must be free: the next call should run immediately.
+    await mutex.run(async () => {
+      log.push("after-throw");
+    });
+
+    expect(log).toEqual(["threw", "after-throw"]);
+  });
+
+  it("queues three callers in order", async () => {
+    const mutex = new Mutex();
+    const order: number[] = [];
+
+    const blockers = [deferred(), deferred(), deferred()];
+
+    const runners = blockers.map((b, i) =>
+      mutex.run(async () => {
+        await b.promise;
+        order.push(i);
+      })
+    );
+
+    // Unblock each in sequence and verify ordering.
+    blockers[0].resolve();
+    await tick();
+    blockers[1].resolve();
+    await tick();
+    blockers[2].resolve();
+    await Promise.all(runners);
+
+    expect(order).toEqual([0, 1, 2]);
+  });
+
+  it("two independent mutexes do not block each other", async () => {
+    const mutexA = new Mutex();
+    const mutexB = new Mutex();
+    const log: string[] = [];
+
+    const { promise: blockerA, resolve: unblockA } = deferred();
+
+    const a = mutexA.run(async () => {
+      await blockerA;
+      log.push("A");
+    });
+
+    // mutexB is independent — it should run without waiting for A.
+    const b = mutexB.run(async () => {
+      log.push("B");
+    });
+
+    await tick();
+    expect(log).toContain("B"); // B ran while A was blocked
+    expect(log).not.toContain("A");
+
+    unblockA();
+    await Promise.all([a, b]);
+    expect(log).toContain("A");
+  });
+
+  it("propagates the callback return value through a queue", async () => {
+    const mutex = new Mutex();
+    const { promise: blocker, resolve: unblock } = deferred();
+
+    // First call holds the lock.
+    const first = mutex.run(async () => {
+      await blocker;
+      return "from-first";
+    });
+
+    // Second call is queued.
+    const second = mutex.run(async () => "from-second");
+
+    unblock();
+    const [r1, r2] = await Promise.all([first, second]);
+    expect(r1).toBe("from-first");
+    expect(r2).toBe("from-second");
+  });
+
+  it("handles a throwing first call followed by a successful second call", async () => {
+    const mutex = new Mutex();
+
+    const first = mutex.run(async () => {
+      throw new Error("first failed");
+    });
+
+    const second = mutex.run(async () => "ok");
+
+    await expect(first).rejects.toThrow("first failed");
+    await expect(second).resolves.toBe("ok");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-book mutex registry — mirrors the pattern used in MatchingService
+// ---------------------------------------------------------------------------
+
+/** Minimal replica of the Map<key, Mutex> registry in MatchingService. */
+class BookMutexRegistry {
+  private mutexes: Map<string, Mutex> = new Map();
+
+  getOrCreate(key: string): Mutex {
+    let mutex = this.mutexes.get(key);
+    if (!mutex) {
+      mutex = new Mutex();
+      this.mutexes.set(key, mutex);
+    }
+    return mutex;
+  }
+}
+
+describe("per-book mutex registry (pattern used by MatchingService)", () => {
+  it("creates independent mutexes for different book keys", () => {
+    const registry = new BookMutexRegistry();
+
+    const mutexA = registry.getOrCreate("market-A:YES");
+    const mutexB = registry.getOrCreate("market-B:YES");
+
+    expect(mutexA).toBeInstanceOf(Mutex);
+    expect(mutexB).toBeInstanceOf(Mutex);
+    expect(mutexA).not.toBe(mutexB);
+  });
+
+  it("returns the same mutex instance for the same book key", () => {
+    const registry = new BookMutexRegistry();
+
+    const key = "market-X:NO";
+    expect(registry.getOrCreate(key)).toBe(registry.getOrCreate(key));
+  });
+
+  it("YES and NO books for the same market get separate mutexes", () => {
+    const registry = new BookMutexRegistry();
+
+    const yes = registry.getOrCreate("market-X:YES");
+    const no = registry.getOrCreate("market-X:NO");
+
+    expect(yes).not.toBe(no);
+  });
+
+  it("concurrent operations on the same key are serialised, different keys run in parallel", async () => {
+    const registry = new BookMutexRegistry();
+    const log: string[] = [];
+
+    const { promise: blocker, resolve: unblock } = deferred();
+
+    // Two operations on the SAME key — second must wait for first.
+    const sameA = registry.getOrCreate("market-X:YES").run(async () => {
+      await blocker;
+      log.push("sameA");
+    });
+    const sameB = registry.getOrCreate("market-X:YES").run(async () => {
+      log.push("sameB");
+    });
+
+    // One operation on a DIFFERENT key — should not be blocked.
+    const other = registry.getOrCreate("market-Y:YES").run(async () => {
+      log.push("other");
+    });
+
+    await tick();
+
+    // `other` must be done; `sameB` must still be waiting.
+    expect(log).toContain("other");
+    expect(log).not.toContain("sameA");
+    expect(log).not.toContain("sameB");
+
+    unblock();
+    await Promise.all([sameA, sameB, other]);
+
+    expect(log).toEqual(["other", "sameA", "sameB"]);
+  });
+});

--- a/src/matching/mutex.ts
+++ b/src/matching/mutex.ts
@@ -1,0 +1,40 @@
+/**
+ * Async mutex for serialising concurrent operations on a shared resource.
+ *
+ * JavaScript is single-threaded, but async functions yield at every `await`,
+ * creating race windows when multiple callers operate on the same in-memory
+ * order book concurrently. This mutex closes that window by ensuring only one
+ * `run()` callback executes at a time per Mutex instance.
+ *
+ * Implementation — promise-chain queue:
+ *   - `tail` points to the promise that resolves when the current holder
+ *     finishes (or immediately if idle).
+ *   - Each new caller captures the current tail as its predecessor, then
+ *     replaces tail with a fresh promise it will resolve when done.
+ *   - The `finally` block always calls `release()`, so a throwing callback
+ *     never leaves the mutex permanently locked.
+ */
+export class Mutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  /**
+   * Acquire the mutex, run `fn`, then release.
+   * Callers queue automatically: the second call waits for the first,
+   * the third waits for the second, and so on.
+   */
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = this.tail;
+
+    let release!: () => void;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    try {
+      await prev;
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+}


### PR DESCRIPTION
## Add per-book Mutex to MatchingService

Closes #569

## Summary

- Extract the inline promise-chain mutex from `serialize()` into a standalone `Mutex` class (`src/matching/mutex.ts`) — easier to test, reason about, and reuse
- Replace `locks: Map<string, Promise<void>>` + `serialize()` in `MatchingService` with `mutexes: Map<string, Mutex>` + `getOrCreateMutex(key)` — one `Mutex` instance per `marketId:outcome` book key
- `finally` always calls `release()`, so a throwing callback never permanently locks a book
- Export `Mutex` from `src/matching/index.ts`

## Test plan

- [ ] `Mutex` unit tests: single execution, serial ordering, release-on-throw, 3-caller queue, independent mutex isolation, return-value propagation, throw-then-succeed
- [ ] Per-book registry tests: same key → same instance, different key → different instance, YES/NO books for the same market are independent, cross-key operations run in parallel while same-key operations are serialised
- [ ] Existing engine, orderbook, and hydration tests (135 total) still pass
