### PR TITLE
test(workers): add Stellar SDK invoke tests for settlement-worker (#578)

### DIFF
--- a/apps/workers/src/settlement/settlement-worker.test.ts
+++ b/apps/workers/src/settlement/settlement-worker.test.ts
@@ -1,11 +1,115 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   SettlementWorker,
   type SettlementWorkerConfig,
   type SettlementRedisClient,
+  type SettlementStellarConfig,
 } from "./settlement-worker.js";
 import type { QueueJob } from "../consumers/queue-consumer.js";
 import type { ILogger } from "../../../../packages/shared/src/logger.js";
+
+// ---------------------------------------------------------------------------
+// Stellar SDK mock — variables hoisted via vi.hoisted so they are accessible
+// inside the vi.mock() factory (which Vitest also hoists to the top).
+// ---------------------------------------------------------------------------
+const {
+  mockContractCall,
+  mockContractCtor,
+  mockKeypairPublicKey,
+  mockKeypairFromSecret,
+  mockTxSign,
+  mockTxBuilderBuild,
+  mockTxBuilderSetTimeout,
+  mockTxBuilderAddOp,
+  mockTransactionBuilderCtor,
+  mockGetAccount,
+  mockPrepareTransaction,
+  mockSendTransaction,
+  mockGetTransaction,
+  mockRpcServerCtor,
+} = vi.hoisted(() => {
+  // Leaf mock functions — referenced by class instances below.
+  const mockContractCall = vi.fn().mockReturnValue("mock-operation");
+  const mockKeypairPublicKey = vi
+    .fn()
+    .mockReturnValue(
+      "GSIGNER1111111111111111111111111111111111111111111111111"
+    );
+  const mockKeypairFromSecret = vi.fn().mockReturnValue({
+    publicKey: mockKeypairPublicKey,
+  });
+  const mockTxSign = vi.fn();
+  const mockTxBuilderBuild = vi.fn();
+  const mockTxBuilderSetTimeout = vi.fn();
+  const mockTxBuilderAddOp = vi.fn();
+  const mockGetAccount = vi.fn().mockResolvedValue({ id: "mock-account" });
+  const mockPrepareTransaction = vi
+    .fn()
+    .mockImplementation((tx: unknown) => Promise.resolve(tx));
+  const mockSendTransaction = vi.fn().mockResolvedValue({
+    status: "PENDING",
+    hash: "abc123txhash",
+  });
+  const mockGetTransaction = vi.fn().mockResolvedValue({
+    status: "SUCCESS",
+    ledger: 1000,
+  });
+
+  // Vitest 4.x: use `class` keyword inside mockImplementation for constructors.
+  const mockContractCtor = vi.fn().mockImplementation(
+    class {
+      call = mockContractCall;
+    }
+  );
+
+  const mockTransactionBuilderCtor = vi.fn().mockImplementation(
+    class {
+      addOperation = mockTxBuilderAddOp.mockReturnThis();
+      setTimeout = mockTxBuilderSetTimeout.mockReturnThis();
+      build = mockTxBuilderBuild.mockReturnValue({ sign: mockTxSign });
+    }
+  );
+
+  const mockRpcServerCtor = vi.fn().mockImplementation(
+    class {
+      getAccount = mockGetAccount;
+      prepareTransaction = mockPrepareTransaction;
+      sendTransaction = mockSendTransaction;
+      getTransaction = mockGetTransaction;
+    }
+  );
+
+  return {
+    mockContractCall,
+    mockContractCtor,
+    mockKeypairPublicKey,
+    mockKeypairFromSecret,
+    mockTxSign,
+    mockTxBuilderBuild,
+    mockTxBuilderSetTimeout,
+    mockTxBuilderAddOp,
+    mockTransactionBuilderCtor,
+    mockGetAccount,
+    mockPrepareTransaction,
+    mockSendTransaction,
+    mockGetTransaction,
+    mockRpcServerCtor,
+  };
+});
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  Contract: mockContractCtor,
+  Keypair: { fromSecret: mockKeypairFromSecret },
+  TransactionBuilder: mockTransactionBuilderCtor,
+  nativeToScVal: vi.fn().mockReturnValue("mock-scval"),
+  rpc: {
+    Server: mockRpcServerCtor,
+    Api: {
+      GetTransactionStatus: { SUCCESS: "SUCCESS", FAILED: "FAILED" },
+    },
+  },
+  xdr: {},
+}));
 
 function makeLogger(): ILogger {
   return {
@@ -226,5 +330,207 @@ describe("SettlementWorker", () => {
       ).mock.calls.filter((call) => call[0] === "Job dead-lettered");
       expect(deadLetterCalls).toHaveLength(0);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stellar SDK invocation tests
+// ---------------------------------------------------------------------------
+describe("SettlementWorker — Stellar SDK invoke (executeOnChain)", () => {
+  const stellarConfig: SettlementStellarConfig = {
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    contractId: "CCONTRACT11111111111111111111111111111111111111111111111111",
+    networkPassphrase: "Test SDF Network ; September 2015",
+    signerSecret: "SSECRET111111111111111111111111111111111111111111111111111",
+  };
+
+  let logger: ILogger;
+  let redisClient: SettlementRedisClient;
+  let stellarWorker: SettlementWorker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    // Reset mocks to their default resolved values
+    mockGetAccount.mockResolvedValue({ id: "mock-account" });
+    mockPrepareTransaction.mockImplementation((tx) => Promise.resolve(tx));
+    mockSendTransaction.mockResolvedValue({
+      status: "PENDING",
+      hash: "abc123txhash",
+    });
+    mockGetTransaction.mockResolvedValue({ status: "SUCCESS", ledger: 1000 });
+
+    logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    };
+    redisClient = {
+      exists: vi.fn().mockResolvedValue(false),
+      set: vi.fn().mockResolvedValue(undefined),
+    };
+    stellarWorker = new SettlementWorker(redisClient, logger, {
+      maxAttempts: 3,
+      processingTimeoutMs: 5_000,
+      idempotencyTtlSeconds: 86_400,
+      stellar: stellarConfig,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("invokes Contract.call('settle_trade') with correct arguments", async () => {
+    const job: QueueJob = {
+      id: "job-stellar-1",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-on-chain-001",
+        marketId: "market-001",
+        outcome: "YES",
+        buyOrderId: "buy-1",
+        sellOrderId: "sell-1",
+        buyerAddress: "GBUYER111111111111111111111111111111111111111111111111",
+        sellerAddress: "GSELLER11111111111111111111111111111111111111111111111",
+        price: "0.65",
+        quantity: "100",
+        timestamp: "1700000000000",
+      },
+    };
+
+    const processPromise = stellarWorker.process(job);
+    await vi.runAllTimersAsync();
+    await processPromise;
+
+    expect(mockContractCall).toHaveBeenCalledWith(
+      "settle_trade",
+      expect.anything(), // tradeId ScVal
+      expect.anything(), // marketId ScVal
+      expect.anything(), // outcome ScVal
+      expect.anything(), // buyerAddress ScVal
+      expect.anything(), // sellerAddress ScVal
+      expect.anything(), // price ScVal
+      expect.anything() // quantity ScVal
+    );
+  });
+
+  it("builds, signs, and submits the transaction", async () => {
+    const job: QueueJob = {
+      id: "job-stellar-2",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-on-chain-002",
+        marketId: "market-002",
+        outcome: "NO",
+        buyOrderId: "buy-2",
+        sellOrderId: "sell-2",
+        buyerAddress: "GBUYER111111111111111111111111111111111111111111111111",
+        sellerAddress: "GSELLER11111111111111111111111111111111111111111111111",
+        price: "0.30",
+        quantity: "50",
+        timestamp: "1700000001000",
+      },
+    };
+
+    const processPromise = stellarWorker.process(job);
+    await vi.runAllTimersAsync();
+    await processPromise;
+
+    expect(mockGetAccount).toHaveBeenCalled();
+    expect(mockPrepareTransaction).toHaveBeenCalled();
+    expect(mockTxSign).toHaveBeenCalled();
+    expect(mockSendTransaction).toHaveBeenCalled();
+  });
+
+  it("logs settlement confirmed after successful on-chain confirmation", async () => {
+    const job: QueueJob = {
+      id: "job-stellar-3",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-on-chain-003",
+        marketId: "market-003",
+        outcome: "YES",
+        buyOrderId: "buy-3",
+        sellOrderId: "sell-3",
+        buyerAddress: "GBUYER111111111111111111111111111111111111111111111111",
+        sellerAddress: "GSELLER11111111111111111111111111111111111111111111111",
+        price: "0.50",
+        quantity: "200",
+        timestamp: "1700000002000",
+      },
+    };
+
+    const processPromise = stellarWorker.process(job);
+    await vi.runAllTimersAsync();
+    await processPromise;
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "settle_trade confirmed on-chain",
+      expect.objectContaining({
+        tradeId: "trade-on-chain-003",
+        hash: "abc123txhash",
+      })
+    );
+  });
+
+  it("throws when sendTransaction returns ERROR status", async () => {
+    mockSendTransaction.mockResolvedValue({
+      status: "ERROR",
+      hash: "errored-hash",
+    });
+
+    const job: QueueJob = {
+      id: "job-stellar-err",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-err-001",
+        marketId: "market-001",
+        outcome: "YES",
+        buyOrderId: "buy-e",
+        sellOrderId: "sell-e",
+        buyerAddress: "GBUYER111111111111111111111111111111111111111111111111",
+        sellerAddress: "GSELLER11111111111111111111111111111111111111111111111",
+        price: "0.50",
+        quantity: "10",
+        timestamp: "1700000003000",
+      },
+    };
+
+    await expect(stellarWorker.process(job)).rejects.toThrow(
+      "settle_trade submission failed"
+    );
+  });
+
+  it("throws when transaction is confirmed as FAILED on-chain", async () => {
+    mockGetTransaction.mockResolvedValue({ status: "FAILED" });
+
+    const job: QueueJob = {
+      id: "job-stellar-fail",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-fail-001",
+        marketId: "market-001",
+        outcome: "YES",
+        buyOrderId: "buy-f",
+        sellOrderId: "sell-f",
+        buyerAddress: "GBUYER111111111111111111111111111111111111111111111111",
+        sellerAddress: "GSELLER11111111111111111111111111111111111111111111111",
+        price: "0.50",
+        quantity: "10",
+        timestamp: "1700000004000",
+      },
+    };
+
+    // Attach rejection handler BEFORE advancing timers to avoid unhandled rejection.
+    const processPromise = stellarWorker.process(job);
+    const expectation = expect(processPromise).rejects.toThrow(
+      "settle_trade transaction failed on-chain"
+    );
+    await vi.runAllTimersAsync();
+    await expectation;
   });
 });


