### PR TITLE
docs(workers): add settlement-worker to docker-compose reference (#576)

### DIFF
--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -18,6 +18,7 @@ just the data layer (for host-run development) or the fully containerized stack.
 | `indexer`             | `app`, `indexer`                        | `vatix-indexer`             | Stellar event indexer               |
 | `finalization-worker` | `app`, `workers`, `finalization-worker` | `vatix-finalization-worker` | Resolution finalization loop        |
 | `oracle-worker`       | `app`, `workers`, `oracle-worker`       | `vatix-oracle-worker`       | Oracle submission queue consumer    |
+| `settlement-worker`   | `app`, `workers`, `settlement-worker`   | `vatix-settlement-worker`   | Trade settlement BullMQ consumer    |
 | `migrate`             | `tools`, `migrate`                      | `vatix-migrate`             | One-off `prisma migrate deploy` job |
 
 Container names match the ones referenced in
@@ -72,6 +73,7 @@ on the host with `tsx`.
    pnpm indexer:dev                  # Indexer
    pnpm workers:finalization:dev     # Finalization worker
    pnpm workers:oracle:dev           # Oracle worker
+   pnpm workers:settlement:dev       # Settlement consumer
    ```
 
 ## Option B — Full containerized stack
@@ -99,13 +101,14 @@ root, which defines one build `--target` per process.
    ```
 
    This builds and starts `postgres`, `redis`, `api`, `indexer`,
-   `finalization-worker`, and `oracle-worker`.
+   `finalization-worker`, `oracle-worker`, and `settlement-worker`.
 
    To run a subset, use the matching profile instead of `app`, e.g.:
 
    ```bash
-   docker compose --profile api up -d --build      # postgres + redis + api only
-   docker compose --profile workers up -d --build  # postgres + redis + both workers
+   docker compose --profile api up -d --build              # postgres + redis + api only
+   docker compose --profile workers up -d --build          # postgres + redis + all workers
+   docker compose --profile settlement-worker up -d --build # settlement consumer only
    ```
 
 Inside the compose network, app containers reach Postgres/Redis via the


### PR DESCRIPTION
## Summary

The `settlement-worker` service was already declared in `docker-compose.yml`
but was absent from the documentation in `docs/docker-compose.md`.

- Add `settlement-worker` row to the services table (profiles: `app`, `workers`, `settlement-worker`)
- Update the `--profile app` description to include the settlement consumer alongside finalization and oracle workers
- Add a `--profile settlement-worker` example for running the settlement consumer in isolation
- Add `pnpm workers:settlement:dev` to the host-run commands list

## Test plan

- [x] `docker compose --profile settlement-worker up -d --build` described in docs matches the service definition in `docker-compose.yml`
- [x] `docker compose --profile workers up -d --build` starts `finalization-worker`, `oracle-worker`, and `settlement-worker`
- [x] Prettier formatting applied (pre-commit hook passed)

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)