### PR TITLE
feat(indexer): add per-page fetch timeout to EventFetcher (#787)

### DIFF
--- a/apps/indexer/src/eventFetcher.test.ts
+++ b/apps/indexer/src/eventFetcher.test.ts
@@ -276,4 +276,102 @@ describe("EventFetcher", () => {
       expect(fetcher.getConsecutiveDisconnections()).toBe(7);
     });
   });
-});
+
+  describe("per-page fetch timeout", () => {
+    it("aborts a hanging getEvents call after fetchTimeoutMs and treats it as transient", async () => {
+      vi.useFakeTimers();
+      try {
+        const mockServer = {
+          getEvents: vi.fn(
+            () =>
+              new Promise<never>(() => {
+                /* never resolves — simulates a hung RPC */
+              })
+          ),
+        };
+
+        const fetcher = new EventFetcher(
+          {
+            rpcUrl: "https://rpc.example.com",
+            contractId: "CTEST",
+            fetchTimeoutMs: 5_000,
+            maxRetries: 0,
+            retryDelayMs: 0,
+          },
+          telemetry
+        );
+        (fetcher as any).server = mockServer;
+
+        const fetchPromise = fetcher
+          .fetchByLedgerWindow({ startLedger: 1, endLedger: 5 })
+          .catch((e) => e);
+
+        await vi.advanceTimersByTimeAsync(5_001);
+        const result = await fetchPromise;
+
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toMatch(/timed out/i);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("records a transient disconnection metric on timeout", async () => {
+      vi.useFakeTimers();
+      try {
+        const mockServer = {
+          getEvents: vi.fn(
+            () =>
+              new Promise<never>(() => {
+                /* never resolves */
+              })
+          ),
+        };
+
+        const fetcher = new EventFetcher(
+          {
+            rpcUrl: "https://rpc.example.com",
+            contractId: "CTEST",
+            fetchTimeoutMs: 3_000,
+            maxRetries: 0,
+            retryDelayMs: 0,
+          },
+          telemetry
+        );
+        (fetcher as any).server = mockServer;
+
+        const fetchPromise = fetcher
+          .fetchByLedgerWindow({ startLedger: 1, endLedger: 5 })
+          .catch(() => {});
+
+        await vi.advanceTimersByTimeAsync(3_001);
+        await fetchPromise;
+
+        const disconnectionMetric = recorded.find(
+          (r) => r.metric === "indexer.rpc.disconnection"
+        );
+        expect(disconnectionMetric).toBeDefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("skips the timeout when fetchTimeoutMs is 0", async () => {
+      const server = makeMockServer([[makeEvent(1)]]);
+      const fetcher = new EventFetcher(
+        {
+          rpcUrl: "https://rpc.example.com",
+          contractId: "CTEST",
+          fetchTimeoutMs: 0,
+        },
+        telemetry
+      );
+      (fetcher as any).server = server;
+
+      const result = await fetcher.fetchByLedgerWindow({
+        startLedger: 1,
+        endLedger: 1,
+      });
+      expect(result.events).toHaveLength(1);
+    });
+  });

--- a/apps/indexer/src/eventFetcher.ts
+++ b/apps/indexer/src/eventFetcher.ts
@@ -12,6 +12,12 @@ import { isTransientError, sleep } from "./retry.js";
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_DELAY_MS = 500;
 const DEFAULT_PAGE_LIMIT = 100;
+/**
+ * Default per-page RPC fetch timeout (ms). A single getEvents call that
+ * hangs longer than this is aborted and treated as a transient failure so
+ * the retry/backoff logic can take over.  Set fetchTimeoutMs: 0 to disable.
+ */
+const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
 
 /**
  * Maximum consecutive RPC failures before the fetcher enters a disconnected
@@ -43,6 +49,7 @@ export class EventFetcher {
       maxRetries: DEFAULT_MAX_RETRIES,
       retryDelayMs: DEFAULT_RETRY_DELAY_MS,
       pageLimit: DEFAULT_PAGE_LIMIT,
+      fetchTimeoutMs: DEFAULT_FETCH_TIMEOUT_MS,
       ...config,
     };
     this.server = new StellarRpc.Server(this.config.rpcUrl);
@@ -119,16 +126,40 @@ export class EventFetcher {
     startLedger: number,
     cursor?: string
   ): Promise<StellarRpc.Api.GetEventsResponse> {
-    const { maxRetries, retryDelayMs, pageLimit, contractId } = this.config;
+    const { maxRetries, retryDelayMs, pageLimit, contractId, fetchTimeoutMs } =
+      this.config;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
-        const response = await this.server.getEvents({
+        const fetchCall = this.server.getEvents({
           startLedger,
           filters: [{ contractIds: [contractId] }],
           limit: pageLimit,
           ...(cursor ? ({ cursor } as any) : {}),
         } as any);
+
+        // Wrap with a per-page timeout when fetchTimeoutMs > 0 so a stalled
+        // RPC endpoint cannot block the ingestion loop indefinitely.
+        const response: StellarRpc.Api.GetEventsResponse =
+          fetchTimeoutMs > 0
+            ? await Promise.race([
+                fetchCall,
+                new Promise<never>((_, reject) =>
+                  setTimeout(
+                    () =>
+                      reject(
+                        Object.assign(
+                          new Error(
+                            `EventFetcher: getEvents timed out after ${fetchTimeoutMs}ms`
+                          ),
+                          { code: "ETIMEDOUT" }
+                        )
+                      ),
+                    fetchTimeoutMs
+                  )
+                ),
+              ])
+            : await fetchCall;
 
         // Success — reset the consecutive disconnection counter
         this.consecutiveDisconnections = 0;

--- a/apps/indexer/src/types.ts
+++ b/apps/indexer/src/types.ts
@@ -161,4 +161,10 @@ export interface EventFetcherConfig {
   maxRetries?: number;
   retryDelayMs?: number;
   pageLimit?: number;
+  /**
+   * Per-page RPC fetch timeout in milliseconds. A getEvents call that takes
+   * longer than this is aborted with a TimeoutError (treated as transient).
+   * Set to 0 to disable. Defaults to 15 000 ms.
+   */
+  fetchTimeoutMs?: number;
 }


### PR DESCRIPTION
## Summary

Add a configurable `fetchTimeoutMs` (default 15 000 ms) to `EventFetcher` so a stalled RPC endpoint cannot block the ingestion loop indefinitely. A timed-out `getEvents` call rejects with an `ETIMEDOUT`-coded error, which `isTransientError` already recognises, so the existing retry/backoff path handles it transparently.

## Changes

- `apps/indexer/src/types.ts`: Add `fetchTimeoutMs?` to `EventFetcherConfig`
- `apps/indexer/src/eventFetcher.ts`: Wrap each `getEvents` call in `Promise.race` with a timeout guard; set `fetchTimeoutMs: 0` to opt-out
- `apps/indexer/src/eventFetcher.test.ts`: Unit tests covering timeout abort, disconnection metric emission, and opt-out path

## Validation

- Prettier formatting verified
- No unrelated files modified

Closes #787