### PR DESCRIPTION
## Summary

Add unit tests for the `executeOnChain` code path of `SettlementWorker`,
which invokes the Soroban `settle_trade` contract via `@stellar/stellar-sdk`.

The `executeOnChain` method was already implemented but had no dedicated test
coverage. This PR adds a full suite covering the Stellar SDK invocation path.

**New tests (5):**
- `Contract.call('settle_trade')` is called with the correct 7 ScVal arguments
- `getAccount`, `prepareTransaction`, `sign`, and `sendTransaction` are all called during a successful flow
- "settle_trade confirmed on-chain" is logged when `getTransaction` returns `SUCCESS`
- Error is thrown immediately when `sendTransaction` returns `ERROR` status
- Error is thrown when on-chain confirmation reports `FAILED`

**Implementation notes:**
- Uses `vi.hoisted()` so mock variable references are accessible inside the hoisted `vi.mock()` factory
- Uses `vi.useFakeTimers()` + `vi.runAllTimersAsync()` to advance the 1s poll interval without real-time delay
- Uses `class` keyword in `mockImplementation` (required by Vitest 4.x for constructor mocks)
- Attaches rejection handler before advancing timers to avoid unhandled rejection warnings

## Test plan

- [x] All 13 tests pass (8 existing + 5 new) with no unhandled rejections
- [x] TypeScript compiles without errors (pre-commit hook passed)
- [x] Prettier formatting applied

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)