### PR TITLE
Indexer reliability: jittered retries, DB env check, atomic batch writes, idempotency coverage

### DIFF
--- a/apps/indexer/src/batchWriter.test.ts
+++ b/apps/indexer/src/batchWriter.test.ts
@@ -265,21 +265,53 @@ describe("PrismaBatchWriter", () => {
     expect(tx.market.upsert).toHaveBeenCalledTimes(1);
   });
 
-  it("collects per-record errors without aborting the transaction", async () => {
-    const tx = createMockTx();
-    tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);
-    tx.indexedTrade.create.mockRejectedValue(new Error("fk violation"));
-    mockPrisma.$transaction.mockImplementation(async (fn) => fn(tx));
+  describe("mid-batch failure rolls back the whole batch (Issue #756)", () => {
+    it("rejects write() instead of returning a partial result when a record fails to persist", async () => {
+      const tx = createMockTx();
+      tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);
+      tx.indexedTrade.create.mockRejectedValue(new Error("fk violation"));
+      mockPrisma.$transaction.mockImplementation(async (fn) => fn(tx));
 
-    const writer = new PrismaBatchWriter();
-    const result = await writer.write([
-      { kind: "trade", data: withIdempotencyKey(TRADE) },
-    ]);
+      const writer = new PrismaBatchWriter();
+      await expect(
+        writer.write([{ kind: "trade", data: withIdempotencyKey(TRADE) }])
+      ).rejects.toThrow("fk violation");
+    });
 
-    expect(result.written).toBe(0);
-    expect(result.skipped).toBe(0);
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].error).toContain("fk violation");
+    it("stops processing subsequent records once one record fails (no partial commit)", async () => {
+      const tx = createMockTx();
+      tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);
+      tx.indexedTrade.create.mockRejectedValue(new Error("fk violation"));
+      mockPrisma.$transaction.mockImplementation(async (fn) => fn(tx));
+
+      const writer = new PrismaBatchWriter();
+      await expect(
+        writer.write([
+          { kind: "trade", data: withIdempotencyKey(TRADE) },
+          { kind: "market_created", data: withIdempotencyKey(MARKET_CREATED) },
+        ])
+      ).rejects.toThrow("fk violation");
+
+      // The trade record failed first — the market_created record after it
+      // must never be attempted within the same (now-aborted) transaction.
+      expect(tx.market.upsert).not.toHaveBeenCalled();
+    });
+
+    it("does not retry a non-retryable mid-batch persist failure", async () => {
+      const tx = createMockTx();
+      tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);
+      tx.market.upsert.mockRejectedValue(new Error("constraint violation"));
+      mockPrisma.$transaction.mockImplementation(async (fn) => fn(tx));
+
+      const writer = new PrismaBatchWriter();
+      await expect(
+        writer.write([
+          { kind: "market_created", data: withIdempotencyKey(MARKET_CREATED) },
+        ])
+      ).rejects.toThrow("constraint violation");
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("transient DB error retry", () => {
@@ -356,7 +388,12 @@ describe("PrismaBatchWriter", () => {
 
     it("logs a warning on each retry attempt", async () => {
       const warnSpy = vi.fn();
-      const logger = { warn: warnSpy, info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+      const logger = {
+        warn: warnSpy,
+        info: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
 
       const tx = createMockTx();
       tx.indexerProcessedEvent.findUnique.mockResolvedValue(null);

--- a/apps/indexer/src/batchWriter.ts
+++ b/apps/indexer/src/batchWriter.ts
@@ -14,7 +14,6 @@ import { insertAllIfNew, insertIfNew } from "./idempotency.js";
 import { getPrismaClient } from "../../../src/services/prisma.js";
 import type { ILogger } from "../../../packages/shared/src/logger.js";
 import type { PrismaClient } from "../../../src/generated/prisma/client/index.js";
-import { sanitizeForJson } from "./safeJson.js";
 import { sleep } from "./retry.js";
 
 export type BatchRecord =
@@ -68,8 +67,7 @@ const BATCH_WRITE_RETRY_DELAY_MS = 200;
 
 function isBatchWriteRetryable(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  const code: string =
-    (err as any).code ?? (err as any).errorCode ?? "";
+  const code: string = (err as any).code ?? (err as any).errorCode ?? "";
   return RETRYABLE_PRISMA_CODES.has(code);
 }
 
@@ -127,46 +125,35 @@ export class PrismaBatchWriter implements BatchWriter {
 
           skipped += deduped.duplicateCount;
 
+          // A record failing to persist must abort and roll back the whole
+          // transaction rather than committing the records that already
+          // succeeded — a batch is applied atomically or not at all, so a
+          // retry never has to reason about a half-applied batch (Issue #756).
           for (const dedupedRecord of deduped.inserted) {
             const record = recordByKey.get(dedupedRecord.idempotencyKey);
             if (!record) {
               continue;
             }
 
-            try {
-              const result = await insertIfNew(
-                record.data,
-                async (persisted) =>
-                  this.persistRecord(
-                    tx,
-                    record,
-                    persisted as
-                      | PersistedTrade
-                      | PersistedResolution
-                      | PersistedCollateralDeposit
-                      | PersistedMarketCreated
-                  ),
-                { logger: duplicateLogger }
-              );
+            const result = await insertIfNew(
+              record.data,
+              async (persisted) =>
+                this.persistRecord(
+                  tx,
+                  record,
+                  persisted as
+                    | PersistedTrade
+                    | PersistedResolution
+                    | PersistedCollateralDeposit
+                    | PersistedMarketCreated
+                ),
+              { logger: duplicateLogger }
+            );
 
-              if (result.status === "inserted") {
-                written += 1;
-              } else {
-                skipped += 1;
-              }
-            } catch (error) {
-              const serializedRecord = sanitizeForJson(record) as Record<
-                string,
-                unknown
-              >;
-              errors.push({
-                record: serializedRecord,
-                error: error instanceof Error ? error.message : String(error),
-              });
-              this.logger?.warn("Failed to persist indexer batch record", {
-                record: serializedRecord,
-                error: sanitizeForJson(error),
-              });
+            if (result.status === "inserted") {
+              written += 1;
+            } else {
+              skipped += 1;
             }
           }
         });

--- a/apps/indexer/src/eventFetcher.test.ts
+++ b/apps/indexer/src/eventFetcher.test.ts
@@ -375,3 +375,4 @@ describe("EventFetcher", () => {
       expect(result.events).toHaveLength(1);
     });
   });
+});

--- a/apps/indexer/src/eventFetcher.ts
+++ b/apps/indexer/src/eventFetcher.ts
@@ -7,7 +7,7 @@ import type {
 } from "./types.js";
 import type { Telemetry } from "./telemetry.js";
 import { consoleTelemetry } from "./telemetry.js";
-import { isTransientError, sleep } from "./retry.js";
+import { isTransientError, sleep, withRetry } from "./retry.js";
 
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_DELAY_MS = 500;
@@ -122,6 +122,10 @@ export class EventFetcher {
     return { events: allEvents, latestLedger };
   }
 
+  /**
+   * Fetch a single page, retrying transient RPC failures with the shared
+   * jittered-backoff policy in retry.ts (bounded by config.maxRetries).
+   */
   private async fetchPageWithRetry(
     startLedger: number,
     cursor?: string
@@ -129,80 +133,75 @@ export class EventFetcher {
     const { maxRetries, retryDelayMs, pageLimit, contractId, fetchTimeoutMs } =
       this.config;
 
-    for (let attempt = 0; attempt <= maxRetries; attempt++) {
-      try {
-        const fetchCall = this.server.getEvents({
-          startLedger,
-          filters: [{ contractIds: [contractId] }],
-          limit: pageLimit,
-          ...(cursor ? ({ cursor } as any) : {}),
-        } as any);
+    let attempt = -1;
 
-        // Wrap with a per-page timeout when fetchTimeoutMs > 0 so a stalled
-        // RPC endpoint cannot block the ingestion loop indefinitely.
-        const response: StellarRpc.Api.GetEventsResponse =
-          fetchTimeoutMs > 0
-            ? await Promise.race([
-                fetchCall,
-                new Promise<never>((_, reject) =>
-                  setTimeout(
-                    () =>
-                      reject(
-                        Object.assign(
-                          new Error(
-                            `EventFetcher: getEvents timed out after ${fetchTimeoutMs}ms`
+    try {
+      return await withRetry(
+        async () => {
+          attempt++;
+          try {
+            const fetchCall = this.server.getEvents({
+              startLedger,
+              filters: [{ contractIds: [contractId] }],
+              limit: pageLimit,
+              ...(cursor ? ({ cursor } as any) : {}),
+            } as any);
+
+            // Wrap with a per-page timeout when fetchTimeoutMs > 0 so a
+            // stalled RPC endpoint cannot block the ingestion loop
+            // indefinitely.
+            const response: StellarRpc.Api.GetEventsResponse =
+              fetchTimeoutMs > 0
+                ? await Promise.race([
+                    fetchCall,
+                    new Promise<never>((_, reject) =>
+                      setTimeout(
+                        () =>
+                          reject(
+                            Object.assign(
+                              new Error(
+                                `EventFetcher: getEvents timed out after ${fetchTimeoutMs}ms`
+                              ),
+                              { code: "ETIMEDOUT" }
+                            )
                           ),
-                          { code: "ETIMEDOUT" }
-                        )
-                      ),
-                    fetchTimeoutMs
-                  )
-                ),
-              ])
-            : await fetchCall;
+                        fetchTimeoutMs
+                      )
+                    ),
+                  ])
+                : await fetchCall;
 
-        // Success — reset the consecutive disconnection counter
-        this.consecutiveDisconnections = 0;
+            // Success — reset the consecutive disconnection counter
+            this.consecutiveDisconnections = 0;
 
-        this.telemetry.record(
-          "indexer.rpc.page_fetched",
-          response.events.length,
-          {
-            attempt: String(attempt),
+            this.telemetry.record(
+              "indexer.rpc.page_fetched",
+              response.events.length,
+              {
+                attempt: String(attempt),
+              }
+            );
+
+            return response;
+          } catch (err) {
+            if (isTransientError(err)) {
+              this.consecutiveDisconnections++;
+              this.telemetry.record("indexer.rpc.disconnection", 1, {
+                consecutive: String(this.consecutiveDisconnections),
+              });
+            }
+            throw err;
           }
-        );
-
-        return response;
-      } catch (err) {
-        const isTransient = isTransientError(err);
-        const isLast = attempt === maxRetries;
-
-        if (isTransient) {
-          this.consecutiveDisconnections++;
-          this.telemetry.record("indexer.rpc.disconnection", 1, {
-            consecutive: String(this.consecutiveDisconnections),
-          });
-        }
-
-        if (isLast || !isTransient) {
-          this.telemetry.record("indexer.rpc.error", 1, {
-            attempt: String(attempt),
-            transient: String(isTransient),
-          });
-          throw err;
-        }
-
-        const delay = retryDelayMs * 2 ** attempt;
-        console.warn(
-          `[EventFetcher] transient error (attempt ${attempt + 1}), retrying in ${delay}ms`,
-          err
-        );
-        await sleep(delay);
-      }
+        },
+        { maxRetries, retryDelayMs }
+      );
+    } catch (err) {
+      this.telemetry.record("indexer.rpc.error", 1, {
+        attempt: String(attempt),
+        transient: String(isTransientError(err)),
+      });
+      throw err;
     }
-
-    // Unreachable — satisfies TypeScript
-    throw new Error("fetchPageWithRetry: exhausted retries");
   }
 
   private toRawEvent(e: StellarRpc.Api.EventResponse): RawChainEvent {

--- a/apps/indexer/src/idempotency.test.ts
+++ b/apps/indexer/src/idempotency.test.ts
@@ -6,7 +6,11 @@ import {
   insertIfNew,
   insertAllIfNew,
 } from "./idempotency.js";
-import type { NormalizedTrade, NormalizedResolution } from "./types.js";
+import type {
+  NormalizedTrade,
+  NormalizedResolution,
+  NormalizedMarketCreated,
+} from "./types.js";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -40,6 +44,18 @@ const RESOLUTION: NormalizedResolution = {
   marketId: "market-xyz",
   outcome: "NO",
   oracleAddress: "GORACLE",
+};
+
+const MARKET_CREATED: NormalizedMarketCreated = {
+  eventId: "0000000010-0000000000-0000000001",
+  ledger: 10,
+  ledgerClosedAt: "2024-05-01T00:00:00Z",
+  contractId: CONTRACT,
+  marketId: "market-new",
+  question: "Will it rain tomorrow?",
+  endTime: "2024-12-31T00:00:00Z",
+  oracleAddress: "GORACLE",
+  status: "ACTIVE",
 };
 
 // ─── parseEventId ─────────────────────────────────────────────────────────────
@@ -164,6 +180,30 @@ describe("withIdempotencyKey", () => {
     expect(persisted.outcome).toBe(RESOLUTION.outcome);
   });
 
+  it("stamps a NormalizedMarketCreated with an idempotencyKey", () => {
+    const persisted = withIdempotencyKey(MARKET_CREATED);
+    expect(persisted.idempotencyKey).toMatch(/^[0-9a-f]{64}$/);
+    expect(persisted.marketId).toBe(MARKET_CREATED.marketId);
+  });
+
+  it("market-created key matches what generateIdempotencyKey produces independently", () => {
+    const expected = generateIdempotencyKey({
+      id: MARKET_CREATED.eventId,
+      contractId: MARKET_CREATED.contractId,
+    }).key;
+    expect(withIdempotencyKey(MARKET_CREATED).idempotencyKey).toBe(expected);
+  });
+
+  it("produces distinct keys for two different market-created events", () => {
+    const other: NormalizedMarketCreated = {
+      ...MARKET_CREATED,
+      eventId: "0000000011-0000000000-0000000001",
+    };
+    expect(withIdempotencyKey(MARKET_CREATED).idempotencyKey).not.toBe(
+      withIdempotencyKey(other).idempotencyKey
+    );
+  });
+
   it("key matches what generateIdempotencyKey produces independently", () => {
     const expected = generateIdempotencyKey({
       id: TRADE.eventId,
@@ -245,5 +285,29 @@ describe("insertIfNew", () => {
 
     expect(result).toEqual({ inserted: [later], duplicateCount: 1 });
     expect(upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not insert a second market on a retried/duplicate market-created delivery (Issue #755)", async () => {
+    const persistedMarket = withIdempotencyKey(MARKET_CREATED);
+
+    // First delivery inserts the market; a retry (or duplicate RPC replay)
+    // of the same ledger/tx/event position must be a no-op, not a second
+    // market row.
+    const upsert = vi
+      .fn()
+      .mockResolvedValueOnce(persistedMarket)
+      .mockResolvedValueOnce(null);
+
+    const first = await insertIfNew(persistedMarket, upsert);
+    const second = await insertIfNew(persistedMarket, upsert);
+
+    expect(first.status).toBe("inserted");
+    expect(second.status).toBe("duplicate");
+    if (second.status === "duplicate") {
+      expect(second.key).toBe(persistedMarket.idempotencyKey);
+    }
+    expect(upsert).toHaveBeenCalledTimes(2);
+    expect(upsert).toHaveBeenNthCalledWith(1, persistedMarket);
+    expect(upsert).toHaveBeenNthCalledWith(2, persistedMarket);
   });
 });

--- a/apps/indexer/src/main.ts
+++ b/apps/indexer/src/main.ts
@@ -6,11 +6,28 @@ import { InternalIndexerMetricsService } from "./metrics.js";
 import { PrismaCursorStorageClient } from "./storage.js";
 import { EventFetcher } from "./eventFetcher.js";
 import { PrismaBatchWriter } from "./batchWriter.js";
+import { checkStartupHealth } from "./startupHealth.js";
 import { disconnectPrisma } from "../../../src/services/prisma.js";
 
 async function bootstrap(): Promise<void> {
   const config = loadConfig();
   const logger = createLogger(config.logLevel);
+
+  // Fail fast on missing required env (e.g. DATABASE_URL) before touching
+  // the database or starting the ingestion loop.
+  const health = checkStartupHealth({
+    cursor: null,
+    networkId: config.networkId,
+    cursorKey: config.cursorKey,
+    databaseUrl: process.env.DATABASE_URL,
+  });
+  if (!health.valid) {
+    logger.error("Indexer startup health check failed", {
+      errors: health.errors,
+    });
+    throw new Error(`Startup health check failed: ${health.errors.join("; ")}`);
+  }
+
   const metrics = new InternalIndexerMetricsService();
   const storage = new PrismaCursorStorageClient(
     config.networkId,

--- a/apps/indexer/src/retry.test.ts
+++ b/apps/indexer/src/retry.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
-import { isTransientError, withRetry, RetryValidationError } from "./retry.js";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  isTransientError,
+  withRetry,
+  RetryValidationError,
+  jitteredBackoffMs,
+} from "./retry.js";
+
+afterEach(() => vi.restoreAllMocks());
 
 // ─── isTransientError ────────────────────────────────────────────────────────
 
@@ -38,6 +45,39 @@ describe("isTransientError", () => {
     expect(isTransientError("string error")).toBe(false);
     expect(isTransientError(null)).toBe(false);
     expect(isTransientError(42)).toBe(false);
+  });
+});
+
+// ─── jitteredBackoffMs ─────────────────────────────────────────────────────────
+
+describe("jitteredBackoffMs", () => {
+  it("returns half the exponential delay when Math.random returns 0", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    expect(jitteredBackoffMs(100, 0)).toBe(50);
+    expect(jitteredBackoffMs(100, 2)).toBe(200);
+  });
+
+  it("approaches the full exponential delay as Math.random approaches 1", () => {
+    vi.spyOn(Math, "random").mockReturnValue(1);
+    expect(jitteredBackoffMs(100, 0)).toBe(100);
+    expect(jitteredBackoffMs(100, 2)).toBe(400);
+  });
+
+  it("stays within [half, full] of the exponential delay", () => {
+    const base = 50;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const exponential = base * 2 ** attempt;
+      for (let i = 0; i < 20; i++) {
+        const delay = jitteredBackoffMs(base, attempt);
+        expect(delay).toBeGreaterThanOrEqual(exponential / 2);
+        expect(delay).toBeLessThanOrEqual(exponential);
+      }
+    }
+  });
+
+  it("returns 0 for a zero base delay regardless of attempt", () => {
+    expect(jitteredBackoffMs(0, 0)).toBe(0);
+    expect(jitteredBackoffMs(0, 5)).toBe(0);
   });
 });
 

--- a/apps/indexer/src/retry.ts
+++ b/apps/indexer/src/retry.ts
@@ -28,6 +28,23 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Compute a jittered exponential backoff delay for the given attempt.
+ *
+ * Uses "equal jitter": half of the exponential delay is guaranteed, the
+ * other half is randomized. Backoff still grows with the attempt count,
+ * but retries from many callers failing at the same time no longer land
+ * on the same schedule (thundering herd).
+ */
+export function jitteredBackoffMs(
+  baseDelayMs: number,
+  attempt: number
+): number {
+  const exponential = baseDelayMs * 2 ** attempt;
+  const half = exponential / 2;
+  return half + Math.random() * half;
+}
+
 export interface RetryOptions {
   /** Maximum number of retry attempts after the first failure. */
   maxRetries: number;
@@ -75,7 +92,7 @@ export async function withRetry<T>(
       if (isLast || !isTransientError(err)) {
         throw err;
       }
-      await sleep(retryDelayMs * 2 ** attempt);
+      await sleep(jitteredBackoffMs(retryDelayMs, attempt));
     }
   }
 

--- a/apps/indexer/src/startupHealth.test.ts
+++ b/apps/indexer/src/startupHealth.test.ts
@@ -5,6 +5,7 @@ const validInput = {
   cursor: "12345",
   networkId: "mainnet",
   cursorKey: "ingestion",
+  databaseUrl: "postgresql://user:pass@localhost:5432/vatix",
 };
 
 describe("checkStartupHealth", () => {
@@ -20,6 +21,29 @@ describe("checkStartupHealth", () => {
     const result = checkStartupHealth({ ...validInput, cursor: null });
     expect(result.status).toBe(200);
     expect(result.valid).toBe(true);
+  });
+
+  it("returns 400 when databaseUrl is missing", () => {
+    const result = checkStartupHealth({
+      ...validInput,
+      databaseUrl: undefined,
+    });
+    expect(result.status).toBe(400);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("DATABASE_URL"))).toBe(true);
+  });
+
+  it("returns 400 when databaseUrl is an empty string", () => {
+    const result = checkStartupHealth({ ...validInput, databaseUrl: "" });
+    expect(result.status).toBe(400);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("DATABASE_URL"))).toBe(true);
+  });
+
+  it("returns 400 when databaseUrl is whitespace only", () => {
+    const result = checkStartupHealth({ ...validInput, databaseUrl: "   " });
+    expect(result.status).toBe(400);
+    expect(result.valid).toBe(false);
   });
 
   it("returns 400 when networkId is empty", () => {
@@ -69,8 +93,9 @@ describe("checkStartupHealth", () => {
       cursor: "bad",
       networkId: "",
       cursorKey: "",
+      databaseUrl: undefined,
     });
     expect(result.status).toBe(400);
-    expect(result.errors.length).toBeGreaterThanOrEqual(3);
+    expect(result.errors.length).toBeGreaterThanOrEqual(4);
   });
 });

--- a/apps/indexer/src/startupHealth.ts
+++ b/apps/indexer/src/startupHealth.ts
@@ -2,6 +2,8 @@ export interface StartupHealthInput {
   cursor: string | null;
   networkId: string;
   cursorKey: string;
+  /** process.env.DATABASE_URL — required for the indexer to persist cursor/events. */
+  databaseUrl: string | undefined;
 }
 
 export interface StartupHealthResult {
@@ -14,6 +16,10 @@ export function checkStartupHealth(
   input: StartupHealthInput
 ): StartupHealthResult {
   const errors: string[] = [];
+
+  if (!input.databaseUrl || input.databaseUrl.trim() === "") {
+    errors.push("Missing required environment variable: DATABASE_URL");
+  }
 
   if (!input.networkId || input.networkId.trim() === "") {
     errors.push("networkId must not be empty");

--- a/docs/indexer-event-mapping.md
+++ b/docs/indexer-event-mapping.md
@@ -8,12 +8,12 @@ Test vectors: [`apps/indexer/fixtures/contract-event-vectors.json`](../apps/inde
 
 ## Event table
 
-| Event topic            | Payload shape            | Parser                         | Normalized type               | DB table(s)                                        |
-| ---------------------- | ------------------------ | ------------------------------ | ----------------------------- | -------------------------------------------------- |
-| `trade_executed`       | ScvMap (9 fields)        | `tradeParser.ts`               | `NormalizedTrade`             | `IndexedTrade`                                     |
-| `collateral_deposited` | ScvVec 3-tuple           | `collateralDepositedParser.ts` | `NormalizedCollateralDeposit` | `CollateralDeposit`                                |
-| `market_resolved`      | ScvVec 3-tuple or ScvMap | `resolutionParser.ts`          | `NormalizedResolution`        | `ResolutionCandidate`                              |
-| `market_created`       | pre-decoded JS object    | `market-created-parser.ts`     | `MarketCreatedEvent`          | `Market` (ingested outside `PollingIngestionLoop`) |
+| Event topic            | Payload shape            | Parser                         | Normalized type               | DB table(s)           |
+| ---------------------- | ------------------------ | ------------------------------ | ----------------------------- | --------------------- |
+| `trade_executed`       | ScvMap (9 fields)        | `tradeParser.ts`               | `NormalizedTrade`             | `IndexedTrade`        |
+| `collateral_deposited` | ScvVec 3-tuple           | `collateralDepositedParser.ts` | `NormalizedCollateralDeposit` | `CollateralDeposit`   |
+| `market_resolved`      | ScvVec 3-tuple or ScvMap | `resolutionParser.ts`          | `NormalizedResolution`        | `ResolutionCandidate` |
+| `market_created`       | ScvMap (topic + value)   | `marketCreatedParser.ts`       | `NormalizedMarketCreated`     | `Market`              |
 
 All events share the same topic encoding: **topic[0] = ScvSymbol** carrying the event name. Soroban's `#[contractevent]` macro derives that symbol from the event struct name including its literal `Event` suffix (e.g. `MarketCreatedEvent` → `market_created_event`) — see `contracts/market/src/events.rs`.
 
@@ -83,17 +83,20 @@ The contract does not publish an oracle address on this event, so `oracleAddress
 
 **Topic XDR:** `AAAADwAAABRtYXJrZXRfY3JlYXRlZF9ldmVudA==` (`market_created_event`)
 
-**Parser input:** Raw chain event (`RawChainEvent`), parsed by `apps/indexer/src/marketCreatedParser.ts` and run inside `PollingIngestionLoop` alongside the other three event types.
+**Parser input:** Raw chain event (`RawChainEvent`), parsed by `apps/indexer/src/marketCreatedParser.ts` and run inside `PollingIngestionLoop.ingestFromCursor()` alongside the other three event types — `parseMarketCreatedEvents()` normalizes each matching event into a `NormalizedMarketCreated`, exactly like `parseTradeEvents()`, `parseResolutionEvents()`, and `parseCollateralDepositedEvents()`.
 
-| Field           | Type                                    | Notes                                       |
-| --------------- | --------------------------------------- | ------------------------------------------- |
-| `id`            | `string`                                | Required                                    |
-| `question`      | `string`                                | Required, non-empty                         |
-| `endTime`       | `number \| string`                      | Unix seconds or ISO-8601; normalized to ISO |
-| `oracleAddress` | `string`                                | G-prefixed, 56 chars; trimmed               |
-| `status`        | `"ACTIVE" \| "RESOLVED" \| "CANCELLED"` | Default `"ACTIVE"`                          |
+| Field           | Type                                    | Notes                                                                         |
+| --------------- | --------------------------------------- | ----------------------------------------------------------------------------- |
+| `eventId`       | `string`                                | Stellar event id — `{ledger}-{txIndex}-{eventIndex}`                          |
+| `marketId`      | `string`                                | On-chain market identifier, used as `Market.id`                               |
+| `question`      | `string`                                | Decoded from the event value `ScvMap`                                         |
+| `endTime`       | `string`                                | Unix seconds or ISO-8601 input; normalized to ISO                             |
+| `oracleAddress` | `string`                                | Not published by the contract on this event; left `""` pending reconciliation |
+| `status`        | `"ACTIVE" \| "RESOLVED" \| "CANCELLED"` | Always `"ACTIVE"` for a freshly created market                                |
 
-**DB write:** `Market` row via `PrismaBatchWriter`, `upsert`-ed on `id` (create on first sight, update on replay — e.g. a status change). The parser itself returns `ParseResult<MarketCreatedEvent>` and does not write directly; the caller (the webhook/subscription handler, not `PollingIngestionLoop`) is responsible for passing the parsed result into `PrismaBatchWriter.write()`.
+**DB write:** `Market` row via `PrismaBatchWriter`, `upsert`-ed on `id` (create on first sight, update on replay — e.g. a status change). Like every other event kind, the normalized record is stamped with an idempotency key via `withIdempotencyKey()` before being handed to `PrismaBatchWriter.write()` — see [Idempotency key format](#idempotency-key-format) below.
+
+`apps/indexer/market-created-parser.ts` (no `src/` prefix) is an unused legacy parser kept only for its own test; it is not wired into `PollingIngestionLoop` or any other ingestion path.
 
 ---
 
@@ -116,11 +119,22 @@ PollingIngestionLoop.ingestFromCursor()
              ▼
         PrismaBatchWriter.write()
              │
+             ├── Market.upsert()           (market_created_event)
              ├── IndexedTrade              (trade_executed_event)
              ├── ResolutionCandidate       (market_resolved)
              └── CollateralDeposit         (collateral_deposited)
-
-Market.upsert()  ← market_created, via the out-of-band ingestion path described in §4
 ```
 
 Events with unrecognised topic symbols are silently skipped by each parser's `isXxxEvent` guard. Parse errors are collected per-event and logged as `warn` without dropping the rest of the batch.
+
+---
+
+## Idempotency key format
+
+Every normalized record — trade, resolution, collateral deposit, and market-created alike — is stamped with an idempotency key by `withIdempotencyKey()` (`apps/indexer/src/idempotency.ts`) before it reaches `PrismaBatchWriter.write()`:
+
+```
+key = SHA256(`${contractId}:${ledger}:${txIndex}:${eventIndex}`)
+```
+
+`ledger`, `txIndex`, and `eventIndex` are parsed from the Stellar event id (`{ledger}-{txIndex}-{eventIndex}`, e.g. `0000000042-0000000001-0000000003`), the same id every event kind — including `market_created` — carries. `PrismaBatchWriter` uses this key as the unique constraint on `IndexerProcessedEvent`, so a duplicate or retried delivery of the same event (same ledger, tx, and event position) is skipped as a no-op instead of writing a second row — e.g. a second `Market` for a replayed `market_created` event. See `apps/indexer/src/idempotency.test.ts` and `apps/indexer/src/batchWriter.test.ts` for the duplicate-delivery test coverage.


### PR DESCRIPTION
## Summary

Closes #758, 
closes #757
closes #756
closes #755 

four scoped indexer reliability fixes, batched together since they touch overlapping files (`retry.ts`, `eventFetcher.ts`, `batchWriter.ts`, `idempotency.ts`, `startupHealth.ts`).

## What changed

**#758 — Event fetcher retries with jittered backoff**
- Added `jitteredBackoffMs()` to `retry.ts` (equal-jitter exponential backoff: half the exponential delay is fixed, half is randomized) and switched `withRetry`'s sleep to use it, so retries no longer all land on the same schedule.
- `EventFetcher.fetchPageWithRetry` previously duplicated its own retry loop instead of using `retry.ts`. Refactored it to delegate to `withRetry`, so the fetcher now goes through the single, bounded, jittered retry policy — while preserving its existing telemetry, per-page timeout, and consecutive-disconnection tracking behavior.

**#757 — Startup health fails when DATABASE_URL missing**
- `checkStartupHealth` validated `networkId`/`cursorKey`/`cursor` but never checked `DATABASE_URL`, and was never actually called anywhere in `main.ts` (dead code). Added `databaseUrl` validation with an error that names the missing variable (`Missing required environment variable: DATABASE_URL`), and wired `checkStartupHealth` into `main.ts`'s `bootstrap()` so a missing `DATABASE_URL` now fails startup immediately (process exits non-zero via the existing top-level `.catch()`) instead of only surfacing later as an opaque Prisma error on first query.

**#756 — Batch writer rolls back partial failed market batches**
- `PrismaBatchWriter.write()` caught per-record persist errors inside the `$transaction` callback and continued the loop, so a batch with one failing record (e.g. a bad `market_created` upsert) would still commit every other record in that batch. Removed the catch-and-continue: a persist failure now propagates and aborts the whole `$transaction`, so a batch is applied atomically or not at all. Since `ingestion.ts`'s cursor only advances after `batchWriter.write()` resolves, an aborted batch also means the cursor is never advanced past a partially-applied window.

**#755 — Indexer idempotency key covers market-created events**
- The idempotency mechanism (`SHA-256(contractId:ledger:txIndex:eventIndex)`) already applied uniformly to all four event kinds, including `market_created` — this was a documentation/test-coverage gap, not a logic bug. Added explicit `withIdempotencyKey`/duplicate-delivery test coverage for `NormalizedMarketCreated` in `idempotency.test.ts`. Also corrected `docs/indexer-event-mapping.md`, which described an out-of-band "webhook/subscription handler" ingestion path for `market_created` — that path is `apps/indexer/market-created-parser.ts`, an unused legacy file kept only for its own test; the real, live path parses and idempotency-stamps `market_created` inside `PollingIngestionLoop.ingestFromCursor()` exactly like every other event kind. Added a new "Idempotency key format" section documenting the key formula.

## Verification performed

- `npx tsc-files --noEmit` on all changed files — no type errors.
- `npx prettier --check` / `--write` on all changed files.
- Full repo test suite run before and after this change for a regression baseline: **26 failed tests / 1067 passed on `dev` before**, **26 failed tests / 1095 passed after** — identical pre-existing failures, zero new failures, +28 net new passing tests from this PR's added coverage.
- `apps/indexer/src/eventFetcher.test.ts` had a pre-existing missing closing brace (syntax error) that made the whole file fail to load/parse on `dev`. Fixed the one-line syntax error since it's the exact file this PR's #758 refactor needs to validate against; all 35 tests in that file pass afterward.

## Test plan

- [x] `retry.test.ts` — new `jitteredBackoffMs` unit tests (bounds, zero-delay edge case, deterministic `Math.random` mocking) + existing exhaustion-path tests (`throws after exhausting all retries`, `respects maxRetries: 0`) confirm retries stop at max and the final error propagates.
- [x] `eventFetcher.test.ts` — existing retry/exhaustion/telemetry/timeout tests all pass unchanged against the `withRetry`-backed refactor.
- [x] `startupHealth.test.ts` — new tests for missing/empty/whitespace `DATABASE_URL`, asserting the error message names `DATABASE_URL`.
- [x] `batchWriter.test.ts` — replaced the test that asserted the old partial-commit behavior with three new tests: `write()` rejects on a mid-batch persist failure, subsequent records are never attempted after a failure (no partial commit), and non-retryable persist failures aren't retried.
- [x] `idempotency.test.ts` — new tests stamping `NormalizedMarketCreated` with `withIdempotencyKey`, and a duplicate-delivery/retry test for market-created events via `insertIfNew`.

