### PR TITLE
Platform hardening: reliability pass 013-016 (closes #759-#762)

### DIFF
--- a/apps/workers/src/finalization/job.test.ts
+++ b/apps/workers/src/finalization/job.test.ts
@@ -41,24 +41,45 @@ function makeCandidate(
   };
 }
 
+/**
+ * Builds a mock tx object for $transaction. marketUpdateCount controls how
+ * many rows tx.market.updateMany() reports as matched — 0 simulates a market
+ * that was canceled/soft-deleted concurrently (see MarketNotEligibleError).
+ */
+function makeTx(marketUpdateCount = 1) {
+  const create = vi.fn().mockResolvedValue({ id: "resolution-1" });
+  const marketUpdateMany = vi
+    .fn()
+    .mockResolvedValue({ count: marketUpdateCount });
+  const updateCandidate = vi.fn().mockResolvedValue({});
+  const positionUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
+
+  const tx = {
+    resolution: { create },
+    market: { updateMany: marketUpdateMany },
+    resolutionCandidate: { update: updateCandidate },
+    userPosition: { updateMany: positionUpdateMany },
+  };
+
+  return {
+    tx,
+    create,
+    marketUpdateMany,
+    updateCandidate,
+    positionUpdateMany,
+  };
+}
+
 function makePrisma(
   candidates: FinalizationCandidate[] = [],
   resolutionError: boolean = false
 ) {
-  const create = vi.fn().mockResolvedValue({ id: "resolution-1" });
-  const update = vi.fn().mockResolvedValue({});
-  const updateMany = vi.fn().mockResolvedValue({ count: 2 });
+  const { tx } = makeTx();
 
   const transaction = vi
     .fn()
     .mockImplementation(
       async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
-        const tx = {
-          resolution: { create },
-          market: { update },
-          resolutionCandidate: { update },
-          userPosition: { updateMany },
-        };
         return await fn(tx);
       }
     );
@@ -170,22 +191,12 @@ describe("FinalizationJob", () => {
           source: "chainlink",
         }),
       ];
-      const create = vi.fn().mockResolvedValue({ id: "resolution-1" });
-      const update = vi.fn().mockResolvedValue({});
-      const updateMany = vi.fn().mockResolvedValue({ count: 2 });
-      const updateCandidate = vi.fn().mockResolvedValue({});
+      const { tx, create } = makeTx();
       const transaction = vi
         .fn()
         .mockImplementation(
-          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
-            const tx = {
-              resolution: { create },
-              market: { update },
-              resolutionCandidate: { update: updateCandidate },
-              userPosition: { updateMany },
-            };
-            return await fn(tx);
-          }
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
         );
       const prisma = {
         resolutionCandidate: {
@@ -206,26 +217,16 @@ describe("FinalizationJob", () => {
       });
     });
 
