### PR TITLE
feat(indexer): retry PrismaBatchWriter on transient DB errors (#788)

### DIFF
--- a/apps/indexer/src/batchWriter.test.ts
+++ b/apps/indexer/src/batchWriter.test.ts
@@ -281,4 +281,101 @@ describe("PrismaBatchWriter", () => {
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].error).toContain("fk violation");
   });
+
+  describe("transient DB error retry", () => {
+    it("retries on a P1001 (cannot reach database) error and succeeds", async () => {
+      const tx = createMockTx();
+      tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);
+
+      const transientErr = Object.assign(new Error("Cannot reach database"), {
+        code: "P1001",
+      });
+
+      // First call throws, second succeeds
+      mockPrisma.$transaction
+        .mockRejectedValueOnce(transientErr)
+        .mockImplementation(async (fn) => fn(tx));
+
+      const writer = new PrismaBatchWriter();
+      const result = await writer.write([
+        { kind: "trade", data: withIdempotencyKey(TRADE) },
+      ]);
+
+      expect(result.written).toBe(1);
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries on a serialization failure (40001) and succeeds", async () => {
+      const tx = createMockTx();
+      tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);
+
+      const serializationErr = Object.assign(
+        new Error("could not serialize access"),
+        { code: "40001" }
+      );
+
+      mockPrisma.$transaction
+        .mockRejectedValueOnce(serializationErr)
+        .mockImplementation(async (fn) => fn(tx));
+
+      const writer = new PrismaBatchWriter();
+      const result = await writer.write([
+        { kind: "resolution", data: withIdempotencyKey(RESOLUTION) },
+      ]);
+
+      expect(result.written).toBe(1);
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws after exhausting retries on persistent transient error", async () => {
+      const transientErr = Object.assign(new Error("timeout"), {
+        code: "P1008",
+      });
+      mockPrisma.$transaction.mockRejectedValue(transientErr);
+
+      const writer = new PrismaBatchWriter();
+      await expect(
+        writer.write([{ kind: "trade", data: withIdempotencyKey(TRADE) }])
+      ).rejects.toThrow("timeout");
+
+      // 1 initial + 3 retries = 4 total
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(4);
+    });
+
+    it("does not retry on a non-transient error", async () => {
+      const nonTransientErr = new Error("syntax error in SQL");
+      mockPrisma.$transaction.mockRejectedValue(nonTransientErr);
+
+      const writer = new PrismaBatchWriter();
+      await expect(
+        writer.write([{ kind: "trade", data: withIdempotencyKey(TRADE) }])
+      ).rejects.toThrow("syntax error");
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs a warning on each retry attempt", async () => {
+      const warnSpy = vi.fn();
+      const logger = { warn: warnSpy, info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+      const tx = createMockTx();
+      tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);
+
+      const transientErr = Object.assign(new Error("deadlock"), {
+        code: "40P01",
+      });
+
+      mockPrisma.$transaction
+        .mockRejectedValueOnce(transientErr)
+        .mockImplementation(async (fn) => fn(tx));
+
+      const writer = new PrismaBatchWriter(logger as any);
+      await writer.write([{ kind: "trade", data: withIdempotencyKey(TRADE) }]);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Transient DB error in batch write, retrying",
+        expect.objectContaining({ attempt: 1 })
+      );
+    });
+  });
 });

--- a/apps/indexer/src/batchWriter.ts
+++ b/apps/indexer/src/batchWriter.ts
@@ -15,6 +15,7 @@ import { getPrismaClient } from "../../../src/services/prisma.js";
 import type { ILogger } from "../../../packages/shared/src/logger.js";
 import type { PrismaClient } from "../../../src/generated/prisma/client/index.js";
 import { sanitizeForJson } from "./safeJson.js";
+import { sleep } from "./retry.js";
 
 export type BatchRecord =
   | { kind: "trade"; data: PersistedTrade }
@@ -43,6 +44,35 @@ const CHAIN_RESOLUTION_SOURCE_PREFIX = "chain:market_resolved";
 const UNKNOWN_OPERATOR_ADDRESS =
   "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 
