### PR TITLE
fix(redis): add missing getClient() guard and setnx resilience

### DIFF
--- a/src/services/redis.test.ts
+++ b/src/services/redis.test.ts
@@ -315,6 +315,68 @@ describe("RedisService", () => {
   });
 
   // =========================================================================
+  // setnx — atomic SET NX with optional TTL (reliability pass 037)
+  // =========================================================================
+  describe("setnx", () => {
+    const key = "test:setnx:key";
+
+    afterEach(async () => {
+      await redis.del(key);
+    });
+
+    it("sets the key and returns true when the key does not exist", async () => {
+      const set = await redis.setnx(key, "val");
+      expect(set).toBe(true);
+      const stored = await redis.get(key);
+      expect(stored).toBe("val");
+    });
+
+    it("returns false when the key already exists and leaves the original value unchanged", async () => {
+      await redis.set(key, "original");
+      const set = await redis.setnx(key, "new-value");
+      expect(set).toBe(false);
+      const stored = await redis.get(key);
+      expect(stored).toBe("original");
+    });
+
+    it("applies TTL when ttlSeconds is provided", async () => {
+      const set = await redis.setnx(key, "expiring", 1);
+      expect(set).toBe(true);
+
+      const existsImmediately = await redis.exists(key);
+      expect(existsImmediately).toBe(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      const existsAfterTtl = await redis.exists(key);
+      expect(existsAfterTtl).toBe(false);
+    });
+
+    it("does not apply TTL when ttlSeconds is omitted", async () => {
+      const svc = new RedisService();
+      const testKey = "test:setnx:no-ttl";
+      await svc.setnx(testKey, "persistent");
+
+      // Key should still be present after a short wait
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      const exists = await svc.exists(testKey);
+      expect(exists).toBe(true);
+
+      await svc.del(testKey);
+      await svc.disconnect();
+    });
+
+    it("succeeds as the very first operation on a cold instance (getClient resilience)", async () => {
+      const svc = new RedisService();
+      const testKey = "test:setnx:cold-start";
+      const set = await svc.setnx(testKey, "cold");
+      expect(set).toBe(true);
+      await svc.del(testKey);
+      await svc.disconnect();
+    });
+  });
+
+  // =========================================================================
   // Redis key prefix enforcement (closes #619)
   // =========================================================================
   describe("key prefix enforcement", () => {

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -98,6 +98,21 @@ class RedisService {
    * `null` and crashes the caller. Routing everything through the pending
    * `connectionPromise` makes those states resolve gracefully instead.
    */
+  /**
+   * Return the active Redis client instance.
+   * Throws if the client is not yet connected or has been closed.
+   * Always call `ensureConnected()` before using this method so
+   * the connection is guaranteed to be live.
+   */
+  private getClient(): Redis {
+    if (!this.client) {
+      throw new Error(
+        "Redis client is not connected. Call ensureConnected() first."
+      );
+    }
+    return this.client;
+  }
+
   private async ensureConnected(): Promise<Redis> {
     if (!this.client) {
       if (!this.connectionPromise) {
@@ -535,10 +550,13 @@ class RedisService {
    * Returns true when the key was set, false when it already existed.
    * When a TTL is provided, the key auto-expires after that many seconds (EX).
    */
-  async setnx(key: string, value: string, ttlSeconds?: number): Promise<boolean> {
+  async setnx(
+    key: string,
+    value: string,
+    ttlSeconds?: number
+  ): Promise<boolean> {
     try {
-      await this.ensureConnected();
-      const client = this.getClient();
+      const client = await this.ensureConnected();
       const result =
         ttlSeconds !== undefined
           ? await client.set(key, value, "EX", ttlSeconds, "NX")


### PR DESCRIPTION
Adds the private getClient() method that was referenced in ensureConnected() and setnx() but never defined, causing a runtime crash on those code paths. The setnx() method now uses the Redis client returned directly from ensureConnected() instead of a separate getClient() call, eliminating the double-call pattern. Tests added covering setnx set/no-set, TTL, and cold-start behaviour.

Closes #783