### PR TITLE
feat(workers): add Zod payload validation to SettlementWorker

### DIFF
--- a/apps/workers/src/settlement/settlement-worker.test.ts
+++ b/apps/workers/src/settlement/settlement-worker.test.ts
@@ -374,6 +374,7 @@ describe("SettlementWorker — Stellar SDK invoke (executeOnChain)", () => {
     redisClient = {
       exists: vi.fn().mockResolvedValue(false),
       set: vi.fn().mockResolvedValue(undefined),
+      setnx: vi.fn().mockResolvedValue(true),
     };
     stellarWorker = new SettlementWorker(redisClient, logger, {
       maxAttempts: 3,
@@ -614,5 +615,147 @@ describe("SettlementWorker — Stellar SDK invoke (executeOnChain)", () => {
       // maxRetries: 3 => 1 initial attempt + 3 retries = 4 calls total.
       expect(mockGetAccount).toHaveBeenCalledTimes(4);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Payload validation tests (reliability pass 039)
+// ---------------------------------------------------------------------------
+describe("SettlementWorker — payload validation", () => {
+  let logger: ILogger;
+  let redisClient: SettlementRedisClient;
+  let worker: SettlementWorker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    };
+    redisClient = {
+      exists: vi.fn().mockResolvedValue(false),
+      set: vi.fn().mockResolvedValue(undefined),
+      setnx: vi.fn().mockResolvedValue(true),
+    };
+    worker = new SettlementWorker(redisClient, logger, {
+      maxAttempts: 3,
+      processingTimeoutMs: 5_000,
+      idempotencyTtlSeconds: 86_400,
+    });
+  });
+
+  it("rejects with invalid payload error when tradeId is missing", async () => {
+    const job: QueueJob = {
+      id: "job-val-1",
+      attempts: 1,
+      payload: {
+        // tradeId intentionally omitted
+        marketId: "market-001",
+        outcome: "YES",
+        buyOrderId: "buy-1",
+        sellOrderId: "sell-1",
+        buyerAddress: "GBUYER",
+        sellerAddress: "GSELLER",
+        price: "0.65",
+        quantity: "100",
+        timestamp: "1700000000000",
+      },
+    };
+
+    await expect(worker.process(job)).rejects.toThrow("invalid payload");
+    expect(redisClient.setnx).not.toHaveBeenCalled();
+  });
+
+  it("rejects with invalid payload error when outcome is not YES or NO", async () => {
+    const job: QueueJob = {
+      id: "job-val-2",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-val-2",
+        marketId: "market-001",
+        outcome: "MAYBE",
+        buyOrderId: "buy-1",
+        sellOrderId: "sell-1",
+        buyerAddress: "GBUYER",
+        sellerAddress: "GSELLER",
+        price: "0.65",
+        quantity: "100",
+        timestamp: "1700000000000",
+      },
+    };
+
+    await expect(worker.process(job)).rejects.toThrow("invalid payload");
+    expect(redisClient.setnx).not.toHaveBeenCalled();
+  });
+
+  it("rejects with invalid payload error when price is not a positive number", async () => {
+    const job: QueueJob = {
+      id: "job-val-3",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-val-3",
+        marketId: "market-001",
+        outcome: "YES",
+        buyOrderId: "buy-1",
+        sellOrderId: "sell-1",
+        buyerAddress: "GBUYER",
+        sellerAddress: "GSELLER",
+        price: "-0.5",
+        quantity: "100",
+        timestamp: "1700000000000",
+      },
+    };
+
+    await expect(worker.process(job)).rejects.toThrow("invalid payload");
+  });
+
+  it("rejects with invalid payload error when quantity is zero", async () => {
+    const job: QueueJob = {
+      id: "job-val-4",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-val-4",
+        marketId: "market-001",
+        outcome: "NO",
+        buyOrderId: "buy-1",
+        sellOrderId: "sell-1",
+        buyerAddress: "GBUYER",
+        sellerAddress: "GSELLER",
+        price: "0.50",
+        quantity: "0",
+        timestamp: "1700000000000",
+      },
+    };
+
+    await expect(worker.process(job)).rejects.toThrow("invalid payload");
+  });
+
+  it("proceeds normally when all payload fields are valid", async () => {
+    const job: QueueJob = {
+      id: "job-val-ok",
+      attempts: 1,
+      payload: {
+        tradeId: "trade-val-ok",
+        marketId: "market-001",
+        outcome: "YES",
+        buyOrderId: "buy-1",
+        sellOrderId: "sell-1",
+        buyerAddress: "GBUYER",
+        sellerAddress: "GSELLER",
+        price: "0.65",
+        quantity: "100",
+        timestamp: "1700000000000",
+      },
+    };
+
+    await expect(worker.process(job)).resolves.not.toThrow();
+    expect(redisClient.setnx).toHaveBeenCalledWith(
+      "settlement:processed:trade-val-ok",
+      "1",
+      86_400
+    );
   });
 });

