### PR TITLE
Platform hardening: reliability pass 017-020 (closes #763-#766)

### DIFF
--- a/apps/workers/src/shared/queue-config.test.ts
+++ b/apps/workers/src/shared/queue-config.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { DEFAULT_JOB_OPTIONS, redisConnectionFromEnv } from "./queue-config.js";
+
+// Regression coverage for #764: `bullmq` was used throughout apps/workers
+// (this module, the settlement consumer, and the oracle submission queue)
+// without ever being declared as a dependency in package.json. A clean
+// `pnpm install` silently dropped it from node_modules, breaking the
+// settlement and oracle-submission workers at startup with
+// "Cannot find module 'bullmq'". Importing it here fails the same way if
+// the dependency ever goes undeclared again.
+describe("queue-config", () => {
+  it("resolves bullmq's JobsOptions type and exposes unified retry/backoff/DLQ defaults", () => {
+    expect(DEFAULT_JOB_OPTIONS).toEqual({
+      attempts: 3,
+      backoff: { type: "exponential", delay: 1_000 },
+      removeOnComplete: { count: 100 },
+      removeOnFail: false,
+    });
+  });
+
+  describe("redisConnectionFromEnv", () => {
+    const originalRedisUrl = process.env.REDIS_URL;
+
+    afterEach(() => {
+      if (originalRedisUrl === undefined) {
+        delete process.env.REDIS_URL;
+      } else {
+        process.env.REDIS_URL = originalRedisUrl;
+      }
+    });
+
+    it("defaults to localhost:6379 when REDIS_URL is unset", () => {
+      delete process.env.REDIS_URL;
+      expect(redisConnectionFromEnv()).toEqual({
+        host: "localhost",
+        port: 6379,
+      });
+    });
+
+    it("parses host and port from a plain redis:// URL", () => {
+      process.env.REDIS_URL = "redis://redis-host:6380";
+      expect(redisConnectionFromEnv()).toEqual({
+        host: "redis-host",
+        port: 6380,
+      });
+    });
+
+    it("parses password and host/port from an authenticated rediss:// URL", () => {
+      process.env.REDIS_URL = "rediss://user:secret@redis-host:6380";
+      expect(redisConnectionFromEnv()).toEqual({
+        host: "redis-host",
+        port: 6380,
+        password: "secret",
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@prisma/adapter-pg": "^7.3.0",
     "@prisma/client": "^7.2.0",
     "@stellar/stellar-sdk": "^14.4.3",
+    "bullmq": "^5.81.2",
     "dotenv": "^16.6.1",
     "fastify": "^5.7.1",
     "fastify-plugin": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 14.6.1
       bullmq:
         specifier: ^5.81.2
-        version: 5.81.2(redis@5.12.1)
+        version: 5.81.2(redis@5.12.1(@opentelemetry/api@1.9.1))
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
@@ -93,14 +93,6 @@ importers:
       vitest:
         specifier: ^4.0.17
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.0.17)(@vitest/ui@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-
-  apps/api: {}
-
-  apps/indexer: {}
-
-  apps/oracle: {}
-
-  apps/workers: {}
 
   apps/api: {}
 
@@ -1327,8 +1319,8 @@ packages:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
-  giget@3.3.0:
-    resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
+  giget@3.3.1:
+    resolution: {integrity: sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==}
     hasBin: true
 
   glob-parent@5.1.2:
@@ -1782,8 +1774,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.22:
-    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -3032,7 +3024,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bullmq@5.81.2(redis@5.12.1):
+  bullmq@5.81.2(redis@5.12.1(@opentelemetry/api@1.9.1)):
     dependencies:
       cron-parser: 4.9.0
       ioredis: 5.11.1
@@ -3041,7 +3033,7 @@ snapshots:
       semver: 7.8.5
       tslib: 2.8.1
     optionalDependencies:
-      redis: 5.12.1
+      redis: 5.12.1(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3052,7 +3044,7 @@ snapshots:
       defu: 6.1.7
       dotenv: 17.4.2
       exsolve: 1.1.0
-      giget: 3.3.0
+      giget: 3.3.1
       jiti: 2.7.0
       ohash: 2.0.11
       pathe: 2.0.3
@@ -3452,7 +3444,7 @@ snapshots:
 
   get-stream@8.0.1: {}
 
-  giget@3.3.0: {}
+  giget@3.3.1: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -3871,7 +3863,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.22:
+  postcss@8.5.23:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -4194,7 +4186,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.22
+      postcss: 8.5.23
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -248,7 +248,8 @@ export const openApiSpec = {
                   summary: "Buy YES outcome",
                   value: {
                     marketId: "mkt_01j9z3k4p2q8r5t6u7v8w9x0y1",
-                    userAddress: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+                    userAddress:
+                      "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA",
                     side: "BUY",
                     outcome: "YES",
                     price: 0.65,
@@ -259,7 +260,8 @@ export const openApiSpec = {
                   summary: "Sell NO outcome",
                   value: {
                     marketId: "mkt_01j9z3k4p2q8r5t6u7v8w9x0y1",
-                    userAddress: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+                    userAddress:
+                      "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA",
                     side: "SELL",
                     outcome: "NO",
                     price: 0.35,
@@ -280,7 +282,10 @@ export const openApiSpec = {
                     summary: "Order placed successfully",
                     value: {
                       success: true,
-                      data: { orderId: "ord_01j9z3k4p2q8r5t6u7v8w9x0y1", status: "OPEN" },
+                      data: {
+                        orderId: "ord_01j9z3k4p2q8r5t6u7v8w9x0y1",
+                        status: "OPEN",
+                      },
                       requestId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
                       timestamp: "2026-07-24T10:00:00.000Z",
                     },
@@ -321,7 +326,11 @@ export const openApiSpec = {
                 examples: {
                   unauthorized: {
                     summary: "No API key provided",
-                    value: { error: "Missing API key", code: "UNAUTHORIZED", statusCode: 401 },
+                    value: {
+                      error: "Missing API key",
+                      code: "UNAUTHORIZED",
+                      statusCode: 401,
+                    },
                   },
                 },
               },
@@ -347,7 +356,8 @@ export const openApiSpec = {
             examples: {
               valid: {
                 summary: "Valid Stellar account",
-                value: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+                value:
+                  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA",
               },
             },
           },
@@ -364,9 +374,12 @@ export const openApiSpec = {
                       success: true,
                       data: {
                         account: {
-                          accountId: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+                          accountId:
+                            "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA",
                           sequence: "987654321",
-                          balances: [{ asset_type: "native", balance: "250.0000000" }],
+                          balances: [
+                            { asset_type: "native", balance: "250.0000000" },
+                          ],
                           fetchedAt: 1753351200000,
                         },
                         source: "cache",

--- a/src/api/routes/positions.test.ts
+++ b/src/api/routes/positions.test.ts
@@ -80,6 +80,13 @@ vi.mock("../../services/prisma", () => ({
 vi.mock("../../matching/validation", () => ({
   validateUserAddress: (addr: string) =>
     /^G[A-Z2-7]{55}$/.test(addr) ? null : "Invalid Stellar address",
+  sanitizeUserAddress: (addr: unknown) =>
+    typeof addr === "string"
+      ? addr
+          .trim()
+          .toUpperCase()
+          .replace(/[\x00-\x1F\x7F]/g, "")
+      : null,
   STELLAR_PUBLIC_KEY_REGEX: /^G[A-Z2-7]{55}$/,
 }));
 

--- a/src/api/routes/positions.ts
+++ b/src/api/routes/positions.ts
@@ -257,7 +257,7 @@ export default async function positionsRouter(server: FastifyInstance) {
       }>,
       reply: FastifyReply
     ) => {
-      const { wallet } = request.params;
+      const { wallet: rawWallet } = request.params;
       const { includePnl = false } = request.query;
       const prisma = getPrismaClient();
 

--- a/src/api/routes/wallet.test.ts
+++ b/src/api/routes/wallet.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import Fastify, { type FastifyInstance } from "fastify";
+import Fastify, { type FastifyError, type FastifyInstance } from "fastify";
 import { walletRoutes } from "./wallet.js";
 
-const VALID_ACCOUNT = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+const VALID_ACCOUNT =
+  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA";
 const VALID_KEY = "test-api-key";
 
 const cachedAccount = {
@@ -24,7 +25,7 @@ vi.mock("../../services/horizonCache.js", () => ({
 function buildServer(apiKey = VALID_KEY): FastifyInstance {
   process.env.API_KEY = apiKey;
   const server = Fastify({ logger: false });
-  server.setErrorHandler((err, _req, reply) => {
+  server.setErrorHandler((err: FastifyError, _req, reply) => {
     reply.status(err.statusCode ?? 500).send({
       code: (err as any).code ?? "error",
       message: err.message,
@@ -99,7 +100,8 @@ describe("GET /v1/wallet/accounts/:accountId", () => {
 
   it("returns 404 when account is not in cache", async () => {
     server = buildServer();
-    const unknownAccount = "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON";
+    const unknownAccount =
+      "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON";
     const res = await server.inject({
       method: "GET",
       url: `/v1/wallet/accounts/${unknownAccount}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { config } from "./config.js";
 import { parseApiEnv } from "./env.js";
 import { corsPlugin } from "./api/middleware/cors.js";
 import { redis } from "./services/redis.js";
+import { walletRoutes } from "./api/routes/wallet.js";
 
 // Default: 64 KB. Override via BODY_LIMIT_BYTES env var.
 // Oversized requests are rejected with 413 Request Entity Too Large.
@@ -133,6 +134,11 @@ export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
   );
 
   registerDeprecatedAliases(server);
+
+  // walletRoutes hardcodes its own /v1 prefix internally, so it must be
+  // registered outside the /v1-scoped block above (the onRoute guard there
+  // rejects routes that already start with /v1 to prevent /v1/v1 double-prefixing).
+  server.register(walletRoutes);
 
   // Prometheus scrape endpoint, unversioned and unauthenticated by convention
   // (restrict network access to it at the infra/ingress layer).

--- a/src/services/horizonCache.test.ts
+++ b/src/services/horizonCache.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
-import { HorizonCacheService, type HorizonAccountData } from "./horizonCache.js";
+import {
+  HorizonCacheService,
+  type HorizonAccountData,
+} from "./horizonCache.js";
 
-const VALID_ACCOUNT = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+const VALID_ACCOUNT =
+  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA";
 const INVALID_ACCOUNT = "not-a-stellar-key";
 
 const sampleData: HorizonAccountData = {
@@ -17,8 +21,12 @@ vi.mock("./redis.js", () => {
   return {
     redis: {
       get: vi.fn(async (key: string) => store.get(key) ?? null),
-      set: vi.fn(async (key: string, value: string) => { store.set(key, value); }),
-      del: vi.fn(async (key: string) => { store.delete(key); }),
+      set: vi.fn(async (key: string, value: string) => {
+        store.set(key, value);
+      }),
+      del: vi.fn(async (key: string) => {
+        store.delete(key);
+      }),
       _store: store, // exposed for test assertions
     },
   };

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -102,14 +102,14 @@ class RedisService {
    * and this.connectionPromise, so without this check getClient() would kick
    * off a new connection but return null before it resolves.
    */
-  private async ensureConnected(): Promise<void> {
+  private async ensureConnected(): Promise<Redis> {
     if (!this.client) {
       if (!this.connectionPromise) {
         this.connectionPromise = this.connect();
       }
       await this.connectionPromise;
     }
-    return this.connectionPromise;
+    return this.getClient();
   }
 
   /**
@@ -323,8 +323,8 @@ class RedisService {
   async clearOrderBook(marketId: string): Promise<void> {
     const pattern = `${this.keyPrefix}orderbook:${marketId}:*`;
     try {
-      await this.ensureConnected();
-      const keys = await this.getClient().keys(pattern);
+      const client = await this.ensureConnected();
+      const keys = await client.keys(pattern);
       if (keys.length > 0) {
         await client.del(...keys);
       }
@@ -423,7 +423,7 @@ class RedisService {
     limit?: string
   ): Promise<Array<[string, string[]]>> {
     try {
-      await this.ensureConnected();
+      const client = await this.ensureConnected();
       if (countArg && limit) {
         return await client.xrange(key, start, end, countArg, limit);
       } else {
@@ -449,7 +449,7 @@ class RedisService {
     limit?: string
   ): Promise<Array<[string, string[]]>> {
     try {
-      await this.ensureConnected();
+      const client = await this.ensureConnected();
       if (countArg && limit) {
         return await client.xrevrange(key, start, end, countArg, limit);
       } else {


### PR DESCRIPTION
## Summary

Four latent, previously-undetected reliability bugs, each traced to a concrete root cause via typecheck/test audit rather than speculative changes:

- **#763** — `RedisService.clearOrderBook()`, `.xrange()`, `.xrevrange()` referenced an out-of-scope `client` variable that was never declared, throwing `ReferenceError` on every call. `ensureConnected()` was also typed `Promise<void>` while actually resolving a client, masking the bug from TypeScript.
- **#764** — `bullmq` is imported directly by the settlement consumer and oracle-submission queue (`apps/workers`) but was never declared in any `package.json`. It only "worked" via a stray, undeclared entry left in a corrupted `pnpm-lock.yaml` (duplicate YAML mapping keys under `importers`). A clean/regenerated install silently drops it, crashing both workers at startup with `Cannot find module 'bullmq'`.
- **#765** — `positions.ts`'s `GET /v1/wallets/:wallet/positions` handler had `const { wallet } = request.params;` followed immediately by `const wallet = sanitizeUserAddress(rawWallet) ?? "";` in the same block — a duplicate `const` binding referencing an undefined `rawWallet`. This is a **SyntaxError**, not a type error: the module fails to load, crashing route registration for the entire file.
- **#766** — `walletRoutes` (`GET /v1/wallet/accounts/:accountId`) is fully implemented, documented in the OpenAPI spec, and has passing unit tests — but was never imported/registered in `src/index.ts`, so the endpoint was completely unreachable on the running server. Also found and fixed a 55-character (one short of valid StrKey length) example Stellar address reused across `horizonCache.test.ts`, `wallet.test.ts`, and OpenAPI spec examples, which silently failed address validation in every test/example that used it.

## What changed

- `src/services/redis.ts` — `ensureConnected()` now returns `Promise<Redis>`; `clearOrderBook`/`xrange`/`xrevrange` capture their own client reference (#763)
- `package.json`, `pnpm-lock.yaml` — declared `bullmq` as a root dependency, regenerated a clean lockfile; added `apps/workers/src/shared/queue-config.test.ts` (previously no coverage) (#764)
- `src/api/routes/positions.ts`, `src/api/routes/positions.test.ts` — restored `const { wallet: rawWallet }` destructuring; fixed a stale test mock missing `sanitizeUserAddress` (#765)
- `src/index.ts` — registered `walletRoutes` outside the `/v1`-scoped block (it hardcodes its own `/v1` prefix, and the block's `onRoute` guard rejects nested `/v1` prefixes); `src/api/openapi.ts`, `src/api/routes/wallet.test.ts`, `src/services/horizonCache.test.ts` — fixed the invalid 55-char example address to a valid 56-char one everywhere it appeared (#766)

## Verification performed

- `pnpm build` (tsc) — clean
- `pnpm tsc --noEmit` on `src`, `apps/tsconfig.json`, `packages/tsconfig.json` — clean
- `pnpm format:check` — clean on all touched files
- `pnpm test:run` — 1318 passing (up from 1233 on `dev` pre-fix), 0 new failures
- `pnpm test:integration` — no new failures vs. baseline

## Test plan

- [x] `src/services/redis.test.ts` — existing cold-start/order-book/stream tests now pass (previously threw `ReferenceError`)
- [x] `apps/workers/src/shared/queue-config.test.ts` (new) — covers `DEFAULT_JOB_OPTIONS` and `redisConnectionFromEnv()` URL parsing; also serves as a regression guard on `bullmq` resolving as a dependency
- [x] `src/api/routes/positions.test.ts` — all 8 tests now pass (previously 0 tests ran — module failed to load)
- [x] `src/api/routes/wallet.test.ts`, `src/services/horizonCache.test.ts` — all pass with the corrected address fixture
- [x] `src/api/openapi.test.ts`, `tests/contract/openapi-routes.test.ts` — now pass now that the wallet route is actually registered



Closes #763
Closes #764
Closes #765
Closes #766