### PR TITLE
Add compose full profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,10 @@ version: "3.8"
 # Profiles let you run just the data layer (the historical default — start
 # infra, then `pnpm dev` on the host) or the fully containerized stack.
 #
-#   docker compose up -d                       # postgres + redis only
-#   docker compose --profile app up -d --build # postgres + redis + every process
-#   docker compose --profile api up -d --build # postgres + redis + api only
+#   docker compose up -d                        # postgres + redis only
+#   docker compose --profile full up -d --build # postgres + redis + api + indexer + all workers
+#   docker compose --profile app up -d --build  # postgres + redis + every process (alias for full)
+#   docker compose --profile api up -d --build  # postgres + redis + api only
 #
 # See docs/docker-compose.md for the full walkthrough.
 
@@ -49,7 +50,7 @@ services:
       context: .
       target: api
     container_name: vatix-backend
-    profiles: ["app", "api"]
+    profiles: ["app", "full", "api"]
     env_file:
       - .env
     environment:
@@ -69,7 +70,7 @@ services:
       context: .
       target: indexer
     container_name: vatix-indexer
-    profiles: ["app", "indexer"]
+    profiles: ["app", "full", "indexer"]
     env_file:
       - .env
     environment:
@@ -84,7 +85,7 @@ services:
       context: .
       target: finalization-worker
     container_name: vatix-finalization-worker
-    profiles: ["app", "workers", "finalization-worker"]
+    profiles: ["app", "full", "workers", "finalization-worker"]
     env_file:
       - .env
     environment:
@@ -99,7 +100,7 @@ services:
       context: .
       target: oracle-worker
     container_name: vatix-oracle-worker
-    profiles: ["app", "workers", "oracle-worker"]
+    profiles: ["app", "full", "workers", "oracle-worker"]
     env_file:
       - .env
     environment:
@@ -117,7 +118,7 @@ services:
       context: .
       target: settlement-worker
     container_name: vatix-settlement-worker
-    profiles: ["app", "workers", "settlement-worker"]
+    profiles: ["app", "full", "workers", "settlement-worker"]
     env_file:
       - .env
     environment:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,6 @@ Vatix Backend is a monorepo of services that together power the Vatix prediction
 | **Indexer**   | `apps/indexer/` | Polls Stellar network for on-chain events, parses them, and writes canonical records to PostgreSQL.             |
 | **Oracle**    | `apps/oracle/`  | Fetches external price/resolution data, signs reports, and submits them on-chain via the Stellar SDK.           |
 | **Workers**   | `apps/workers/` | Queue consumers and scheduled jobs (e.g. settlement, expiry sweeps). Decoupled from the HTTP request lifecycle. |
-| **Shared DB** | `packages/db/`  | Shared Prisma client and migration utilities used by all services.                                              |
 
 ## Major Data Flows
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -135,6 +135,50 @@ Snapshot-style position record per wallet/market/outcome (used for PnL queries).
 
 Unique constraint: `(wallet_address, market_id, outcome)`
 
+### `Trade`
+
+CLOB-engine trade records. Written atomically with order fills; `trade_id` is the idempotency key preventing duplicate writes on retry.
+
+| Column          | Type            | Notes                              |
+| --------------- | --------------- | ---------------------------------- |
+| `id`            | `uuid`          | Primary key                        |
+| `trade_id`      | `VarChar(256)`  | Unique idempotency key             |
+| `market_id`     | `uuid`          | FK → `markets.id`                  |
+| `outcome`       | `Outcome`       | `YES` or `NO`                      |
+| `buyer_address` | `VarChar(56)`   | Stellar wallet address of buyer    |
+| `seller_address`| `VarChar(56)`   | Stellar wallet address of seller   |
+| `buy_order_id`  | `uuid`          | FK reference to the buy order      |
+| `sell_order_id` | `uuid`          | FK reference to the sell order     |
+| `price`         | `Decimal(10,8)` | Execution price                    |
+| `quantity`      | `Int`           | Quantity traded                    |
+| `traded_at`     | `DateTime`      | When the trade occurred            |
+| `created_at`    | `DateTime`      | Auto-set on insert                 |
+
+Indexes: `market_id`, `buyer_address`, `seller_address`, `(buyer_address, traded_at DESC)`, `(seller_address, traded_at DESC)`
+
+### `IndexedTrade`
+
+On-chain trade events ingested by the indexer. Keyed by `idempotency_key` until fill reconciliation with CLOB orders exists.
+
+| Column                 | Type           | Notes                                   |
+| ---------------------- | -------------- | --------------------------------------- |
+| `id`                   | `uuid`         | Primary key                             |
+| `idempotency_key`      | `VarChar(64)`  | Unique; prevents duplicate ingestion    |
+| `event_id`             | `String`       | Stellar event identifier                |
+| `ledger`               | `Int`          | Ledger sequence number                  |
+| `market_id`            | `String`       | Market identifier from on-chain event   |
+| `trader_address`       | `VarChar(56)`  | Stellar address of the trader           |
+| `counterparty_address` | `VarChar(56)`  | Stellar address of the counterparty     |
+| `direction`            | `VarChar(8)`   | Trade direction (e.g. `BUY`, `SELL`)    |
+| `outcome`              | `VarChar(8)`   | Outcome string from on-chain event      |
+| `price_raw`            | `String`       | Raw price value (preserves precision)   |
+| `quantity_raw`         | `String`       | Raw quantity value (preserves precision)|
+| `buy_order_id`         | `String`       | Buy-side order reference                |
+| `sell_order_id`        | `String`       | Sell-side order reference               |
+| `created_at`           | `DateTime`     | Auto-set on insert                      |
+
+Indexes: `market_id`, `ledger`
+
 ### `IndexerCursor`
 
 Tracks the Stellar ledger cursor position for the indexer.


### PR DESCRIPTION
Closes #621 
Added a new full profile to docker-compose.yml that runs the complete
  containerized local stack (postgres, redis, api, indexer, finalization-worker, oracle-worker,
  settlement-worker). All application services now include the full profile in addition to their
  existing profiles. The app profile remains functional for backward compatibility. Updated help
  comments document the new usage: docker compose --profile full up -d --build.