### PR TITLE
docs(middleware): add queue consumer doc

### DIFF
--- a/apps/workers/README.md
+++ b/apps/workers/README.md
@@ -11,30 +11,54 @@ Workers handle tasks that must run outside the HTTP request lifecycle: settlemen
 | **Queue consumers** | Process jobs pushed to Redis by the API or Oracle (e.g. trade settlement) |
 | **Scheduled jobs** | Cron-style tasks such as market expiry sweeps and position reconciliation |
 
-## Status
+## Implemented Workers
 
-Module scaffolded. No queues or jobs are implemented yet.
-See [docs/architecture.md](../../docs/architecture.md) for how Workers fit into the overall system.
+### Finalization Worker
 
-## Structure (planned)
+Polls for `ResolutionCandidate` rows that have passed the challenge window and promotes them to a settled `Resolution`.
+
+| Config env var | Default | Description |
+|---|---|---|
+| `FINALIZATION_INTERVAL_MS` | `60000` | How often the job runs (ms). Minimum 1000. |
+| `FINALIZATION_CHALLENGE_WINDOW_SECONDS` | `3600` | How long (seconds) a candidate must be in `PROPOSED` status before it can be finalized. |
+| `FINALIZATION_LOG_LEVEL` | `info` | Log verbosity: `debug` \| `info` \| `warn` \| `error`. |
+
+#### Queue Consumer Pattern
+
+The finalization worker uses a **poll-based** approach: it queries the database on each tick for candidates that satisfy the challenge window cutoff. Future workers for real-time settlement will instead subscribe to Redis Streams produced by the API after order matching.
+
+```
+API (order match) ──xadd──▶ Redis Stream ──xreadgroup──▶ Worker consumer
+                                                              │
+                                                         writes result
+                                                              │
+                                                        PostgreSQL
+```
+
+## Structure
 
 ```
 apps/workers/
 ├── src/
-│   ├── consumers/   # One file per queue consumer
-│   ├── schedulers/  # Cron / interval jobs
-│   └── index.ts     # Entry point
+│   └── finalization/
+│       ├── config.ts    # Env-based config loader
+│       ├── job.ts       # FinalizationJob class
+│       └── main.ts      # Entry point / bootstrap
 └── README.md
 ```
 
 ## Running
 
 ```bash
-# Not yet available — implementation pending
+# Development (hot reload)
+pnpm workers:finalization:dev
+
+# Production
+pnpm workers:finalization:start
 ```
 
 ## Adding a Worker
 
 1. Create a consumer in `src/consumers/<name>.ts` or a scheduler in `src/schedulers/<name>.ts`
 2. Register it in `src/index.ts`
-3. Document the queue name and payload shape in this README
+3. Document the queue name, payload shape, and env config in this README

--- a/src/api/middleware/README.md
+++ b/src/api/middleware/README.md
@@ -1,0 +1,38 @@
+# Middleware
+
+Request-handling plugins registered on the Fastify server in [src/index.ts](../../index.ts).
+
+## Modules
+
+| File | Role |
+|---|---|
+| `requestId.ts` | Accepts a caller-supplied `x-request-id` UUID or generates one; echoes it in the response header. Register first so the ID is set before any log entry. |
+| `logger.ts` | Structured request/response logging. Redacts secrets before writing to stdout. |
+| `cors.ts` | CORS policy driven by `CORS_ALLOWED_ORIGINS` env var. Falls back to `localhost:3000/5173` in dev, blocks all cross-origin in production unless configured. |
+| `rateLimiter.ts` | In-process sliding-window rate limiter with three tiers: global (100 req/60 s), heavy-read (20 req/60 s), write (10 req/60 s). Emits IETF RateLimit headers. |
+| `errorHandler.ts` | Centralised error-to-response mapping. Converts `ValidationError`, `NotFoundError`, and unhandled exceptions to consistent JSON payloads. |
+| `errors.ts` | Custom error classes (`ValidationError`, `NotFoundError`) thrown by routes and services. |
+| `apiKeyAuth.ts` | Static API-key guard for internal-facing endpoints. |
+| `adminGuard.ts` | Admin-only route guard; validates the `X-Admin-Key` header. |
+| `responses.ts` | `success(data)` helper for uniform 200 response envelopes. |
+
+## Queue Consumer Interaction
+
+Routes that trigger background work (e.g. order creation) enqueue a job to Redis after writing to the database. The middleware layer is not involved in consuming those jobs — that is handled by the Workers module (`apps/workers/`).
+
+```
+HTTP request
+   │
+   ▼
+rateLimiter → requestId → logger → route handler
+                                        │
+                              DB write + redis xadd (enqueue)
+                                        │
+                              response returned to client
+                                        │
+                                  (async, decoupled)
+                                        ▼
+                              Worker picks up job from Redis Stream
+```
+
+See [docs/architecture.md](../../../docs/architecture.md) for the full data-flow diagram and [apps/workers/README.md](../../../apps/workers/README.md) for the consumer side.


### PR DESCRIPTION
## Summary

- **`src/api/middleware/README.md`** (new): documents every middleware module and the enqueue-then-consume flow — HTTP route writes to DB + enqueues via `redis.xadd`, Worker picks up via `xreadgroup`
- **`apps/workers/README.md`** (updated): replaces stale "no queues implemented yet" with documentation of the live `FinalizationJob`, its env config table, the poll-based consumer pattern, and the planned Redis Stream consumer architecture diagram

## Test plan

- [ ] Verify middleware table covers all files in `src/api/middleware/`
- [ ] Verify finalization config env vars match `apps/workers/src/finalization/config.ts`
- [ ] Verify run commands match `pnpm` scripts in root `package.json`

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)