--- a/apps/workers/src/settlement/settlement-worker.ts
+++ b/apps/workers/src/settlement/settlement-worker.ts
@@ -6,6 +6,7 @@ import {
   rpc as StellarRpc,
   xdr,
 } from "@stellar/stellar-sdk";
+import { z } from "zod";
 import type { ILogger } from "../../../../packages/shared/src/logger.js";
 import {
   processJob,
@@ -14,10 +15,7 @@ import {
 } from "../consumers/queue-consumer.js";
 import { logDeadLetter } from "../consumers/dead-letter.js";
 import { withRetry } from "../../../oracle/retry-utils.js";
-import {
-  classifySettlementError,
-  annotateError,
-} from "./error-codes.js";
+import { classifySettlementError, annotateError } from "./error-codes.js";
 
 /** Retry config for individual Stellar RPC calls (getAccount, prepareTransaction,
  *  sendTransaction). Bounded and short-lived so a transient RPC blip is absorbed
@@ -27,6 +25,41 @@ const STELLAR_RPC_RETRY_CONFIG = {
   initialDelayMs: 500,
   maxDelayMs: 5_000,
 };
+
+/**
+ * Zod schema used to validate the raw job payload before processing.
+ * Any field that is missing, empty, or of the wrong type causes the job to be
+ * classified as INVALID_PAYLOAD and dead-lettered immediately (non-retryable).
+ */
+const SettlementPayloadSchema = z.object({
+  tradeId: z.string().min(1, "tradeId is required"),
+  marketId: z.string().min(1, "marketId is required"),
+  outcome: z.enum(["YES", "NO"], {
+    errorMap: () => ({ message: "outcome must be YES or NO" }),
+  }),
+  buyOrderId: z.string().min(1, "buyOrderId is required"),
+  sellOrderId: z.string().min(1, "sellOrderId is required"),
+  buyerAddress: z.string().min(1, "buyerAddress is required"),
+  sellerAddress: z.string().min(1, "sellerAddress is required"),
+  price: z
+    .string()
+    .min(1, "price is required")
+    .refine((v) => Number.isFinite(Number(v)) && Number(v) > 0, {
+      message: "price must be a positive numeric string",
+    }),
+  quantity: z
+    .string()
+    .min(1, "quantity is required")
+    .refine((v) => Number.isInteger(Number(v)) && Number(v) > 0, {
+      message: "quantity must be a positive integer string",
+    }),
+  timestamp: z
+    .string()
+    .min(1, "timestamp is required")
+    .refine((v) => Number.isFinite(Number(v)), {
+      message: "timestamp must be a numeric string",
+    }),
+});
 
 export interface SettlementJobPayload {
   tradeId: string;
@@ -120,7 +153,18 @@ export class SettlementWorker {
   }
 
   private async handleJob(job: QueueJob): Promise<void> {
-    const payload = job.payload as unknown as SettlementJobPayload;
+    // Validate the raw payload before touching any external resources.
+    // An invalid payload is a non-retryable client error — fail fast so the job
+    // is dead-lettered immediately rather than burning retry quota.
+    const parseResult = SettlementPayloadSchema.safeParse(job.payload);
+    if (!parseResult.success) {
+      const issues = parseResult.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ");
+      throw new Error(`invalid payload — ${issues}`);
+    }
+
+    const payload = parseResult.data as SettlementJobPayload;
     const { tradeId } = payload;
 
     const idempotencyKey = `settlement:processed:${tradeId}`;


### PR DESCRIPTION
SettlementWorker.handleJob() previously cast the raw job payload with no validation, silently propagating missing or malformed fields deep into the Stellar call path. This change validates the payload against a Zod schema at the start of handleJob(). Any missing, empty, or incorrectly typed field throws an 'invalid payload' error before any Redis or Stellar I/O is attempted, causing the job to be classified as INVALID_PAYLOAD and dead-lettered immediately rather than burning retry quota.

Closes #785