### PR TITLE
docs: remove packages/db references from architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,6 @@ Vatix Backend is a monorepo of services that together power the Vatix prediction
 | **Indexer**   | `apps/indexer/` | Polls Stellar network for on-chain events, parses them, and writes canonical records to PostgreSQL.             |
 | **Oracle**    | `apps/oracle/`  | Fetches external price/resolution data, signs reports, and submits them on-chain via the Stellar SDK.           |
 | **Workers**   | `apps/workers/` | Queue consumers and scheduled jobs (e.g. settlement, expiry sweeps). Decoupled from the HTTP request lifecycle. |
-| **Shared DB** | `packages/db/`  | Shared Prisma client and migration utilities used by all services.                                              |
 
 ## Major Data Flows
 


### PR DESCRIPTION
Closes #623 
Remove the Shared DB entry (packages/db/) from the Service Boundaries table in docs/architecture.md. The shared Prisma client is an implementation detail of the individual services rather than a separately documented module, so the row was adding noise without providing architectural value.