### PR TITLE
feat(workers): cap oracle submission stream length and expose getStreamLength (#790)

### DIFF
--- a/apps/workers/src/oracle/redis-submission-queue.test.ts
+++ b/apps/workers/src/oracle/redis-submission-queue.test.ts
@@ -354,4 +354,107 @@ describe("RedisSubmissionQueue", () => {
       );
     });
   });
+
+  describe("stream length cap (maxStreamLength)", () => {
+    function makeItem(marketId = "mkt-cap"): SubmissionQueueItem {
+      return {
+        id: `item-${marketId}`,
+        request: { marketId, oracleAddress: "GORACLE" },
+        result: {
+          outcome: true,
+          source: "Test",
+          signature: "sig",
+          publicKey: "pub",
+          confidence: 1,
+          confidenceMetadata: { score: 1, method: "test" },
+          sourceMetadata: { provider: "Test" },
+          timestamp: "2024-01-01T00:00:00Z",
+        },
+        status: "pending" as const,
+        enqueuedAt: "2024-01-01T00:00:00Z",
+        attempts: 0,
+      };
+    }
+
+    it("passes MAXLEN ~ args to xadd when maxStreamLength is set", async () => {
+      const cappedClient = createMockRedisClient();
+      cappedClient.exists.mockResolvedValue(0);
+      cappedClient.set.mockResolvedValue("OK");
+      cappedClient.xadd.mockResolvedValue("1-0");
+
+      const cappedQueue = new RedisSubmissionQueue({
+        redisClient: cappedClient,
+        visibilityTimeoutMs: 5000,
+        logger: mockLogger,
+        keyPrefix: "test:",
+        maxStreamLength: 500,
+      });
+
+      await cappedQueue.enqueue(makeItem("mkt-1"));
+
+      expect(cappedClient.xadd).toHaveBeenCalledWith(
+        "test:oracle:submissions",
+        "MAXLEN",
+        "~",
+        "500",
+        "*",
+        "payload",
+        expect.any(String),
+        "marketId",
+        "mkt-1",
+        "payloadHash",
+        expect.any(String)
+      );
+    });
+
+    it("does not pass MAXLEN when maxStreamLength is 0 (default)", async () => {
+      mockClient.exists.mockResolvedValue(0);
+      mockClient.set.mockResolvedValue("OK");
+      mockClient.xadd.mockResolvedValue("1-0");
+
+      await queue.enqueue(makeItem("mkt-2"));
+
+      const xaddArgs: string[] = mockClient.xadd.mock.calls[0];
+      expect(xaddArgs).not.toContain("MAXLEN");
+    });
+
+    it("does not pass MAXLEN when maxStreamLength is omitted", async () => {
+      const noCapClient = createMockRedisClient();
+      noCapClient.exists.mockResolvedValue(0);
+      noCapClient.set.mockResolvedValue("OK");
+      noCapClient.xadd.mockResolvedValue("2-0");
+
+      const noCapQueue = new RedisSubmissionQueue({
+        redisClient: noCapClient,
+        visibilityTimeoutMs: 5000,
+        logger: mockLogger,
+        keyPrefix: "test:",
+        // maxStreamLength omitted
+      });
+
+      await noCapQueue.enqueue(makeItem("mkt-3"));
+
+      const xaddArgs: string[] = noCapClient.xadd.mock.calls[0];
+      expect(xaddArgs).not.toContain("MAXLEN");
+    });
+  });
+
+  describe("getStreamLength", () => {
+    it("returns the stream length reported by xlen", async () => {
+      mockClient.xlen = vi.fn().mockResolvedValue(42);
+
+      const len = await queue.getStreamLength();
+
+      expect(len).toBe(42);
+      expect(mockClient.xlen).toHaveBeenCalledWith("test:oracle:submissions");
+    });
+
+    it("returns 0 when xlen returns a non-number", async () => {
+      mockClient.xlen = vi.fn().mockResolvedValue(null);
+
+      const len = await queue.getStreamLength();
+
+      expect(len).toBe(0);
+    });
+  });
 });

