### PR TITLE
fix: platform hardening reliability pass (#751-#754)

### DIFF
--- a/apps/oracle/main.test.ts
+++ b/apps/oracle/main.test.ts
@@ -82,7 +82,7 @@ vi.mock("../workers/src/oracle/redis-submission-queue.js", () => ({
   }),
 }));
 
-import { poll } from "./main.js";
+import { poll, createOverlapGuardedPoll } from "./main.js";
 import { loadOracleConfig } from "./oracle-config.js";
 
 const RESOLVED_RESULT = {
@@ -193,5 +193,64 @@ describe("apps/oracle/main poll()", () => {
 
     await expect(poll()).rejects.toThrow("ORACLE_SECRET_KEY is required");
     expect(mockPrisma.market.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("createOverlapGuardedPoll", () => {
+  it("skips a tick that starts while a previous poll is still in flight", async () => {
+    let resolveFirst: () => void = () => {};
+    const first = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const pollFn = vi
+      .fn()
+      .mockImplementationOnce(() => first)
+      .mockImplementationOnce(() => Promise.resolve());
+
+    const guardedPoll = createOverlapGuardedPoll(pollFn, mockLogger as any);
+
+    const firstCall = guardedPoll();
+    const secondCall = guardedPoll(); // fires while the first is still pending
+
+    resolveFirst();
+    await Promise.all([firstCall, secondCall]);
+
+    expect(pollFn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Skipping oracle poll because a previous poll is active"
+    );
+  });
+
+  it("allows the next tick to run once the previous poll has completed", async () => {
+    const pollFn = vi.fn().mockResolvedValue(undefined);
+    const guardedPoll = createOverlapGuardedPoll(pollFn, mockLogger as any);
+
+    await guardedPoll();
+    await guardedPoll();
+
+    expect(pollFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("catches and logs a poll failure instead of throwing", async () => {
+    const pollFn = vi.fn().mockRejectedValue(new Error("provider down"));
+    const guardedPoll = createOverlapGuardedPoll(pollFn, mockLogger as any);
+
+    await expect(guardedPoll()).resolves.toBeUndefined();
+    expect(mockLogger.error).toHaveBeenCalledWith("Poll cycle failed", {
+      error: "provider down",
+    });
+  });
+
+  it("allows a poll to run again after a previous cycle failed", async () => {
+    const pollFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("provider down"))
+      .mockResolvedValueOnce(undefined);
+    const guardedPoll = createOverlapGuardedPoll(pollFn, mockLogger as any);
+
+    await guardedPoll();
+    await guardedPoll();
+
+    expect(pollFn).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/oracle/main.ts
+++ b/apps/oracle/main.ts
@@ -137,23 +137,51 @@ export async function poll(): Promise<void> {
   }
 }
 
+/**
+ * Wraps a poll function so overlapping invocations are skipped instead of
+ * running concurrently. If a cycle takes longer than the scheduling interval
+ * (e.g. a slow provider or many active markets), the next tick logs a
+ * warning and returns immediately rather than double-processing the same
+ * markets (duplicate provider calls, duplicate OracleReport writes).
+ * Errors from `pollFn` are caught and logged, never thrown, so a single bad
+ * cycle can't take down the setInterval loop.
+ */
+export function createOverlapGuardedPoll(
+  pollFn: () => Promise<void>,
+  logger: ReturnType<typeof createLogger>
+): () => Promise<void> {
+  let isPollInProgress = false;
+
+  return async (): Promise<void> => {
+    if (isPollInProgress) {
+      logger.warn("Skipping oracle poll because a previous poll is active");
+      return;
+    }
+    isPollInProgress = true;
+    try {
+      await pollFn();
+    } catch (err) {
+      logger.error("Poll cycle failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      isPollInProgress = false;
+    }
+  };
+}
+
 export async function bootstrap(): Promise<void> {
   const config = loadOracleConfig();
   const logger = createLogger(config.logLevel);
 
   logger.info("Oracle starting", { pollIntervalMs: config.pollIntervalMs });
 
-  // Run immediately, then on interval
+  const runPoll = createOverlapGuardedPoll(poll, logger);
+
+  // Run immediately (unguarded — fail fast on startup misconfiguration,
+  // matching the previous behavior), then on interval with overlap guarding.
   await poll();
-  const timer = setInterval(
-    () =>
-      void poll().catch((err) => {
-        logger.error("Poll cycle failed", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }),
-    config.pollIntervalMs
-  );
+  const timer = setInterval(() => void runPoll(), config.pollIntervalMs);
 
   const VALID_SHUTDOWN_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
   let isShuttingDown = false;

--- a/apps/workers/src/oracle/bullmq-submission-queue.test.ts
+++ b/apps/workers/src/oracle/bullmq-submission-queue.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for BullMQSubmissionQueue / createOracleSubmissionWorker's Redis
+ * connection error handling.
+ *
+ * BullMQ's Queue and Worker are EventEmitters that forward Redis connection
+ * errors as "error" events. Node's default EventEmitter behavior for an
+ * "error" event with no listener is to throw, crashing the process on the
+ * next transient Redis blip. These tests verify an "error" listener is
+ * registered so that no longer happens.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// A minimal EventEmitter stand-in (rather than importing Node's `events`)
+// so this stays self-contained inside vi.hoisted, whose callback runs before
+// any of this file's own imports are evaluated.
+const { mockQueueInstances, mockWorkerInstances, MockQueue, MockWorker } =
+  vi.hoisted(() => {
+    const queueInstances: any[] = [];
+    const workerInstances: any[] = [];
+
+    class MinimalEmitter {
+      private listeners: Record<string, Array<(...args: any[]) => void>> = {};
+      on(event: string, listener: (...args: any[]) => void) {
+        (this.listeners[event] ??= []).push(listener);
+        return this;
+      }
+      emit(event: string, ...args: any[]) {
+        for (const listener of this.listeners[event] ?? []) listener(...args);
+        return (this.listeners[event]?.length ?? 0) > 0;
+      }
+      listenerCount(event: string) {
+        return this.listeners[event]?.length ?? 0;
+      }
+    }
+
+    class HoistedMockQueue extends MinimalEmitter {
+      getJob = vi.fn();
+      add = vi.fn();
+      close = vi.fn();
+      constructor() {
+        super();
+        queueInstances.push(this);
+      }
+    }
+
+    class HoistedMockWorker extends MinimalEmitter {
+      close = vi.fn();
+      constructor() {
+        super();
+        workerInstances.push(this);
+      }
+    }
+
+    return {
+      mockQueueInstances: queueInstances,
+      mockWorkerInstances: workerInstances,
+      MockQueue: HoistedMockQueue,
+      MockWorker: HoistedMockWorker,
+    };
+  });
+
+vi.mock("bullmq", () => ({
+  Queue: MockQueue,
+  Worker: MockWorker,
+}));
+
+vi.mock("../shared/queue-config.js", () => ({
+  DEFAULT_JOB_OPTIONS: {},
+  redisConnectionFromEnv: () => ({ host: "localhost", port: 6379 }),
+}));
+
+import {
+  BullMQSubmissionQueue,
+  createOracleSubmissionWorker,
+} from "./bullmq-submission-queue.js";
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe("BullMQSubmissionQueue error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueueInstances.length = 0;
+    mockWorkerInstances.length = 0;
+  });
+
+  it("registers an error listener on the underlying Queue", () => {
+    new BullMQSubmissionQueue(mockLogger as any);
+
+    expect(mockQueueInstances).toHaveLength(1);
+    expect(mockQueueInstances[0].listenerCount("error")).toBeGreaterThan(0);
+  });
+
+  it("logs instead of throwing when the Queue emits an error", () => {
+    new BullMQSubmissionQueue(mockLogger as any);
+
+    const emit = () =>
+      mockQueueInstances[0].emit("error", new Error("connection reset"));
+
+    expect(emit).not.toThrow();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Oracle submission queue connection error",
+      { error: "connection reset" }
+    );
+  });
+});
+
+describe("createOracleSubmissionWorker error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueueInstances.length = 0;
+    mockWorkerInstances.length = 0;
+  });
+
+  it("registers an error listener on the underlying Worker", () => {
+    createOracleSubmissionWorker(async () => {}, mockLogger as any);
+
+    expect(mockWorkerInstances).toHaveLength(1);
+    expect(mockWorkerInstances[0].listenerCount("error")).toBeGreaterThan(0);
+  });
+
+  it("logs instead of throwing when the Worker emits an error", () => {
+    createOracleSubmissionWorker(async () => {}, mockLogger as any);
+
+    const emit = () =>
+      mockWorkerInstances[0].emit("error", new Error("ECONNRESET"));
+
+    expect(emit).not.toThrow();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Oracle submission worker connection error",
+      { error: "ECONNRESET" }
+    );
+  });
+});

--- a/apps/workers/src/oracle/bullmq-submission-queue.ts
+++ b/apps/workers/src/oracle/bullmq-submission-queue.ts
@@ -39,6 +39,15 @@ export class BullMQSubmissionQueue {
       connection: redisConnectionFromEnv(),
       defaultJobOptions: DEFAULT_JOB_OPTIONS,
     });
+
+    // BullMQ (via EventEmitter) forwards Redis connection errors as "error"
+    // events. Without a listener, Node's default EventEmitter behavior is to
+    // throw and crash the process on the very next transient Redis blip.
+    this.queue.on("error", (err: Error) => {
+      this.logger.error("Oracle submission queue connection error", {
+        error: err.message,
+      });
+    });
   }
 
   /**
@@ -111,6 +120,14 @@ export function createOracleSubmissionWorker(
       });
     }
   );
+
+  // See the matching comment in BullMQSubmissionQueue's constructor — an
+  // unhandled "error" event here would crash the whole worker process.
+  worker.on("error", (err: Error) => {
+    logger.error("Oracle submission worker connection error", {
+      error: err.message,
+    });
+  });
 
   return worker;
 }

--- a/apps/workers/src/settlement/consumer.ts
+++ b/apps/workers/src/settlement/consumer.ts
@@ -101,6 +101,16 @@ async function bootstrap(): Promise<void> {
     });
   });
 
+  // BullMQ forwards Redis connection errors as "error" events. Without a
+  // listener, Node's default EventEmitter behavior is to throw and crash
+  // the process on the next transient Redis blip.
+  worker.on("error", (err) => {
+    logger.error("Settlement worker connection error", {
+      error: err.message,
+      component: "settlement-worker",
+    });
+  });
+
   const shutdown = createShutdown(logger, {
     timeoutMs: 30_000,
     component: "settlement-worker",

--- a/src/api/routes/positions.test.ts
+++ b/src/api/routes/positions.test.ts
@@ -78,6 +78,13 @@ vi.mock("../../services/prisma", () => ({
 }));
 
 vi.mock("../../matching/validation", () => ({
+  sanitizeUserAddress: (addr: unknown) =>
+    typeof addr === "string"
+      ? addr
+          .trim()
+          .toUpperCase()
+          .replace(/[\x00-\x1F\x7F]/g, "")
+      : null,
   validateUserAddress: (addr: string) =>
     /^G[A-Z2-7]{55}$/.test(addr) ? null : "Invalid Stellar address",
   STELLAR_PUBLIC_KEY_REGEX: /^G[A-Z2-7]{55}$/,

--- a/src/api/routes/positions.ts
+++ b/src/api/routes/positions.ts
@@ -257,7 +257,7 @@ export default async function positionsRouter(server: FastifyInstance) {
       }>,
       reply: FastifyReply
     ) => {
-      const { wallet } = request.params;
+      const { wallet: rawWallet } = request.params;
       const { includePnl = false } = request.query;
       const prisma = getPrismaClient();
 

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -88,26 +88,22 @@ class RedisService {
   }
 
   /**
-   * Get the current Redis client instance. Callers must await ensureConnected()
-   * first — this only returns whatever client is currently set.
+   * Get the connected Redis client, establishing (or awaiting) the
+   * connection first if necessary.
+   *
+   * Every method that talks to Redis must go through this helper instead of
+   * reading `this.client` directly — reading `this.client` before the
+   * connection promise resolves (e.g. the very first call after startup, or
+   * any call issued right after a "close" event resets the client) returns
+   * `null` and crashes the caller. Routing everything through the pending
+   * `connectionPromise` makes those states resolve gracefully instead.
    */
-  private getClient(): Redis {
-    return this.client!;
-  }
-
-  /**
-   * Wait for Redis connection to be established, (re)initiating a connection
-   * attempt if none is in flight. This must be called before getClient() in
-   * every method — a dropped connection (see onClose) nulls both this.client
-   * and this.connectionPromise, so without this check getClient() would kick
-   * off a new connection but return null before it resolves.
-   */
-  private async ensureConnected(): Promise<void> {
-    if (!this.client) {
-      if (!this.connectionPromise) {
-        this.connectionPromise = this.connect();
-      }
-      await this.connectionPromise;
+  private async ensureConnected(): Promise<Redis> {
+    if (this.client) {
+      return this.client;
+    }
+    if (!this.connectionPromise) {
+      this.connectionPromise = this.connect();
     }
     return this.connectionPromise;
   }
@@ -242,8 +238,8 @@ class RedisService {
    */
   async del(key: string): Promise<void> {
     try {
-      await this.ensureConnected();
-      await this.getClient().del(key);
+      const client = await this.ensureConnected();
+      await client.del(key);
     } catch (error) {
       console.error({ service: "redis", key, err: error }, "Redis DEL failed");
       throw error;
@@ -255,8 +251,8 @@ class RedisService {
    */
   async exists(key: string): Promise<boolean> {
     try {
-      await this.ensureConnected();
-      const result = await this.getClient().exists(key);
+      const client = await this.ensureConnected();
+      const result = await client.exists(key);
       return result === 1;
     } catch (error) {
       console.error(
@@ -323,8 +319,8 @@ class RedisService {
   async clearOrderBook(marketId: string): Promise<void> {
     const pattern = `${this.keyPrefix}orderbook:${marketId}:*`;
     try {
-      await this.ensureConnected();
-      const keys = await this.getClient().keys(pattern);
+      const client = await this.ensureConnected();
+      const keys = await client.keys(pattern);
       if (keys.length > 0) {
         await client.del(...keys);
       }
@@ -344,9 +340,7 @@ class RedisService {
    */
   async healthCheck(): Promise<boolean> {
     try {
-      await this.ensureConnected();
-      const client = this.client;
-      if (!client) return false;
+      const client = await this.ensureConnected();
       const result = await client.ping();
       return result === "PONG";
     } catch (error) {
@@ -382,8 +376,7 @@ class RedisService {
     options?: { MKSTREAM?: boolean }
   ): Promise<string | void> {
     try {
-      await this.ensureConnected();
-      const client = this.getClient();
+      const client = await this.ensureConnected();
       const args = [subcommand, key, groupName, id];
       if (options?.MKSTREAM) {
         args.push("MKSTREAM");
@@ -423,7 +416,7 @@ class RedisService {
     limit?: string
   ): Promise<Array<[string, string[]]>> {
     try {
-      await this.ensureConnected();
+      const client = await this.ensureConnected();
       if (countArg && limit) {
         return await client.xrange(key, start, end, countArg, limit);
       } else {
@@ -449,7 +442,7 @@ class RedisService {
     limit?: string
   ): Promise<Array<[string, string[]]>> {
     try {
-      await this.ensureConnected();
+      const client = await this.ensureConnected();
       if (countArg && limit) {
         return await client.xrevrange(key, start, end, countArg, limit);
       } else {
@@ -475,8 +468,7 @@ class RedisService {
     options?: { COUNT?: number; BLOCK?: number }
   ): Promise<Array<[string, Array<[string, string[]]>]>> {
     try {
-      await this.ensureConnected();
-      const client = this.getClient();
+      const client = await this.ensureConnected();
       const args = ["GROUP", groupName, consumerName];
       if (options?.COUNT) {
         args.push("COUNT", String(options.COUNT));
@@ -504,8 +496,7 @@ class RedisService {
     ...messageIds: string[]
   ): Promise<number> {
     try {
-      await this.ensureConnected();
-      const client = this.getClient();
+      const client = await this.ensureConnected();
       return await (client.xack as any)(streamKey, groupName, ...messageIds);
     } catch (error) {
       console.error({ service: "redis", err: error }, "Redis XACK failed");
@@ -524,8 +515,7 @@ class RedisService {
     ...messageIds: string[]
   ): Promise<Array<[string, string[]]>> {
     try {
-      await this.ensureConnected();
-      const client = this.getClient();
+      const client = await this.ensureConnected();
       const args = [
         streamKey,
         groupName,
@@ -545,8 +535,8 @@ class RedisService {
    */
   async xinfo(subcommand: "STREAM", key: string): Promise<any> {
     try {
-      await this.ensureConnected();
-      return await this.getClient().xinfo(subcommand, key);
+      const client = await this.ensureConnected();
+      return await client.xinfo(subcommand, key);
     } catch (error) {
       console.error(
         { service: "redis", key, err: error },


### PR DESCRIPTION
## Summary

Four "reliability pass" tickets (#751-#754), each template-generated with no concrete scope ("implement the change in the relevant code paths... handle stale/disconnected/invalid states gracefully... follow existing patterns"). Following the same approach as prior batches in this series (#747-750, #759-762), I audited the codebase for genuine reliability gaps and picked one concrete, independently-shippable fix per issue.

## What changed

### #751 — Redis client resolution broken by a merge regression (`src/services/redis.ts`)
A later merge regressed the `ensureConnected()`/`getClient()` split introduced by the #747-750 batch back into a broken hybrid: `ensureConnected()` was typed `Promise<void>` while several call sites still treated its resolved value as the client, and `clearOrderBook`/`xrange`/`xrevrange` referenced a bare `client` identifier that was never declared in scope. That's a `ReferenceError` on **every** call to `clearOrderBook`, `xrange`, or `xrevrange` — used by order book invalidation after trades and by stream consumers (settlement/oracle workers). Confirmed via `tsc` (9 type errors in this file) before the fix. Restored the single `ensureConnected(): Promise<Redis>` pattern all methods route through, consistent with how the rest of the class already worked.

### #752 — `GET /wallets/:wallet/positions` broken by a merge artifact (`src/api/routes/positions.ts`)
The handler had a duplicate `const wallet` declaration and a reference to an undefined `rawWallet` — a hard `SyntaxError`/`ReferenceError`, confirmed via `tsc`, left over from a partial merge that added address sanitization but didn't rename the original destructure. Renamed the destructured param to `rawWallet` so the existing `sanitizeUserAddress` → `validateUserAddress` flow resolves correctly, matching the identical pattern already used in `orders.ts`.

### #753 — Oracle poll loop has no overlap guard (`apps/oracle/main.ts`)
The oracle's `setInterval`-driven poll loop had no guard against overlapping cycles, unlike the indexer (`isTickInProgress`) and the finalization worker (`activePollPromise`), both of which guard the identical `setInterval` pattern. A slow cycle (slow provider, many active markets) could let a second cycle start before the first finishes, doubling provider calls and `OracleReport` writes for the same markets. Extracted the guard into a small, directly-testable `createOverlapGuardedPoll()` helper used by `bootstrap()`'s scheduled ticks; the initial call stays unguarded so startup misconfiguration (e.g. missing `ORACLE_SECRET_KEY`) still fails fast, matching prior behavior.

### #754 — BullMQ Worker/Queue instances have no `error` listener (`apps/workers/src/oracle/bullmq-submission-queue.ts`, `apps/workers/src/settlement/consumer.ts`)
None of the three live BullMQ `Queue`/`Worker` instances (oracle submission queue, oracle submission worker, settlement worker) registered an `"error"` listener. BullMQ forwards Redis connection errors as `"error"` events, and Node's default `EventEmitter` behavior with no listener for `"error"` is to **throw** — a transient Redis blip would crash the whole worker process instead of being logged and retried by BullMQ's own reconnect/retry logic. Added logged error handlers matching the existing `completed`/`failed` handler style already in these files.

## Verification performed

- `tsc --noEmit`: clean except 3 pre-existing errors in `src/api/routes/wallet.test.ts` — confirmed present on unmodified `dev` (not touched by this PR).
- `prettier --check` on all touched files: clean.
- Full `vitest` suite run against real local Postgres + Redis (docker-compose services), compared against the same suite run on unmodified `dev`: both show ~18 failing tests scattered across files this PR does not touch (OpenAPI contract tests, `horizonCache`, `markets`, indexer ingestion, `stellarAuth`). Confirmed identical/pre-existing by running the same failing files in isolation against a stashed (unmodified) working tree — same failures, same error messages. The exact failing set is order-dependent (shared DB/Redis state across test files run in the same process), not something introduced by this branch.
- Every test in every file this PR touches passes deterministically: `redis.test.ts` (32/32), `positions.test.ts` (12/12, updated to mock the newly-exercised `sanitizeUserAddress`), `apps/oracle/main.test.ts` (8/8 — 4 existing + 4 new for `createOverlapGuardedPoll`), `apps/workers/src/oracle/bullmq-submission-queue.test.ts` (4/4, new file).
- For #751/#752, verified via `git blame`/`git log` that both were real, recent regressions (not intentional code) by diffing against the last known-good commit for each file.

## Test plan

- [x] `pnpm prisma:generate && pnpm exec tsc --noEmit -p tsconfig.json`
- [x] `pnpm exec prettier --check <touched files>`
- [x] `pnpm exec vitest run src/services/redis.test.ts src/api/routes/positions.test.ts apps/oracle/main.test.ts apps/workers/src/oracle/bullmq-submission-queue.test.ts`
- [x] Full `pnpm exec vitest run` against local Postgres/Redis containers, diffed against unmodified `dev`

## Known pre-existing issues (out of scope for this PR)

- `wallet.test.ts` has 3 pre-existing `tsc` errors (`'err' is of type 'unknown'`), present on `dev` prior to this branch.
- ~18 tests fail on both this branch and unmodified `dev` in files unrelated to this PR (OpenAPI contract tests, `horizonCache.test.ts`, `tests/markets.test.ts`, `apps/indexer/src/ingestion.test.ts`, `stellarAuth.test.ts`, `tests/integration/*`). These appear to be pre-existing environment/test-isolation issues (shared DB/Redis state, network-dependent assertions) — confirmed present on unmodified `dev` via the same test runs.
- `pnpm-lock.yaml` on `dev` currently has a cosmetic duplicate-key artifact from an earlier merge (`apps/api: {}` etc. listed twice under `importers`). It doesn't break anything — `pnpm install` (non-frozen, what CI runs) silently repairs it — so I left it untouched to keep this PR scoped to the four issues above.

Closes #751
Closes #752
Closes #753
Closes #754