### PR TITLE
feat(markets): add soft delete support for canceled markets

### DIFF
--- a/prisma/migrations/20260724074257_add_soft_delete_to_markets/migration.sql
+++ b/prisma/migrations/20260724074257_add_soft_delete_to_markets/migration.sql
@@ -1,0 +1,6 @@
+-- Add soft delete support to markets table
+-- Add deleted_at column to track soft deletion
+ALTER TABLE "markets" ADD COLUMN "deleted_at" TIMESTAMP(3);
+
+-- Create index on deleted_at for efficient filtering of non-deleted markets
+CREATE INDEX "markets_deleted_at_idx" ON "markets"("deleted_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model Market {
   outcome        Boolean?
   createdAt      DateTime     @default(now()) @map("created_at")
   updatedAt      DateTime     @default(now()) @updatedAt @map("updated_at")
+  deletedAt      DateTime?    @map("deleted_at")
 
   orders               Order[]
   positions            UserPosition[]
@@ -88,6 +89,7 @@ model Market {
   @@index([endTime])
   @@index([status, endTime])
   @@index([status, createdAt(sort: Desc)])
+  @@index([deletedAt])
   @@map("markets")
 }
 

--- a/src/api/routes/markets.ts
+++ b/src/api/routes/markets.ts
@@ -107,7 +107,10 @@ export async function marketsRoutes(fastify: FastifyInstance) {
         limit = 50,
       } = request.query;
 
-      const whereClause = status ? { status } : {};
+      const whereClause = {
+        ...(status ? { status } : {}),
+        deletedAt: null,
+      };
 
       const orderBy = {
         [sort]: direction,
@@ -146,7 +149,7 @@ export async function marketsRoutes(fastify: FastifyInstance) {
       const { id } = request.params;
 
       const market = await prisma.market.findUnique({ where: { id } });
-      if (!market) {
+      if (!market || market.deletedAt !== null) {
         throw new MarketNotFoundError(id);
       }
 
@@ -173,7 +176,7 @@ export async function marketsRoutes(fastify: FastifyInstance) {
       const { id } = request.params;
 
       const market = await prisma.market.findUnique({ where: { id } });
-      if (!market) {
+      if (!market || market.deletedAt !== null) {
         throw new MarketNotFoundError(id);
       }
 

--- a/src/matching/validation.ts
+++ b/src/matching/validation.ts
@@ -211,7 +211,7 @@ export async function validateMarketState(
     where: { id: marketId },
   });
 
-  if (!market) {
+  if (!market || market.deletedAt !== null) {
     errors.marketId = "Market not found";
     return { valid: false, errors };
   }


### PR DESCRIPTION
## Summary

- Add soft delete support to the Market model by introducing a deletedAt field
- Soft-deleted markets are excluded from public API queries by default
- Admin endpoint continues to show all markets for management purposes
- Prevents orders from being placed on soft-deleted markets

## Implementation Details

- Add deletedAt field to Market Prisma schema with index
- Create database migration to add deleted_at column
- Update market queries to filter out soft-deleted records (deletedAt IS NULL)
- Add soft delete check in order validation

## Validation

- Schema changes aligned with existing patterns
- Soft delete logic integrated into all market query paths
- Order validation prevents trading on soft-deleted markets

Closes #722