--- a/apps/workers/src/oracle/redis-submission-queue.ts
+++ b/apps/workers/src/oracle/redis-submission-queue.ts
@@ -37,6 +37,13 @@ export interface RedisSubmissionQueueConfig {
   logger: ILogger;
   /** Optional key prefix override. Falls back to REDIS_KEY_PREFIX env var (default: "vatix:"). */
   keyPrefix?: string;
+  /**
+   * Maximum number of entries to retain in the Redis stream (approximate,
+   * uses XADD MAXLEN ~ semantics). Older entries beyond this cap are trimmed
+   * by Redis automatically. Set to 0 to disable trimming (default: 0).
+   * Recommended production value: 10 000.
+   */
+  maxStreamLength?: number;
 }
 
 export interface QueuedSubmission extends SubmissionQueueItem {
@@ -54,6 +61,8 @@ export class RedisSubmissionQueue {
   private logger: ILogger;
   /** Fully-qualified Redis stream key (prefix + base name). */
   private streamKey: string;
+  /** Approximate maximum number of entries kept in the stream. 0 = unlimited. */
+  private maxStreamLength: number;
 
   constructor(config: RedisSubmissionQueueConfig) {
     this.redisClient = config.redisClient;
@@ -61,6 +70,7 @@ export class RedisSubmissionQueue {
     this.deduplicationTtlSeconds = config.deduplicationTtlSeconds ?? 86400;
     this.logger = config.logger;
     this.streamKey = buildStreamKey(config.keyPrefix);
+    this.maxStreamLength = config.maxStreamLength ?? 0;
   }
 
   /**
@@ -197,16 +207,35 @@ export class RedisSubmissionQueue {
       return false;
     }
 
-    const streamId = await this.redisClient.xadd(
-      this.streamKey,
-      "*",
-      "payload",
-      JSON.stringify(item),
-      "marketId",
-      marketId,
-      "payloadHash",
-      payloadHash
-    );
+    // Use XADD MAXLEN ~ to cap stream size when maxStreamLength is configured.
+    // The tilde (~) makes the trim approximate for better performance.
+    const xaddArgs: any[] =
+      this.maxStreamLength > 0
+        ? [
+            this.streamKey,
+            "MAXLEN",
+            "~",
+            String(this.maxStreamLength),
+            "*",
+            "payload",
+            JSON.stringify(item),
+            "marketId",
+            marketId,
+            "payloadHash",
+            payloadHash,
+          ]
+        : [
+            this.streamKey,
+            "*",
+            "payload",
+            JSON.stringify(item),
+            "marketId",
+            marketId,
+            "payloadHash",
+            payloadHash,
+          ];
+
+    const streamId = await this.redisClient.xadd(...xaddArgs);
 
     await this.markAsQueued(marketId, payloadHash, streamId);
     await this.markMarketInFlight(marketId, streamId);
@@ -220,6 +249,15 @@ export class RedisSubmissionQueue {
     });
 
     return true;
+  }
+
+  /**
+   * Return the current number of entries in the Redis stream.
+   * Useful for health checks and operational dashboards.
+   */
+  async getStreamLength(): Promise<number> {
+    const len = await this.redisClient.xlen(this.streamKey);
+    return typeof len === "number" ? len : 0;
   }
 
   /**


### PR DESCRIPTION
## Summary

Add a configurable `maxStreamLength` option to `RedisSubmissionQueueConfig`. When set > 0, `XADD` uses `MAXLEN ~` semantics to trim the stream to the given approximate cap, preventing unbounded growth under backlog conditions. Also adds `getStreamLength()` for health-check and dashboard surfaces. Both changes are backward-compatible (`maxStreamLength` defaults to 0 = no trim).

## Changes

- `apps/workers/src/oracle/redis-submission-queue.ts`: Add `maxStreamLength?` to config, pass `MAXLEN ~ <n>` args when enabled, add `getStreamLength()` via `XLEN`
- `apps/workers/src/oracle/redis-submission-queue.test.ts`: Tests for MAXLEN arg presence/absence and `getStreamLength` return value

## Validation

- Prettier formatting verified
- No unrelated files modified

Closes #790