+/**
+ * Prisma/Postgres error codes that are safe to retry — the operation did not
+ * partially commit so repeating it is idempotent given the write-idempotency
+ * guarantees already in place.
+ *
+ * P1001 — Cannot reach database server
+ * P1008 — Operations timed out
+ * P1017 — Server closed the connection
+ * 40001 — Serialization failure (Postgres)
+ * 40P01 — Deadlock detected (Postgres)
+ */
+const RETRYABLE_PRISMA_CODES = new Set([
+  "P1001",
+  "P1008",
+  "P1017",
+  "40001",
+  "40P01",
+]);
+
+const BATCH_WRITE_MAX_RETRIES = 3;
+const BATCH_WRITE_RETRY_DELAY_MS = 200;
+
+function isBatchWriteRetryable(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code: string =
+    (err as any).code ?? (err as any).errorCode ?? "";
+  return RETRYABLE_PRISMA_CODES.has(code);
+}
+
 export class PrismaBatchWriter implements BatchWriter {
   private readonly prisma = getPrismaClient();
 
@@ -62,74 +92,109 @@ export class PrismaBatchWriter implements BatchWriter {
         }
       : undefined;
 
-    await this.prisma.$transaction(async (tx) => {
-      const keyedRecords = records.map((record) => ({
-        ...record,
-        idempotencyKey: record.data.idempotencyKey,
-      }));
-      const recordByKey = new Map(
-        records.map((record) => [record.data.idempotencyKey, record])
-      );
+    // Retry the transaction on transient DB errors (connection reset,
+    // serialisation failures, deadlocks). Each batch is idempotent thanks to
+    // the indexerProcessedEvent deduplication layer so retrying is safe.
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= BATCH_WRITE_MAX_RETRIES; attempt++) {
+      try {
+        await this.prisma.$transaction(async (tx) => {
+          // Reset per-attempt counters inside the transaction so a retry
+          // starts from a clean slate.
+          written = 0;
+          skipped = 0;
+          errors.length = 0;
 
-      const deduped = await insertAllIfNew(
-        keyedRecords,
-        async (record) => {
-          const existing = await tx.indexerProcessedEvent.findUnique({
-            where: { idempotencyKey: record.idempotencyKey },
-          });
+          const keyedRecords = records.map((record) => ({
+            ...record,
+            idempotencyKey: record.data.idempotencyKey,
+          }));
+          const recordByKey = new Map(
+            records.map((record) => [record.data.idempotencyKey, record])
+          );
 
-          return existing ? null : record;
-        },
-        { logger: duplicateLogger }
-      );
+          const deduped = await insertAllIfNew(
+            keyedRecords,
+            async (record) => {
+              const existing = await tx.indexerProcessedEvent.findUnique({
+                where: { idempotencyKey: record.idempotencyKey },
+              });
 
-      skipped += deduped.duplicateCount;
-
-      for (const dedupedRecord of deduped.inserted) {
-        const record = recordByKey.get(dedupedRecord.idempotencyKey);
-        if (!record) {
-          continue;
-        }
-
-        try {
-          const result = await insertIfNew(
-            record.data,
-            async (persisted) =>
-              this.persistRecord(
-                tx,
-                record,
-                persisted as
-                  | PersistedTrade
-                  | PersistedResolution
-                  | PersistedCollateralDeposit
-                  | PersistedMarketCreated
-              ),
+              return existing ? null : record;
+            },
             { logger: duplicateLogger }
           );
 
-          if (result.status === "inserted") {
-            written += 1;
-          } else {
-            skipped += 1;
-          }
-        } catch (error) {
-          const serializedRecord = sanitizeForJson(record) as Record<
-            string,
-            unknown
-          >;
-          errors.push({
-            record: serializedRecord,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          this.logger?.warn("Failed to persist indexer batch record", {
-            record: serializedRecord,
-            error: sanitizeForJson(error),
-          });
-        }
-      }
-    });
+          skipped += deduped.duplicateCount;
 
-    return { written, skipped, errors };
+          for (const dedupedRecord of deduped.inserted) {
+            const record = recordByKey.get(dedupedRecord.idempotencyKey);
+            if (!record) {
+              continue;
+            }
+
+            try {
+              const result = await insertIfNew(
+                record.data,
+                async (persisted) =>
+                  this.persistRecord(
+                    tx,
+                    record,
+                    persisted as
+                      | PersistedTrade
+                      | PersistedResolution
+                      | PersistedCollateralDeposit
+                      | PersistedMarketCreated
+                  ),
+                { logger: duplicateLogger }
+              );
+
+              if (result.status === "inserted") {
+                written += 1;
+              } else {
+                skipped += 1;
+              }
+            } catch (error) {
+              const serializedRecord = sanitizeForJson(record) as Record<
+                string,
+                unknown
+              >;
+              errors.push({
+                record: serializedRecord,
+                error: error instanceof Error ? error.message : String(error),
+              });
+              this.logger?.warn("Failed to persist indexer batch record", {
+                record: serializedRecord,
+                error: sanitizeForJson(error),
+              });
+            }
+          }
+        });
+
+        // Transaction succeeded — exit the retry loop
+        return { written, skipped, errors };
+      } catch (err) {
+        lastError = err;
+        const isLast = attempt === BATCH_WRITE_MAX_RETRIES;
+
+        if (!isLast && isBatchWriteRetryable(err)) {
+          const delay = BATCH_WRITE_RETRY_DELAY_MS * 2 ** attempt;
+          this.logger?.warn("Transient DB error in batch write, retrying", {
+            attempt: attempt + 1,
+            maxRetries: BATCH_WRITE_MAX_RETRIES,
+            delayMs: delay,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          await sleep(delay);
+          continue;
+        }
+
+        throw err;
+      }
+    }
+
+    // Unreachable — satisfies TypeScript
+    throw lastError;
   }
 
   async flush(): Promise<void> {


### PR DESCRIPTION
## Summary

Add retry logic to `PrismaBatchWriter.write()` for transient Postgres/Prisma errors. Each batch is already idempotent via `indexerProcessedEvent` deduplication so retrying is safe. Up to 3 retries with 200 ms exponential back-off before re-throwing.

## Changes

- `apps/indexer/src/batchWriter.ts`: Detect retryable codes (P1001, P1008, P1017, 40001, 40P01), wrap `$transaction` in retry loop with counter reset, warn-log each retry
- `apps/indexer/src/batchWriter.test.ts`: Unit tests for retry-on-success, retry-exhaustion, non-transient passthrough, and warn logging

## Validation

- Prettier formatting verified
- No unrelated files modified

Closes #788