### PR TITLE
feat(workers): add maxRunMs elapsed-time guard to FinalizationJob (#789)

### DIFF
--- a/apps/workers/src/finalization/job.test.ts
+++ b/apps/workers/src/finalization/job.test.ts
@@ -560,4 +560,87 @@ describe("FinalizationJob", () => {
       });
     });
   });
+
+  describe("maxRunMs elapsed-time guard", () => {
+    it("processes all candidates when maxRunMs is 0 (disabled)", async () => {
+      const candidates = [
+        makeCandidate({ id: "c1", marketId: "m1" }),
+        makeCandidate({ id: "c2", marketId: "m2" }),
+      ];
+      const prisma = makePrisma(candidates);
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: 3600,
+        maxRunMs: 0,
+      });
+
+      const result = await job.run();
+
+      expect(result.totalCandidates).toBe(2);
+      expect(result.finalizedCount).toBe(2);
+    });
+
+    it("stops early when elapsed time exceeds maxRunMs", async () => {
+      vi.useFakeTimers();
+      try {
+        const candidates = [
+          makeCandidate({ id: "c1", marketId: "m1" }),
+          makeCandidate({ id: "c2", marketId: "m2" }),
+          makeCandidate({ id: "c3", marketId: "m3" }),
+        ];
+
+        // Each $transaction call advances fake time by 200 ms
+        const { tx } = makeTx();
+        const transaction = vi.fn().mockImplementation(
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
+            await vi.advanceTimersByTimeAsync(200);
+            return fn(tx);
+          }
+        );
+        const prisma = {
+          resolutionCandidate: { findMany: vi.fn().mockResolvedValue(candidates) },
+          $transaction: transaction,
+        } as unknown as PrismaClient;
+
+        const logger = makeLogger();
+        // Allow only 300 ms → first candidate (200 ms) fits, second is blocked
+        const job = new FinalizationJob(prisma, logger, {
+          challengeWindowSeconds: 3600,
+          maxRunMs: 300,
+        });
+
+        const result = await job.run();
+
+        // Only the first candidate was processed before the guard triggered
+        expect(result.finalizedCount).toBe(1);
+        expect(result.totalCandidates).toBe(3);
+        expect(logger.warn).toHaveBeenCalledWith(
+          "Finalization job exceeded maxRunMs, stopping early",
+          expect.objectContaining({ maxRunMs: 300 })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not stop early when all candidates finish within maxRunMs", async () => {
+      const candidates = [
+        makeCandidate({ id: "c1", marketId: "m1" }),
+        makeCandidate({ id: "c2", marketId: "m2" }),
+      ];
+      const prisma = makePrisma(candidates);
+      const logger = makeLogger();
+      const job = new FinalizationJob(prisma, logger, {
+        challengeWindowSeconds: 3600,
+        maxRunMs: 60_000,
+      });
+
+      const result = await job.run();
+
+      expect(result.finalizedCount).toBe(2);
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        "Finalization job exceeded maxRunMs, stopping early",
+        expect.anything()
+      );
+    });
+  });
 });

--- a/apps/workers/src/finalization/job.ts
+++ b/apps/workers/src/finalization/job.ts
@@ -13,6 +13,13 @@ export interface FinalizationJobConfig {
   /** How long (in seconds) a resolution candidate must sit in PROPOSED
    *  before it is eligible for finalization. Must be >= 0. */
   challengeWindowSeconds: number;
+  /**
+   * Maximum wall-clock time (ms) the job is allowed to run before it stops
+   * processing further candidates and returns a partial result.  This
+   * prevents a large backlog from blocking the scheduler for an unbounded
+   * amount of time.  Set to 0 to disable (no time limit).  Default: 0.
+   */
+  maxRunMs?: number;
 }
 
 export interface FinalizationCandidate {
@@ -47,6 +54,7 @@ class MarketNotEligibleError extends Error {
 
 export class FinalizationJob {
   private readonly challengeWindowSeconds: number;
+  private readonly maxRunMs: number;
 
   constructor(
     private readonly prisma: PrismaClient,
@@ -54,6 +62,7 @@ export class FinalizationJob {
     config: FinalizationJobConfig
   ) {
     this.challengeWindowSeconds = config.challengeWindowSeconds;
+    this.maxRunMs = config.maxRunMs ?? 0;
   }
 
   async run(): Promise<FinalizationJobResult> {
@@ -120,6 +129,17 @@ export class FinalizationJob {
     const results: FinalizationCandidateResult[] = [];
 
     for (const candidate of candidates) {
+      // Elapsed-time guard: stop processing if the job has exceeded maxRunMs.
+      // This prevents a large backlog from monopolising the scheduler slot.
+      if (this.maxRunMs > 0 && Date.now() - startedAt.getTime() >= this.maxRunMs) {
+        this.logger.warn("Finalization job exceeded maxRunMs, stopping early", {
+          maxRunMs: this.maxRunMs,
+          processedSoFar: results.length,
+          remainingCandidates: candidates.length - results.length,
+        });
+        break;
+      }
+
       this.logger.info("Finalization candidate eligible", {
         candidateId: candidate.id,
         marketId: candidate.marketId,


### PR DESCRIPTION
## Summary

Add a configurable `maxRunMs` option to `FinalizationJobConfig`. When set, the candidate loop checks elapsed wall-clock time before each candidate and stops early if the budget is exceeded, logging a warning with remaining count. Prevents a large backlog from monopolising the scheduler slot.

## Changes

- `apps/workers/src/finalization/job.ts`: Add `maxRunMs?` to config, store on instance, check `Date.now() - startedAt` before each candidate, warn-log on early stop
- `apps/workers/src/finalization/job.test.ts`: Tests for disabled guard (0), early-stop with fake timers, and within-budget no-warn path

## Validation

- Prettier formatting verified
- No unrelated files modified

Closes #789