-    it("updates Market status to RESOLVED and sets outcome", async () => {
+    it("updates Market status to RESOLVED and sets outcome, guarded against canceled/deleted markets", async () => {
       const candidates = [
         makeCandidate({ marketId: "mkt-1", proposedOutcome: false }),
       ];
-      const create = vi.fn().mockResolvedValue({ id: "resolution-1" });
-      const update = vi.fn().mockResolvedValue({});
-      const updateMany = vi.fn().mockResolvedValue({ count: 2 });
-      const updateCandidate = vi.fn().mockResolvedValue({});
+      const { tx, marketUpdateMany } = makeTx();
       const transaction = vi
         .fn()
         .mockImplementation(
-          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
-            const tx = {
-              resolution: { create },
-              market: { update },
-              resolutionCandidate: { update: updateCandidate },
-              userPosition: { updateMany },
-            };
-            return await fn(tx);
-          }
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
         );
       const prisma = {
         resolutionCandidate: {
@@ -237,8 +238,12 @@ describe("FinalizationJob", () => {
       const job = new FinalizationJob(prisma, makeLogger(), makeConfig(3600));
       await job.run();
 
-      expect(update).toHaveBeenCalledWith({
-        where: { id: "mkt-1" },
+      expect(marketUpdateMany).toHaveBeenCalledWith({
+        where: {
+          id: "mkt-1",
+          status: { not: "CANCELLED" },
+          deletedAt: null,
+        },
         data: expect.objectContaining({
           status: "RESOLVED",
           outcome: false,
@@ -248,22 +253,12 @@ describe("FinalizationJob", () => {
 
     it("updates resolution candidate status to ACCEPTED", async () => {
       const candidates = [makeCandidate({ id: "cand-1" })];
-      const create = vi.fn().mockResolvedValue({ id: "resolution-1" });
-      const update = vi.fn().mockResolvedValue({});
-      const updateMany = vi.fn().mockResolvedValue({ count: 2 });
-      const updateCandidate = vi.fn().mockResolvedValue({});
+      const { tx, updateCandidate } = makeTx();
       const transaction = vi
         .fn()
         .mockImplementation(
-          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
-            const tx = {
-              resolution: { create },
-              market: { update },
-              resolutionCandidate: { update: updateCandidate },
-              userPosition: { updateMany },
-            };
-            return await fn(tx);
-          }
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
         );
       const prisma = {
         resolutionCandidate: {
@@ -283,22 +278,12 @@ describe("FinalizationJob", () => {
 
     it("settles UserPosition records for the market", async () => {
       const candidates = [makeCandidate({ marketId: "mkt-1" })];
-      const create = vi.fn().mockResolvedValue({ id: "resolution-1" });
-      const update = vi.fn().mockResolvedValue({});
-      const updateMany = vi.fn().mockResolvedValue({ count: 3 });
-      const updateCandidate = vi.fn().mockResolvedValue({});
+      const { tx, positionUpdateMany } = makeTx();
       const transaction = vi
         .fn()
         .mockImplementation(
-          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
-            const tx = {
-              resolution: { create },
-              market: { update },
-              resolutionCandidate: { update: updateCandidate },
-              userPosition: { updateMany },
-            };
-            return await fn(tx);
-          }
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
         );
       const prisma = {
         resolutionCandidate: {
@@ -310,7 +295,7 @@ describe("FinalizationJob", () => {
       const job = new FinalizationJob(prisma, makeLogger(), makeConfig(3600));
       await job.run();
 
-      expect(updateMany).toHaveBeenCalledWith({
+      expect(positionUpdateMany).toHaveBeenCalledWith({
         where: { marketId: "mkt-1" },
         data: { isSettled: true },
       });
@@ -351,22 +336,12 @@ describe("FinalizationJob", () => {
 
     it("sets resolutionTime on the market", async () => {
       const candidates = [makeCandidate()];
-      const create = vi.fn().mockResolvedValue({ id: "resolution-1" });
-      const update = vi.fn().mockResolvedValue({});
-      const updateMany = vi.fn().mockResolvedValue({ count: 2 });
-      const updateCandidate = vi.fn().mockResolvedValue({});
+      const { tx, marketUpdateMany } = makeTx();
       const transaction = vi
         .fn()
         .mockImplementation(
-          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
-            const tx = {
-              resolution: { create },
-              market: { update },
-              resolutionCandidate: { update: updateCandidate },
-              userPosition: { updateMany },
-            };
-            return await fn(tx);
-          }
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
         );
       const prisma = {
         resolutionCandidate: {
@@ -378,12 +353,104 @@ describe("FinalizationJob", () => {
       const job = new FinalizationJob(prisma, makeLogger(), makeConfig(3600));
       await job.run();
 
-      expect(update).toHaveBeenCalledWith({
-        where: { id: candidates[0].marketId },
+      expect(marketUpdateMany).toHaveBeenCalledWith({
+        where: expect.objectContaining({ id: candidates[0].marketId }),
         data: expect.objectContaining({
           resolutionTime: expect.any(Date),
         }),
       });
+    });
+  });
+
+  describe("canceled/soft-deleted market handling", () => {
+    it("excludes CANCELLED and soft-deleted markets from the candidate query", async () => {
+      const findMany = vi.fn().mockResolvedValue([]);
+      const prisma = {
+        resolutionCandidate: { findMany },
+        $transaction: vi.fn(),
+      } as unknown as PrismaClient;
+
+      const job = new FinalizationJob(prisma, makeLogger(), makeConfig(3600));
+      await job.run();
+
+      expect(findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            market: {
+              status: { not: "CANCELLED" },
+              deletedAt: null,
+            },
+          }),
+        })
+      );
+    });
+
+    it("skips (not errors) a candidate whose market was canceled/deleted concurrently", async () => {
+      const candidates = [
+        makeCandidate({ id: "cand-race", marketId: "mkt-race" }),
+      ];
+      // updateMany reports 0 rows matched — the market's status/deletedAt
+      // changed between the candidate query and the transaction.
+      const { tx, updateCandidate, positionUpdateMany } = makeTx(0);
+      const transaction = vi
+        .fn()
+        .mockImplementation(
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
+        );
+      const prisma = {
+        resolutionCandidate: {
+          findMany: vi.fn().mockResolvedValue(candidates),
+        },
+        $transaction: transaction,
+      } as unknown as PrismaClient;
+
+      const logger = makeLogger();
+      const job = new FinalizationJob(prisma, logger, makeConfig(3600));
+
+      const result = await job.run();
+
+      expect(result.finalizedCount).toBe(0);
+      expect(result.erroredCount).toBe(0);
+      expect(result.skippedCount).toBe(1);
+      expect(result.candidates[0]).toMatchObject({
+        candidateId: "cand-race",
+        marketId: "mkt-race",
+        status: "skipped",
+      });
+      // Rolled back before touching the candidate or positions.
+      expect(updateCandidate).not.toHaveBeenCalled();
+      expect(positionUpdateMany).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        "Finalization candidate skipped: market canceled or deleted",
+        expect.objectContaining({
+          candidateId: "cand-race",
+          marketId: "mkt-race",
+        })
+      );
+    });
+
+    it("does not log a skipped candidate as an error", async () => {
+      const candidates = [makeCandidate({ id: "cand-race" })];
+      const { tx } = makeTx(0);
+      const transaction = vi
+        .fn()
+        .mockImplementation(
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
+        );
+      const prisma = {
+        resolutionCandidate: {
+          findMany: vi.fn().mockResolvedValue(candidates),
+        },
+        $transaction: transaction,
+      } as unknown as PrismaClient;
+
+      const logger = makeLogger();
+      const job = new FinalizationJob(prisma, logger, makeConfig(3600));
+      await job.run();
+
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 
@@ -393,22 +460,12 @@ describe("FinalizationJob", () => {
         makeCandidate({ id: "cand-1", marketId: "mkt-1" }),
         makeCandidate({ id: "cand-2", marketId: "mkt-2" }),
       ];
-      const createOk = vi.fn().mockResolvedValue({ id: "resolution-1" });
-      const updateOk = vi.fn().mockResolvedValue({});
-      const updateManyOk = vi.fn().mockResolvedValue({ count: 2 });
-      const updateCandidateOk = vi.fn().mockResolvedValue({});
+      const { tx: okTx } = makeTx();
       const transaction = vi
         .fn()
         .mockImplementationOnce(
-          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
-            const tx = {
-              resolution: { create: createOk },
-              market: { update: updateOk },
-              resolutionCandidate: { update: updateCandidateOk },
-              userPosition: { updateMany: updateManyOk },
-            };
-            return await fn(tx);
-          }
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(okTx)
         )
         .mockRejectedValueOnce(new Error("DB write failed"));
 
@@ -488,6 +545,10 @@ describe("FinalizationJob", () => {
         where: {
           status: "PROPOSED",
           createdAt: { lte: expect.any(Date) },
+          market: {
+            status: { not: "CANCELLED" },
+            deletedAt: null,
+          },
         },
         select: {
           id: true,

--- a/apps/workers/src/finalization/job.ts
+++ b/apps/workers/src/finalization/job.ts
@@ -31,6 +31,20 @@ export class FinalizationValidationError extends Error {
   }
 }
 
+/**
+ * Thrown inside the finalization transaction when the target market was
+ * canceled or soft-deleted after the candidate query ran (e.g. an admin
+ * canceled the market during the challenge window). Rolls back the
+ * transaction and is translated into a "skipped" result rather than
+ * "errored", since this is expected concurrent state, not a failure.
+ */
+class MarketNotEligibleError extends Error {
+  constructor(marketId: string) {
+    super(`Market ${marketId} is canceled or deleted; skipping finalization`);
+    this.name = "MarketNotEligibleError";
+  }
+}
+
 export class FinalizationJob {
   private readonly challengeWindowSeconds: number;
 
@@ -69,6 +83,10 @@ export class FinalizationJob {
         where: {
           status: "PROPOSED",
           createdAt: { lte: windowCutoff },
+          market: {
+            status: { not: "CANCELLED" },
+            deletedAt: null,
+          },
         },
         select: {
           id: true,
@@ -123,14 +141,22 @@ export class FinalizationJob {
             },
           });
 
-          await tx.market.update({
-            where: { id: candidate.marketId },
+          const marketUpdate = await tx.market.updateMany({
+            where: {
+              id: candidate.marketId,
+              status: { not: "CANCELLED" },
+              deletedAt: null,
+            },
             data: {
               status: "RESOLVED",
               outcome: candidate.proposedOutcome,
               resolutionTime: now,
             },
           });
+
+          if (marketUpdate.count === 0) {
+            throw new MarketNotEligibleError(candidate.marketId);
+          }
 
           await tx.resolutionCandidate.update({
             where: { id: candidate.id },
@@ -156,22 +182,40 @@ export class FinalizationJob {
           proposedOutcome: candidate.proposedOutcome,
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        if (error instanceof MarketNotEligibleError) {
+          results.push({
+            candidateId: candidate.id,
+            marketId: candidate.marketId,
+            proposedOutcome: candidate.proposedOutcome,
+            status: "skipped",
+          });
 
-        results.push({
-          candidateId: candidate.id,
-          marketId: candidate.marketId,
-          proposedOutcome: candidate.proposedOutcome,
-          status: "errored",
-          error: message,
-        });
+          this.logger.info(
+            "Finalization candidate skipped: market canceled or deleted",
+            {
+              candidateId: candidate.id,
+              marketId: candidate.marketId,
+            }
+          );
+        } else {
+          const message =
+            error instanceof Error ? error.message : String(error);
 
-        this.logger.error("Finalization candidate failed", {
-          candidateId: candidate.id,
-          marketId: candidate.marketId,
-          proposedOutcome: candidate.proposedOutcome,
-          error: message,
-        });
+          results.push({
+            candidateId: candidate.id,
+            marketId: candidate.marketId,
+            proposedOutcome: candidate.proposedOutcome,
+            status: "errored",
+            error: message,
+          });
+
+          this.logger.error("Finalization candidate failed", {
+            candidateId: candidate.id,
+            marketId: candidate.marketId,
+            proposedOutcome: candidate.proposedOutcome,
+            error: message,
+          });
+        }
       }
     }
 

--- a/apps/workers/src/oracle/submission-worker.test.ts
+++ b/apps/workers/src/oracle/submission-worker.test.ts
@@ -2,7 +2,7 @@
  * Submission Worker Tests
  */
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 vi.mock("../../../oracle/signature-helper.js", () => ({
   verifyResolutionReport: vi.fn((report: { signature?: string }) =>
@@ -24,6 +24,8 @@ const stellarMocks = vi.hoisted(() => ({
   })),
 }));
 
+// Vitest 4.x requires the `class` keyword (not an arrow function) inside
+// mockImplementation for a mock to work as a constructor via `new`.
 vi.mock("@stellar/stellar-sdk", () => ({
   Keypair: {
     fromSecret: vi.fn(() => ({
@@ -31,25 +33,28 @@ vi.mock("@stellar/stellar-sdk", () => ({
       sign: stellarMocks.sign,
     })),
   },
-  Contract: vi.fn().mockImplementation(() => ({
-    call: stellarMocks.contractCall,
-  })),
-  TransactionBuilder: vi.fn().mockImplementation(() => {
-    const builder = {
-      addOperation: vi.fn(() => builder),
-      setTimeout: vi.fn(() => builder),
-      build: vi.fn(() => ({ sign: vi.fn() })),
-    };
-    return builder;
-  }),
+  Contract: vi.fn().mockImplementation(
+    class {
+      call = stellarMocks.contractCall;
+    }
+  ),
+  TransactionBuilder: vi.fn().mockImplementation(
+    class {
+      addOperation = vi.fn().mockReturnThis();
+      setTimeout = vi.fn().mockReturnThis();
+      build = vi.fn(() => ({ sign: vi.fn() }));
+    }
+  ),
   nativeToScVal: vi.fn((value: unknown) => value),
   rpc: {
-    Server: vi.fn().mockImplementation(() => ({
-      getAccount: stellarMocks.getAccount,
-      prepareTransaction: stellarMocks.prepareTransaction,
-      sendTransaction: stellarMocks.sendTransaction,
-      getTransaction: stellarMocks.getTransaction,
-    })),
+    Server: vi.fn().mockImplementation(
+      class {
+        getAccount = stellarMocks.getAccount;
+        prepareTransaction = stellarMocks.prepareTransaction;
+        sendTransaction = stellarMocks.sendTransaction;
+        getTransaction = stellarMocks.getTransaction;
+      }
+    ),
     Api: {
       GetTransactionStatus: {
         SUCCESS: "SUCCESS",
@@ -417,9 +422,9 @@ describe("SubmissionWorker", () => {
         }
       );
 
-      await expect(
-        stellarWorker.processSubmission(submission)
-      ).rejects.toThrow(/resolve_market submission failed/);
+      await expect(stellarWorker.processSubmission(submission)).rejects.toThrow(
+        /resolve_market submission failed/
+      );
 
       expect(stellarMocks.getTransaction).not.toHaveBeenCalled();
       expect(mockQueue.nack).toHaveBeenCalled();
@@ -454,11 +459,101 @@ describe("SubmissionWorker", () => {
         }
       );
 
-      await expect(
-        stellarWorker.processSubmission(submission)
-      ).rejects.toThrow(/resolve_market transaction failed on-chain/);
+      await expect(stellarWorker.processSubmission(submission)).rejects.toThrow(
+        /resolve_market transaction failed on-chain/
+      );
 
       expect(mockQueue.nack).toHaveBeenCalled();
+    });
+  });
+
+  describe("Stellar RPC retry/backoff", () => {
+    let stellarWorker: SubmissionWorker;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      stellarWorker = new SubmissionWorker(
+        mockQueue as any,
+        mockPrisma as any,
+        {
+          submissionMaxRetries: 3,
+          consumerName: "test-consumer",
+          logger: mockLogger,
+          stellar: TEST_STELLAR_CONFIG,
+        }
+      );
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("retries a transient getAccount failure in place and still succeeds", async () => {
+      const submission = createTestSubmission();
+      stellarMocks.getAccount
+        .mockRejectedValueOnce(new Error("ECONNRESET: connection reset"))
+        .mockResolvedValueOnce({ accountId: () => "GSOURCEACCOUNT" });
+      stellarMocks.prepareTransaction.mockResolvedValueOnce({ sign: vi.fn() });
+      stellarMocks.sendTransaction.mockResolvedValueOnce({
+        status: "PENDING",
+        hash: "txhash-retry",
+      });
+      stellarMocks.getTransaction.mockResolvedValueOnce({
+        status: "SUCCESS",
+        ledger: 1,
+      });
+      mockPrisma.oracleReport.create.mockResolvedValueOnce({ id: "report-1" });
+      mockPrisma.resolutionCandidate.upsert.mockResolvedValueOnce({
+        id: "candidate-1",
+      });
+      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
+
+      const processPromise = stellarWorker.processSubmission(submission);
+      await vi.runAllTimersAsync();
+      await processPromise;
+
+      expect(stellarMocks.getAccount).toHaveBeenCalledTimes(2);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Retrying Stellar RPC call for resolve_market",
+        expect.objectContaining({
+          marketId: submission.request.marketId,
+          attempt: 1,
+        })
+      );
+    });
+
+    it("does not retry a non-retryable (4xx-classified) failure", async () => {
+      const submission = createTestSubmission();
+      stellarMocks.getAccount.mockRejectedValue(
+        new Error("400 Bad Request: invalid account")
+      );
+      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockQueue.nack.mockResolvedValueOnce(undefined);
+
+      const processPromise = stellarWorker.processSubmission(submission);
+      const expectation =
+        expect(processPromise).rejects.toThrow("400 Bad Request");
+      await vi.runAllTimersAsync();
+      await expectation;
+
+      expect(stellarMocks.getAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives up and rejects after exhausting retries on a persistent transient failure", async () => {
+      const submission = createTestSubmission();
+      stellarMocks.getAccount.mockRejectedValue(
+        new Error("ECONNRESET: connection reset")
+      );
+      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockQueue.nack.mockResolvedValueOnce(undefined);
+
+      const processPromise = stellarWorker.processSubmission(submission);
+      const expectation = expect(processPromise).rejects.toThrow("ECONNRESET");
+      await vi.runAllTimersAsync();
+      await expectation;
+
+      // maxRetries: 3 => 1 initial attempt + 3 retries = 4 calls total.
+      expect(stellarMocks.getAccount).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/apps/workers/src/oracle/submission-worker.ts
+++ b/apps/workers/src/oracle/submission-worker.ts
@@ -30,6 +30,16 @@ import {
   logDeadLetter,
   type DeadLetterMessage,
 } from "../consumers/dead-letter.js";
+import { withRetry } from "../../../oracle/retry-utils.js";
+
+/** Retry config for individual Stellar RPC calls (getAccount, prepareTransaction,
+ *  sendTransaction). Bounded and short-lived so a transient RPC blip is absorbed
+ *  in place instead of burning one of the submission's limited job-level retries. */
+const STELLAR_RPC_RETRY_CONFIG = {
+  maxRetries: 3,
+  initialDelayMs: 500,
+  maxDelayMs: 5_000,
+};
 
 export interface OracleStellarConfig {
   rpcUrl: string;
@@ -218,7 +228,20 @@ export class SubmissionWorker {
     const server = new StellarRpc.Server(rpcUrl);
     const contract = new Contract(contractId);
 
-    const sourceAccount = await server.getAccount(keypair.publicKey());
+    const onRpcRetry = (error: Error, attempt: number, delayMs: number) => {
+      this.logger.warn("Retrying Stellar RPC call for resolve_market", {
+        marketId: report.payload.marketId,
+        attempt,
+        delayMs,
+        error: error.message,
+      });
+    };
+
+    const sourceAccount = await withRetry(
+      () => server.getAccount(keypair.publicKey()),
+      STELLAR_RPC_RETRY_CONFIG,
+      onRpcRetry
+    );
 
     const args: xdr.ScVal[] = [
       nativeToScVal(report.payload.marketId, { type: "string" }),
@@ -235,10 +258,18 @@ export class SubmissionWorker {
       .setTimeout(30)
       .build();
 
-    const preparedTx = await server.prepareTransaction(tx);
+    const preparedTx = await withRetry(
+      () => server.prepareTransaction(tx),
+      STELLAR_RPC_RETRY_CONFIG,
+      onRpcRetry
+    );
     preparedTx.sign(keypair);
 
-    const sendResult = await server.sendTransaction(preparedTx);
+    const sendResult = await withRetry(
+      () => server.sendTransaction(preparedTx),
+      STELLAR_RPC_RETRY_CONFIG,
+      onRpcRetry
+    );
 
     if (sendResult.status === "ERROR") {
       throw new Error(

--- a/apps/workers/src/settlement/settlement-worker.test.ts
+++ b/apps/workers/src/settlement/settlement-worker.test.ts
@@ -533,4 +533,83 @@ describe("SettlementWorker — Stellar SDK invoke (executeOnChain)", () => {
     await vi.runAllTimersAsync();
     await expectation;
   });
+
+  describe("Stellar RPC retry/backoff", () => {
+    const retryJob: QueueJob = {
+      id: "job-stellar-retry",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-retry-001",
+        marketId: "market-001",
+        outcome: "YES",
+        buyOrderId: "buy-r",
+        sellOrderId: "sell-r",
+        buyerAddress: "GBUYER111111111111111111111111111111111111111111111111",
+        sellerAddress: "GSELLER11111111111111111111111111111111111111111111111",
+        price: "0.50",
+        quantity: "10",
+        timestamp: "1700000005000",
+      },
+    };
+
+    it("retries a transient getAccount failure in place and still succeeds", async () => {
+      mockGetAccount
+        .mockRejectedValueOnce(new Error("ECONNRESET: connection reset"))
+        .mockResolvedValueOnce({ id: "mock-account" });
+
+      const processPromise = stellarWorker.process(retryJob);
+      await vi.runAllTimersAsync();
+      await processPromise;
+
+      expect(mockGetAccount).toHaveBeenCalledTimes(2);
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Retrying Stellar RPC call for settle_trade",
+        expect.objectContaining({
+          tradeId: "trade-retry-001",
+          attempt: 1,
+        })
+      );
+      expect(mockSendTransaction).toHaveBeenCalled();
+    });
+
+    it("retries a transient sendTransaction failure in place and still succeeds", async () => {
+      mockSendTransaction
+        .mockRejectedValueOnce(new Error("ETIMEDOUT: RPC timed out"))
+        .mockResolvedValueOnce({ status: "PENDING", hash: "abc123txhash" });
+
+      const processPromise = stellarWorker.process(retryJob);
+      await vi.runAllTimersAsync();
+      await processPromise;
+
+      expect(mockSendTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not retry a non-retryable (4xx-classified) failure", async () => {
+      mockGetAccount.mockRejectedValue(
+        new Error("400 Bad Request: invalid account")
+      );
+
+      const processPromise = stellarWorker.process(retryJob);
+      const expectation =
+        expect(processPromise).rejects.toThrow("400 Bad Request");
+      await vi.runAllTimersAsync();
+      await expectation;
+
+      expect(mockGetAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives up and rejects after exhausting retries on a persistent transient failure", async () => {
+      mockGetAccount.mockRejectedValue(
+        new Error("ECONNRESET: connection reset")
+      );
+
+      const processPromise = stellarWorker.process(retryJob);
+      const expectation = expect(processPromise).rejects.toThrow("ECONNRESET");
+      await vi.runAllTimersAsync();
+      await expectation;
+
+      // maxRetries: 3 => 1 initial attempt + 3 retries = 4 calls total.
+      expect(mockGetAccount).toHaveBeenCalledTimes(4);
+    });
+  });
 });

--- a/apps/workers/src/settlement/settlement-worker.ts
+++ b/apps/workers/src/settlement/settlement-worker.ts
@@ -13,6 +13,16 @@ import {
   type QueueConsumerConfig,
 } from "../consumers/queue-consumer.js";
 import { logDeadLetter } from "../consumers/dead-letter.js";
+import { withRetry } from "../../../oracle/retry-utils.js";
+
+/** Retry config for individual Stellar RPC calls (getAccount, prepareTransaction,
+ *  sendTransaction). Bounded and short-lived so a transient RPC blip is absorbed
+ *  in place instead of burning one of the settlement job's limited queue retries. */
+const STELLAR_RPC_RETRY_CONFIG = {
+  maxRetries: 3,
+  initialDelayMs: 500,
+  maxDelayMs: 5_000,
+};
 
 export interface SettlementJobPayload {
   tradeId: string;
@@ -136,7 +146,20 @@ export class SettlementWorker {
     const server = new StellarRpc.Server(rpcUrl);
     const contract = new Contract(contractId);
 
-    const sourceAccount = await server.getAccount(keypair.publicKey());
+    const onRpcRetry = (error: Error, attempt: number, delayMs: number) => {
+      this.logger.warn("Retrying Stellar RPC call for settle_trade", {
+        tradeId: payload.tradeId,
+        attempt,
+        delayMs,
+        error: error.message,
+      });
+    };
+
+    const sourceAccount = await withRetry(
+      () => server.getAccount(keypair.publicKey()),
+      STELLAR_RPC_RETRY_CONFIG,
+      onRpcRetry
+    );
 
     const outcomeScVal = nativeToScVal(payload.outcome === "YES", {
       type: "bool",
@@ -161,10 +184,18 @@ export class SettlementWorker {
       .setTimeout(30)
       .build();
 
-    const preparedTx = await server.prepareTransaction(tx);
+    const preparedTx = await withRetry(
+      () => server.prepareTransaction(tx),
+      STELLAR_RPC_RETRY_CONFIG,
+      onRpcRetry
+    );
     preparedTx.sign(keypair);
 
-    const sendResult = await server.sendTransaction(preparedTx);
+    const sendResult = await withRetry(
+      () => server.sendTransaction(preparedTx),
+      STELLAR_RPC_RETRY_CONFIG,
+      onRpcRetry
+    );
 
     if (sendResult.status === "ERROR") {
       throw new Error(

--- a/src/api/routes/fills.test.ts
+++ b/src/api/routes/fills.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi } from "vitest";
+import fastify from "fastify";
+import { fillsRoutes, parseResumeCursor } from "./fills";
+import { errorHandler } from "../middleware/errorHandler";
+
+const VALID_WALLET = "GINJ46CDSMNOSKETX3K5DU44435TGRWIQEM7ZVI3ON3BTOOFVJJHTWXO";
+
+const mockPrisma = {
+  trade: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+};
+
+vi.mock("../../services/prisma", () => ({
+  getPrismaClient: () => mockPrisma,
+  disconnectPrisma: vi.fn(),
+}));
+
+vi.mock("../../matching/validation", () => ({
+  validateUserAddress: (addr: string) =>
+    /^G[A-Z2-7]{55}$/.test(addr) ? null : "Invalid Stellar address",
+  STELLAR_PUBLIC_KEY_REGEX: /^G[A-Z2-7]{55}$/,
+}));
+
+vi.mock("../middleware/rateLimiter", () => ({
+  heavyReadLimiter: async () => {},
+}));
+
+describe("parseResumeCursor", () => {
+  it("returns null when neither header nor query param is set", () => {
+    expect(parseResumeCursor(undefined, undefined)).toBeNull();
+  });
+
+  it("prefers Last-Event-ID header over the since query param", () => {
+    const result = parseResumeCursor(
+      "2026-01-01T00:00:00.000Z",
+      "2025-01-01T00:00:00.000Z"
+    );
+    expect(result?.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("falls back to the since query param when no header is present", () => {
+    const result = parseResumeCursor(undefined, "2026-02-02T00:00:00.000Z");
+    expect(result?.toISOString()).toBe("2026-02-02T00:00:00.000Z");
+  });
+
+  it("takes the first value when Last-Event-ID is sent as an array", () => {
+    const result = parseResumeCursor(
+      ["2026-03-03T00:00:00.000Z", "2026-04-04T00:00:00.000Z"],
+      undefined
+    );
+    expect(result?.toISOString()).toBe("2026-03-03T00:00:00.000Z");
+  });
+
+  it("returns null for an unparseable cursor instead of throwing", () => {
+    expect(parseResumeCursor("not-a-date", undefined)).toBeNull();
+  });
+
+  it("returns null for an empty string cursor", () => {
+    expect(parseResumeCursor("", "")).toBeNull();
+  });
+});
+
+describe("Fills stream route", () => {
+  // The route never calls reply.raw.end() itself — it relies on the real
+  // socket tearing down both sides of the connection together when the
+  // client disconnects. light-my-request's mock req/res aren't linked that
+  // way, so tests capture the mock request via a hook and destroy it
+  // manually to simulate the client disconnecting (equivalent to the
+  // request.raw "close" event a real disconnect would fire) and let the
+  // route's cleanup (clearInterval) run before the test ends.
+  const createTestServer = async () => {
+    const app = fastify();
+    app.setErrorHandler(errorHandler);
+    let capturedRequest: { destroy: () => void } | undefined;
+    app.addHook("onRequest", async (request) => {
+      capturedRequest = request.raw as unknown as { destroy: () => void };
+    });
+    await app.register(fillsRoutes);
+    return { app, getCapturedRequest: () => capturedRequest };
+  };
+
+  it("returns 400 for an invalid wallet address", async () => {
+    const { app } = await createTestServer();
+    const response = await app.inject({
+      method: "GET",
+      url: "/wallets/0xInvalidAddress/fills/stream",
+    });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("starts the stream at 'now' on a fresh connection (no resume cursor)", async () => {
+    const { app, getCapturedRequest } = await createTestServer();
+    const beforeConnect = Date.now();
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/wallets/${VALID_WALLET}/fills/stream`,
+      payloadAsStream: true,
+    });
+
+    expect(response.headers["content-type"]).toContain("text/event-stream");
+
+    const connectedEvent = await readFirstSseEvent(response.stream());
+    await disconnect(getCapturedRequest());
+
+    expect(connectedEvent.wallet).toBe(VALID_WALLET);
+    expect(new Date(connectedEvent.since).getTime()).toBeGreaterThanOrEqual(
+      beforeConnect
+    );
+  });
+
+  it("resumes from the Last-Event-ID header instead of resetting to now", async () => {
+    const { app, getCapturedRequest } = await createTestServer();
+    const cursor = "2026-01-01T00:00:00.000Z";
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/wallets/${VALID_WALLET}/fills/stream`,
+      headers: { "last-event-id": cursor },
+      payloadAsStream: true,
+    });
+
+    const connectedEvent = await readFirstSseEvent(response.stream());
+    await disconnect(getCapturedRequest());
+
+    expect(connectedEvent.since).toBe(cursor);
+  });
+
+  it("resumes from the ?since= query param when no header is present", async () => {
+    const { app, getCapturedRequest } = await createTestServer();
+    const cursor = "2026-02-02T00:00:00.000Z";
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/wallets/${VALID_WALLET}/fills/stream?since=${encodeURIComponent(cursor)}`,
+      payloadAsStream: true,
+    });
+
+    const connectedEvent = await readFirstSseEvent(response.stream());
+    await disconnect(getCapturedRequest());
+
+    expect(connectedEvent.since).toBe(cursor);
+  });
+
+  it("falls back to now for an unparseable resume cursor instead of erroring", async () => {
+    const { app, getCapturedRequest } = await createTestServer();
+    const beforeConnect = Date.now();
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/wallets/${VALID_WALLET}/fills/stream`,
+      headers: { "last-event-id": "not-a-valid-timestamp" },
+      payloadAsStream: true,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const connectedEvent = await readFirstSseEvent(response.stream());
+    await disconnect(getCapturedRequest());
+
+    expect(new Date(connectedEvent.since).getTime()).toBeGreaterThanOrEqual(
+      beforeConnect
+    );
+  });
+});
+
+/** Destroys the mock request to fire "close", then yields a couple of ticks
+ *  so the route's request.raw.on("close") handler runs and clears its
+ *  timers before the test ends. */
+async function disconnect(
+  request: { destroy: () => void } | undefined
+): Promise<void> {
+  request?.destroy();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+/** Reads only the first SSE message from the stream (up to the first blank
+ *  line) instead of waiting for the stream to end, since this route's
+ *  stream never ends on its own within a test. */
+function readFirstSseEvent(stream: NodeJS.ReadableStream): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let buffer = "";
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString("utf-8");
+      const idx = buffer.indexOf("\n\n");
+      if (idx !== -1) {
+        cleanup();
+        resolve(parseSseEvent(buffer.slice(0, idx) + "\n\n", "connected"));
+      }
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const cleanup = () => {
+      stream.removeListener("data", onData);
+      stream.removeListener("error", onError);
+    };
+    stream.on("data", onData);
+    stream.on("error", onError);
+  });
+}
+
+function parseSseEvent(body: string, eventName: string): any {
+  const messages = body.split("\n\n").filter(Boolean);
+  for (const message of messages) {
+    const lines = message.split("\n");
+    const eventLine = lines.find((l) => l.startsWith("event: "));
+    if (eventLine?.slice("event: ".length) === eventName) {
+      const dataLine = lines.find((l) => l.startsWith("data: "));
+      return JSON.parse(dataLine?.slice("data: ".length) ?? "{}");
+    }
+  }
+  return undefined;
+}

--- a/src/api/routes/fills.ts
+++ b/src/api/routes/fills.ts
@@ -20,6 +20,37 @@ interface FillStreamParams {
   wallet: string;
 }
 
+interface FillStreamQuerystring {
+  /** Explicit resume cursor (ISO timestamp), used when a client cannot set
+   *  request headers (e.g. EventSource does not expose Last-Event-ID on the
+   *  initial connect). Ignored if the Last-Event-ID header is present. */
+  since?: string;
+}
+
+/**
+ * Resolves the cursor a reconnecting client should resume from, so fills
+ * that occurred during a disconnect gap are not silently dropped.
+ *
+ * Browsers' native EventSource automatically resends the last received
+ * event's `id:` field as the `Last-Event-ID` header on reconnect, so that
+ * takes priority. The `?since=` query param is a fallback for clients that
+ * can't set headers. Falls back to `null` (caller should use "now") for a
+ * fresh connection or an unparseable cursor.
+ */
+export function parseResumeCursor(
+  lastEventIdHeader: string | string[] | undefined,
+  sinceQuery: string | undefined
+): Date | null {
+  const raw = Array.isArray(lastEventIdHeader)
+    ? lastEventIdHeader[0]
+    : (lastEventIdHeader ?? sinceQuery);
+
+  if (!raw) return null;
+
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
 export interface OrderFillEvent {
   tradeId: string;
   marketId: string;
@@ -38,7 +69,7 @@ export async function fillsRoutes(fastify: FastifyInstance) {
   // Server-Sent Events stream of order fill notifications for a wallet.
   // Only fills that occur after the client connects are pushed — historical
   // fills are already served by GET /trades/user/:address.
-  fastify.get<{ Params: FillStreamParams }>(
+  fastify.get<{ Params: FillStreamParams; Querystring: FillStreamQuerystring }>(
     "/wallets/:wallet/fills/stream",
     {
       onRequest: [heavyReadLimiter],
@@ -53,9 +84,21 @@ export async function fillsRoutes(fastify: FastifyInstance) {
             },
           },
         },
+        querystring: {
+          type: "object",
+          properties: {
+            since: { type: "string" },
+          },
+        },
       },
     },
-    async (request: FastifyRequest<{ Params: FillStreamParams }>, reply) => {
+    async (
+      request: FastifyRequest<{
+        Params: FillStreamParams;
+        Querystring: FillStreamQuerystring;
+      }>,
+      reply
+    ) => {
       const { wallet } = request.params;
 
       const addressError = validateUserAddress(wallet);
@@ -71,10 +114,17 @@ export async function fillsRoutes(fastify: FastifyInstance) {
         "X-Accel-Buffering": "no",
       });
 
-      let since = new Date();
+      let since =
+        parseResumeCursor(
+          request.headers["last-event-id"],
+          request.query.since
+        ) ?? new Date();
 
-      const sendEvent = (event: string, data: unknown) => {
-        reply.raw.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+      const sendEvent = (event: string, data: unknown, id?: string) => {
+        const idLine = id ? `id: ${id}\n` : "";
+        reply.raw.write(
+          `${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+        );
       };
 
       sendEvent("connected", { wallet, since: since.toISOString() });
@@ -111,7 +161,7 @@ export async function fillsRoutes(fastify: FastifyInstance) {
             quantity: fill.quantity,
             tradedAt: fill.tradedAt.toISOString(),
           };
-          sendEvent("order_fill", event);
+          sendEvent("order_fill", event, fill.tradedAt.toISOString());
         }
       };
 

--- a/src/services/redis.test.ts
+++ b/src/services/redis.test.ts
@@ -157,6 +157,37 @@ describe("RedisService", () => {
       const isHealthy = await redis.healthCheck();
       expect(isHealthy).toBe(true);
     });
+
+    it("should reconnect for del/exists after a disconnect (regression: stale connectionPromise)", async () => {
+      const testKey = "test:reconnect:del-exists";
+      await redis.set(testKey, "value");
+      await redis.disconnect();
+
+      // Both del and exists must re-establish the connection rather than
+      // throwing on a null client or awaiting a stale, already-resolved
+      // connectionPromise left over from the previous connection.
+      const existed = await redis.exists(testKey);
+      expect(existed).toBe(true);
+
+      await redis.del(testKey);
+      const stillExists = await redis.exists(testKey);
+      expect(stillExists).toBe(false);
+    });
+
+    it("should not reuse a stale connectionPromise after disconnect", async () => {
+      await redis.healthCheck();
+      await redis.disconnect();
+
+      // Fire two operations concurrently right after disconnect — neither
+      // should throw on a null client, and both should observe a live
+      // connection rather than racing a stale promise.
+      const [existed, healthy] = await Promise.all([
+        redis.exists("test:concurrent-after-disconnect"),
+        redis.healthCheck(),
+      ]);
+      expect(existed).toBe(false);
+      expect(healthy).toBe(true);
+    });
   });
 
   describe("error handling", () => {

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -88,21 +88,25 @@ class RedisService {
   }
 
   /**
-   * Get or create Redis client instance with proper async connection handling
+   * Get the current Redis client instance. Callers must await ensureConnected()
+   * first — this only returns whatever client is currently set.
    */
   private getClient(): Redis {
-    if (!this.client) {
-      // Connection not attempted or failed; initiate new connection attempt
-      this.connectionPromise = this.connect();
-    }
     return this.client!;
   }
 
   /**
-   * Wait for Redis connection to be established
+   * Wait for Redis connection to be established, (re)initiating a connection
+   * attempt if none is in flight. This must be called before getClient() in
+   * every method — a dropped connection (see onClose) nulls both this.client
+   * and this.connectionPromise, so without this check getClient() would kick
+   * off a new connection but return null before it resolves.
    */
   private async ensureConnected(): Promise<void> {
-    if (this.connectionPromise) {
+    if (!this.client) {
+      if (!this.connectionPromise) {
+        this.connectionPromise = this.connect();
+      }
       await this.connectionPromise;
     }
   }
@@ -237,6 +241,7 @@ class RedisService {
    */
   async del(key: string): Promise<void> {
     try {
+      await this.ensureConnected();
       await this.getClient().del(key);
     } catch (error) {
       console.error({ service: "redis", key, err: error }, "Redis DEL failed");
@@ -249,6 +254,7 @@ class RedisService {
    */
   async exists(key: string): Promise<boolean> {
     try {
+      await this.ensureConnected();
       const result = await this.getClient().exists(key);
       return result === 1;
     } catch (error) {
@@ -316,6 +322,7 @@ class RedisService {
   async clearOrderBook(marketId: string): Promise<void> {
     const pattern = `${this.keyPrefix}orderbook:${marketId}:*`;
     try {
+      await this.ensureConnected();
       const keys = await this.getClient().keys(pattern);
       if (keys.length > 0) {
         await this.getClient().del(...keys);
@@ -355,6 +362,7 @@ class RedisService {
     if (this.client) {
       await this.client.quit();
       this.client = null;
+      this.connectionPromise = null;
       this.retryCount = 0;
       console.info({ service: "redis" }, "Redis disconnected gracefully");
     }
@@ -371,6 +379,7 @@ class RedisService {
     options?: { MKSTREAM?: boolean }
   ): Promise<string | void> {
     try {
+      await this.ensureConnected();
       const client = this.getClient();
       const args = [subcommand, key, groupName, id];
       if (options?.MKSTREAM) {
@@ -412,6 +421,7 @@ class RedisService {
     limit?: string
   ): Promise<Array<[string, string[]]>> {
     try {
+      await this.ensureConnected();
       if (countArg && limit) {
         return await this.getClient().xrange(key, start, end, countArg, limit);
       } else {
@@ -437,6 +447,7 @@ class RedisService {
     limit?: string
   ): Promise<Array<[string, string[]]>> {
     try {
+      await this.ensureConnected();
       if (countArg && limit) {
         return await this.getClient().xrevrange(
           key,
@@ -468,6 +479,7 @@ class RedisService {
     options?: { COUNT?: number; BLOCK?: number }
   ): Promise<Array<[string, Array<[string, string[]]>]>> {
     try {
+      await this.ensureConnected();
       const client = this.getClient();
       const args = ["GROUP", groupName, consumerName];
       if (options?.COUNT) {
@@ -496,6 +508,7 @@ class RedisService {
     ...messageIds: string[]
   ): Promise<number> {
     try {
+      await this.ensureConnected();
       const client = this.getClient();
       return await (client.xack as any)(streamKey, groupName, ...messageIds);
     } catch (error) {
@@ -515,6 +528,7 @@ class RedisService {
     ...messageIds: string[]
   ): Promise<Array<[string, string[]]>> {
     try {
+      await this.ensureConnected();
       const client = this.getClient();
       const args = [
         streamKey,
@@ -535,6 +549,7 @@ class RedisService {
    */
   async xinfo(subcommand: "STREAM", key: string): Promise<any> {
     try {
+      await this.ensureConnected();
       return await this.getClient().xinfo(subcommand, key);
     } catch (error) {
       console.error(


### PR DESCRIPTION


Closes #759, 
closes #760 
closes  #761 
closes #762 

## Summary

four "reliability pass" tickets. Since all four issues were template-generated with no concrete scope, I investigated the codebase for genuine reliability gaps in the areas the recent commit history was already touching (oracle price feeds, trade/position reconciliation, market lifecycle) and picked the four most concrete, independently-shippable fixes.

### #759 — Redis connection readiness race (`src/services/redis.ts`)
- Every `RedisService` method now awaits `ensureConnected()` before calling `getClient()`. Previously only 4 of 12 methods did this — `del`/`exists` were missed, and those are exactly the calls backing the settlement idempotency check (`settlement-worker.ts`) and the oracle-submission dedup lock (`redis-submission-queue.ts`). A reconnect blip on those paths could throw on a null client instead of waiting for reconnection.
- Fixed `disconnect()` leaving a stale, already-resolved `connectionPromise` behind after nulling `client`. This silently broke reconnection after a manual disconnect — confirmed by reverting the fix and watching 13 existing tests fail.
- Added regression tests for both.

### #760 — FinalizationJob doesn't respect canceled/soft-deleted markets (`apps/workers/src/finalization/job.ts`)
- The resolution-candidate query now excludes markets with `status: CANCELLED` or a non-null `deletedAt` (soft-delete landed in this same area recently).
- Defense in depth: the finalization transaction itself re-checks eligibility via a guarded `updateMany` (instead of an unconditional `update`) right before writing, so a market canceled *during* the challenge window — after the initial query ran — is rolled back and recorded as `"skipped"` rather than silently finalized with its positions marked settled.
- Added tests for the query filter and the concurrent-cancellation race.

### #761 — Fill-stream SSE has no reconnect/resume support (`src/api/routes/fills.ts`)
- The stream's cursor (`since`) no longer resets to `new Date()` on every connect. It now resumes from the `Last-Event-ID` header (which browsers' native `EventSource` automatically resends on reconnect) or a `?since=` query param fallback for non-browser clients — so a client reconnecting after a network blip doesn't silently lose fills that occurred during the gap.
- Each `order_fill` event now carries an `id:` line (the trade's `tradedAt` timestamp) to make this resumable.
- Added a full test file — this route had no test coverage before.

### #762 — No retry/backoff on Stellar RPC calls (`submission-worker.ts`, `settlement-worker.ts`)
- `getAccount`, `prepareTransaction`, and `sendTransaction` now go through the existing `withRetry` helper (already used by the oracle HTTP adapters), so a transient RPC blip is retried in place instead of consuming one of the job's limited top-level retries.
- Added retry/backoff tests to both workers. Along the way, fixed a pre-existing Vitest 4.x mock bug in `submission-worker.test.ts` (arrow-function `mockImplementation` doesn't work as a `new`-able constructor under this Vitest version — `settlement-worker.test.ts` already used the correct `class`-based pattern) that was silently breaking 3 unrelated tests in that file.

## Test plan

- [x] Ran the full suite against real local Postgres + Redis containers (not mocked): baseline (`dev`) was 71 failing / 1148 passing; this branch is 48 failing / 1183 passing — no regressions, and the remaining failures are pre-existing/unrelated (mostly a recent soft-delete migration not yet reflected in some route test mocks).
- [x] For each fix, reverted it locally and confirmed the new tests fail against the old code, to make sure the tests actually catch the regression rather than passing vacuously.
- [x] `tsc --noEmit` — same 3 pre-existing unrelated errors as baseline, nothing new.
- [x] Confirmed no leaked timers/hanging test processes (checked exit time on each affected suite).

