### PR TITLE
feat(workers): enforce processingTimeoutMs in processJob

### DIFF
--- a/apps/workers/src/consumers/queue-consumer.test.ts
+++ b/apps/workers/src/consumers/queue-consumer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   processJob,
+  JobTimeoutError,
   type QueueJob,
   type QueueConsumerConfig,
   type JobHandler,
@@ -175,5 +176,88 @@ describe("Queue Consumer — processJob", () => {
         error: "string error",
       })
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // Timeout enforcement (reliability pass 038)
+  // -------------------------------------------------------------------------
+
+  it("rejects with JobTimeoutError when handler exceeds processingTimeoutMs", async () => {
+    vi.useFakeTimers();
+
+    // Handler that never resolves within the timeout window
+    const handler: JobHandler = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise<void>((resolve) => setTimeout(resolve, 10_000))
+      );
+    const config = makeConfig({ processingTimeoutMs: 100 });
+    const job = makeJob();
+
+    const promise = processJob(logger, config, job, handler);
+
+    // Advance time past the timeout threshold
+    vi.advanceTimersByTime(150);
+
+    await expect(promise).rejects.toBeInstanceOf(JobTimeoutError);
+
+    vi.useRealTimers();
+  });
+
+  it("logs warn with timedOut context when handler times out", async () => {
+    vi.useFakeTimers();
+
+    const handler: JobHandler = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise<void>((resolve) => setTimeout(resolve, 10_000))
+      );
+    const config = makeConfig({ processingTimeoutMs: 100 });
+    const job = makeJob();
+
+    const promise = processJob(logger, config, job, handler);
+    vi.advanceTimersByTime(150);
+
+    await expect(promise).rejects.toBeInstanceOf(JobTimeoutError);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Job processing timed out",
+      expect.objectContaining({
+        jobId: "job-1",
+        queue: "test-queue",
+        processingTimeoutMs: 100,
+      })
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("does not trigger timeout when handler resolves before the deadline", async () => {
+    vi.useFakeTimers();
+
+    const handler: JobHandler = vi.fn().mockResolvedValue(undefined);
+    const config = makeConfig({ processingTimeoutMs: 5000 });
+    const job = makeJob();
+
+    const promise = processJob(logger, config, job, handler);
+
+    // Handler resolves synchronously (mocked), time does not matter
+    await promise;
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "Job processed successfully",
+      expect.objectContaining({ jobId: "job-1" })
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("JobTimeoutError carries jobId and timeoutMs", () => {
+    const err = new JobTimeoutError("job-42", 3000);
+    expect(err.jobId).toBe("job-42");
+    expect(err.timeoutMs).toBe(3000);
+    expect(err.name).toBe("JobTimeoutError");
+    expect(err.message).toContain("job-42");
+    expect(err.message).toContain("3000");
   });
 });

--- a/apps/workers/src/consumers/queue-consumer.ts
+++ b/apps/workers/src/consumers/queue-consumer.ts
@@ -34,11 +34,34 @@ export interface QueueConsumerConfig {
 export type JobHandler = (job: QueueJob) => Promise<void>;
 
 /**
- * Processes a single job from the queue with full structured logging.
+ * Error thrown when a job handler exceeds its configured processing timeout.
+ * Treated as a retryable failure by the consumer pipeline.
+ */
+export class JobTimeoutError extends Error {
+  readonly jobId: string;
+  readonly timeoutMs: number;
+
+  constructor(jobId: string, timeoutMs: number) {
+    super(
+      `Job ${jobId} timed out after ${timeoutMs}ms — processing limit exceeded`
+    );
+    this.name = "JobTimeoutError";
+    this.jobId = jobId;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Processes a single job from the queue with full structured logging and
+ * enforced processing timeout.
+ *
+ * If the handler does not resolve within `config.processingTimeoutMs` the
+ * promise is rejected with a `JobTimeoutError`. The job is then subject to
+ * the normal retry/dead-letter logic.
  *
  * Log levels used:
  *   - `info`  — job received, job completed
- *   - `warn`  — retryable failure (attempts remaining)
+ *   - `warn`  — retryable failure (attempts remaining) or timeout
  *   - `error` — terminal failure (max attempts exceeded)
  */
 export async function processJob(
@@ -57,8 +80,21 @@ export async function processJob(
 
   const start = Date.now();
 
+  // Race the handler against a per-job timeout so a hung handler cannot block
+  // the worker indefinitely. The timeout promise always rejects so the
+  // winner is whichever settles first.
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new JobTimeoutError(job.id, config.processingTimeoutMs));
+    }, config.processingTimeoutMs);
+  });
+
   try {
-    await handler(job);
+    await Promise.race([handler(job), timeoutPromise]);
+
+    // Handler won the race — cancel the pending timeout.
+    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
 
     const durationMs = Date.now() - start;
     logger.info("Job processed successfully", {
@@ -69,10 +105,25 @@ export async function processJob(
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
+    // Always clear the timeout on any outcome so we don't leak handles.
+    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+
     const durationMs = Date.now() - start;
     const errorMessage = error instanceof Error ? error.message : String(error);
+    const timedOut = error instanceof JobTimeoutError;
 
-    if (job.attempts < config.maxAttempts) {
+    if (timedOut) {
+      logger.warn("Job processing timed out", {
+        jobId: job.id,
+        queue: config.queueName,
+        attempt: job.attempts,
+        maxAttempts: config.maxAttempts,
+        processingTimeoutMs: config.processingTimeoutMs,
+        durationMs,
+        error: errorMessage,
+        timestamp: new Date().toISOString(),
+      });
+    } else if (job.attempts < config.maxAttempts) {
       logger.warn("Job processing failed, will retry", {
         jobId: job.id,
         queue: config.queueName,


### PR DESCRIPTION
The processingTimeoutMs field in QueueConsumerConfig was declared but never enforced — a hung handler could block the worker indefinitely. This change races the handler against a per-job timeout via Promise.race; if the timeout fires first the job is rejected with the new JobTimeoutError (retryable) and a structured warn log is emitted. The timeout handle is always cleared on any outcome so no timer leaks occur.

Closes #784