### PR TITLE
feat(workers): centralize queue names in shared/queue-config

### DIFF
--- a/apps/workers/src/oracle/bullmq-submission-queue.test.ts
+++ b/apps/workers/src/oracle/bullmq-submission-queue.test.ts
@@ -67,6 +67,7 @@ vi.mock("bullmq", () => ({
 vi.mock("../shared/queue-config.js", () => ({
   DEFAULT_JOB_OPTIONS: {},
   redisConnectionFromEnv: () => ({ host: "localhost", port: 6379 }),
+  submissionQueueName: () => "oracle-submissions",
 }));
 
 import {

--- a/apps/workers/src/oracle/bullmq-submission-queue.ts
+++ b/apps/workers/src/oracle/bullmq-submission-queue.ts
@@ -14,9 +14,8 @@ import type { SubmissionQueueItem } from "../../../oracle/submission-queue.js";
 import {
   DEFAULT_JOB_OPTIONS,
   redisConnectionFromEnv,
+  submissionQueueName,
 } from "../shared/queue-config.js";
-
-const QUEUE_NAME = process.env.SUBMISSION_QUEUE_NAME ?? "oracle-submissions";
 
 function payloadHash(item: SubmissionQueueItem): string {
   return createHash("sha256")
@@ -35,7 +34,7 @@ export class BullMQSubmissionQueue {
 
   constructor(logger: ILogger) {
     this.logger = logger;
-    this.queue = new Queue<SubmissionQueueItem>(QUEUE_NAME, {
+    this.queue = new Queue<SubmissionQueueItem>(submissionQueueName(), {
       connection: redisConnectionFromEnv(),
       defaultJobOptions: DEFAULT_JOB_OPTIONS,
     });
@@ -96,7 +95,7 @@ export function createOracleSubmissionWorker(
   logger: ILogger
 ): Worker<SubmissionQueueItem> {
   const worker = new Worker<SubmissionQueueItem>(
-    QUEUE_NAME,
+    submissionQueueName(),
     async (job: Job<SubmissionQueueItem>) => {
       await handler(job.data, job.attemptsMade);
     },

--- a/apps/workers/src/settlement/bullmq-consumer.ts
+++ b/apps/workers/src/settlement/bullmq-consumer.ts
@@ -16,13 +16,10 @@ import { createLogger } from "../../../indexer/src/logger.js";
 import { disconnectPrisma } from "../../../../src/services/prisma.js";
 import { SettlementWorker } from "./settlement-worker.js";
 import type { QueueJob } from "../consumers/queue-consumer.js";
-import { redisConnectionFromEnv } from "../shared/queue-config.js";
-
-const QUEUE_NAME = (): string => {
-  const name = process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades";
-  const prefix = process.env.REDIS_KEY_PREFIX ?? "vatix:";
-  return `${prefix}${name}`;
-};
+import {
+  redisConnectionFromEnv,
+  settlementQueueName,
+} from "../shared/queue-config.js";
 
 const MAX_ATTEMPTS = 3;
 const PROCESSING_TIMEOUT_MS = 30_000;
@@ -31,7 +28,7 @@ const IDEMPOTENCY_TTL_SECONDS = 86_400;
 async function bootstrap(): Promise<void> {
   const logLevel = process.env.LOG_LEVEL ?? "info";
   const logger = createLogger(logLevel as Parameters<typeof createLogger>[0]);
-  const queueName = QUEUE_NAME();
+  const queueName = settlementQueueName();
 
   logger.info("BullMQ settlement worker started", { queue: queueName });
 

--- a/apps/workers/src/settlement/consumer.ts
+++ b/apps/workers/src/settlement/consumer.ts
@@ -19,14 +19,11 @@ import {
   type SettlementStellarConfig,
 } from "./settlement-worker.js";
 import type { QueueJob } from "../consumers/queue-consumer.js";
-import { redisConnectionFromEnv } from "../shared/queue-config.js";
+import {
+  redisConnectionFromEnv,
+  settlementQueueName,
+} from "../shared/queue-config.js";
 import { createShutdown } from "../../../../packages/shared/src/shutdown.js";
-
-const QUEUE_NAME = (): string => {
-  const name = process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades";
-  const prefix = process.env.REDIS_KEY_PREFIX ?? "vatix:";
-  return `${prefix}${name}`;
-};
 
 const MAX_ATTEMPTS = 3;
 const PROCESSING_TIMEOUT_MS = 30_000;
@@ -37,7 +34,7 @@ async function bootstrap(): Promise<void> {
     typeof createLogger
   >[0];
   const logger = createLogger(logLevel);
-  const queueName = QUEUE_NAME();
+  const queueName = settlementQueueName();
 
   logger.info("Settlement worker started (BullMQ)", {
     queue: queueName,

--- a/apps/workers/src/shared/queue-config.test.ts
+++ b/apps/workers/src/shared/queue-config.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { DEFAULT_JOB_OPTIONS, redisConnectionFromEnv } from "./queue-config.js";
+import {
+  DEFAULT_JOB_OPTIONS,
+  redisConnectionFromEnv,
+  settlementQueueName,
+  submissionQueueName,
+} from "./queue-config.js";
 
 // Regression coverage for #764: `bullmq` was used throughout apps/workers
 // (this module, the settlement consumer, and the oracle submission queue)
@@ -15,6 +20,76 @@ describe("queue-config", () => {
       backoff: { type: "exponential", delay: 1_000 },
       removeOnComplete: { count: 100 },
       removeOnFail: false,
+    });
+  });
+
+  describe("settlementQueueName", () => {
+    const originalSettlementName = process.env.SETTLEMENT_QUEUE_NAME;
+    const originalKeyPrefix = process.env.REDIS_KEY_PREFIX;
+
+    afterEach(() => {
+      if (originalSettlementName === undefined) {
+        delete process.env.SETTLEMENT_QUEUE_NAME;
+      } else {
+        process.env.SETTLEMENT_QUEUE_NAME = originalSettlementName;
+      }
+      if (originalKeyPrefix === undefined) {
+        delete process.env.REDIS_KEY_PREFIX;
+      } else {
+        process.env.REDIS_KEY_PREFIX = originalKeyPrefix;
+      }
+    });
+
+    it("returns the default prefixed queue name when env vars are unset", () => {
+      delete process.env.SETTLEMENT_QUEUE_NAME;
+      delete process.env.REDIS_KEY_PREFIX;
+      expect(settlementQueueName()).toBe("vatix:settlement-trades");
+    });
+
+    it("uses REDIS_KEY_PREFIX and SETTLEMENT_QUEUE_NAME when both are set", () => {
+      process.env.REDIS_KEY_PREFIX = "staging:";
+      process.env.SETTLEMENT_QUEUE_NAME = "my-settlement";
+      expect(settlementQueueName()).toBe("staging:my-settlement");
+    });
+
+    it("uses the default name with a custom prefix", () => {
+      process.env.REDIS_KEY_PREFIX = "prod:";
+      delete process.env.SETTLEMENT_QUEUE_NAME;
+      expect(settlementQueueName()).toBe("prod:settlement-trades");
+    });
+
+    it("uses the custom name with the default prefix", () => {
+      delete process.env.REDIS_KEY_PREFIX;
+      process.env.SETTLEMENT_QUEUE_NAME = "custom-settlement";
+      expect(settlementQueueName()).toBe("vatix:custom-settlement");
+    });
+  });
+
+  describe("submissionQueueName", () => {
+    const originalSubmissionName = process.env.SUBMISSION_QUEUE_NAME;
+
+    afterEach(() => {
+      if (originalSubmissionName === undefined) {
+        delete process.env.SUBMISSION_QUEUE_NAME;
+      } else {
+        process.env.SUBMISSION_QUEUE_NAME = originalSubmissionName;
+      }
+    });
+
+    it("returns the default queue name when SUBMISSION_QUEUE_NAME is unset", () => {
+      delete process.env.SUBMISSION_QUEUE_NAME;
+      expect(submissionQueueName()).toBe("oracle-submissions");
+    });
+
+    it("returns SUBMISSION_QUEUE_NAME when set", () => {
+      process.env.SUBMISSION_QUEUE_NAME = "custom-oracle-submissions";
+      expect(submissionQueueName()).toBe("custom-oracle-submissions");
+    });
+
+    it("does not include a key prefix (oracle queue is prefix-free by design)", () => {
+      process.env.SUBMISSION_QUEUE_NAME = "oracle-submissions";
+      const name = submissionQueueName();
+      expect(name).not.toContain(":");
     });
   });
 

--- a/apps/workers/src/shared/queue-config.ts
+++ b/apps/workers/src/shared/queue-config.ts
@@ -1,7 +1,9 @@
 /**
- * Shared BullMQ job options for all queues (settlement + oracle submission).
+ * Shared BullMQ job options and queue-name helpers for all queues
+ * (settlement + oracle submission).
  *
  * Unified retry / backoff / DLQ configuration — ADR 001.
+ * Single source of truth for queue names — #779.
  *
  * @module apps/workers/src/shared/queue-config
  */
@@ -22,6 +24,34 @@ export const DEFAULT_JOB_OPTIONS: JobsOptions = {
   removeOnComplete: { count: 100 },
   removeOnFail: false,
 };
+
+/**
+ * Returns the fully-qualified BullMQ queue name for the settlement worker.
+ *
+ * Format: `${REDIS_KEY_PREFIX}${SETTLEMENT_QUEUE_NAME}`
+ *
+ * Evaluated at call-time so tests can override env vars without module-cache
+ * complications.
+ */
+export function settlementQueueName(): string {
+  const name = process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades";
+  const prefix = process.env.REDIS_KEY_PREFIX ?? "vatix:";
+  return `${prefix}${name}`;
+}
+
+/**
+ * Returns the BullMQ queue name for the oracle submission worker.
+ *
+ * The oracle submission queue intentionally omits the key prefix because the
+ * BullMQ Worker is scoped to the oracle service and does not share a Redis
+ * keyspace with the settlement worker.
+ *
+ * Evaluated at call-time so tests can override env vars without module-cache
+ * complications.
+ */
+export function submissionQueueName(): string {
+  return process.env.SUBMISSION_QUEUE_NAME ?? "oracle-submissions";
+}
 
 /** Build a Redis connection config from the environment. */
 export function redisConnectionFromEnv(): {

--- a/src/services/settlement-queue.ts
+++ b/src/services/settlement-queue.ts
@@ -1,5 +1,6 @@
 import { redis } from "./redis.js";
 import type { Outcome } from "../types/index.js";
+import { settlementQueueName } from "../../apps/workers/src/shared/queue-config.js";
 
 export interface SettlementJob {
   tradeId: string;
@@ -18,9 +19,7 @@ class SettlementQueueProducer {
   private streamKey: string;
 
   constructor() {
-    const queueName = process.env.SETTLEMENT_QUEUE_NAME ?? "settlement-trades";
-    const keyPrefix = process.env.REDIS_KEY_PREFIX ?? "vatix:";
-    this.streamKey = `${keyPrefix}${queueName}`;
+    this.streamKey = settlementQueueName();
   }
 
   async enqueue(job: SettlementJob): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #779

Adds `settlementQueueName()` and `submissionQueueName()` helpers to `apps/workers/src/shared/queue-config.ts` as the single source of truth for all BullMQ queue names.

Previously each consumer/producer duplicated the same env-var lookup inline — `SETTLEMENT_QUEUE_NAME + REDIS_KEY_PREFIX` in three places, `SUBMISSION_QUEUE_NAME` in two places — making name drift a silent risk.

## Changes

| File | Change |
|---|---|
| `apps/workers/src/shared/queue-config.ts` | Add `settlementQueueName()` and `submissionQueueName()` exports |
| `apps/workers/src/settlement/bullmq-consumer.ts` | Replace local `QUEUE_NAME()` with shared import |
| `apps/workers/src/settlement/consumer.ts` | Replace local `QUEUE_NAME()` with shared import |
| `apps/workers/src/oracle/bullmq-submission-queue.ts` | Replace local `QUEUE_NAME` const with shared import |
| `src/services/settlement-queue.ts` | Replace inline stream-key construction with shared import |
| `apps/workers/src/shared/queue-config.test.ts` | Add 7 new tests (4 `settlementQueueName`, 3 `submissionQueueName`) |
| `apps/workers/src/oracle/bullmq-submission-queue.test.ts` | Add `submissionQueueName` to the `vi.mock` stub |

## What was tested

- `queue-config.test.ts` — 11 tests pass ✅
- `bullmq-submission-queue.test.ts` — 4 tests pass ✅
- No regressions in the remaining 8 workers unit-test files ✅
- Pre-existing failures (`settlement-worker.test.ts`, `dead-letter.test.ts` — missing Prisma client in unit env; `job.test.ts` — timing flake) are unrelated to this PR

## Notes

- `settlementQueueName()` preserves the `${REDIS_KEY_PREFIX}${SETTLEMENT_QUEUE_NAME}` format (both BullMQ consumers and the Redis Streams producer share the same key)
- `submissionQueueName()` intentionally omits the key prefix (oracle queue design, unchanged from before)
- Both functions are evaluated at call-time so env-var overrides in tests work without module-cache workarounds