### PR TITLE
Add payload hash to dead-letter records for dedupe detection

### DIFF
--- a/apps/workers/src/consumers/dead-letter.test.ts
+++ b/apps/workers/src/consumers/dead-letter.test.ts
@@ -1,14 +1,35 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { store } = vi.hoisted(() => ({ store: new Map<string, string>() }));
+
+vi.mock("../../../../src/services/redis.js", () => ({
+  redis: {
+    exists: vi.fn(async (key: string) => store.has(key)),
+    set: vi.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    xadd: vi.fn(async () => "1-0"),
+  },
+}));
+
 import { logDeadLetter, type DeadLetterMessage } from "./dead-letter.js";
 
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
 describe("Dead Letter Log", () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
   it("should log the dead letter message with appropriate structured fields", () => {
-    const mockLogger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    };
+    const mockLogger = createMockLogger();
 
     const message: DeadLetterMessage = {
       id: "msg-123",
@@ -26,9 +47,91 @@ describe("Dead Letter Log", () => {
           queue: "settlement",
           reason: "Max retries exceeded",
           payloadType: "object",
+          payloadHash: expect.any(String),
+          duplicate: false,
           timestamp: expect.any(String),
         })
       );
     });
+  });
+
+  it("should not flag the first occurrence of a payload as a duplicate", async () => {
+    const mockLogger = createMockLogger();
+    const message: DeadLetterMessage = {
+      id: "msg-1",
+      queue: "settlement",
+      payload: { tradeId: "t-1" },
+      reason: "Max retries exceeded",
+    };
+
+    const result = await logDeadLetter(mockLogger as any, message);
+
+    expect(result).toEqual({ duplicate: false });
+  });
+
+  it("should flag a repeat insert of the same payload+queue as a duplicate", async () => {
+    const mockLogger = createMockLogger();
+    const message: DeadLetterMessage = {
+      id: "msg-2",
+      queue: "settlement",
+      payload: { tradeId: "t-2" },
+      reason: "Max retries exceeded",
+    };
+
+    const first = await logDeadLetter(mockLogger as any, message);
+    const second = await logDeadLetter(mockLogger as any, {
+      ...message,
+      id: "msg-3",
+    });
+
+    expect(first).toEqual({ duplicate: false });
+    expect(second).toEqual({ duplicate: true });
+    expect(mockLogger.error).toHaveBeenLastCalledWith(
+      "Job dead-lettered",
+      expect.objectContaining({ duplicate: true })
+    );
+  });
+
+  it("should compute the same payload hash for identical payloads and a different hash for different payloads", async () => {
+    const mockLogger = createMockLogger();
+
+    await logDeadLetter(mockLogger as any, {
+      id: "msg-4",
+      queue: "oracle",
+      payload: { marketId: "m-1" },
+      reason: "Poison message",
+    });
+    const hashA = mockLogger.error.mock.calls[0][1].payloadHash;
+
+    await logDeadLetter(mockLogger as any, {
+      id: "msg-5",
+      queue: "oracle",
+      payload: { marketId: "m-2" },
+      reason: "Poison message",
+    });
+    const hashB = mockLogger.error.mock.calls[1][1].payloadHash;
+
+    expect(hashA).not.toEqual(hashB);
+  });
+
+  it("should not treat identical payloads on different queues as duplicates", async () => {
+    const mockLogger = createMockLogger();
+    const payload = { tradeId: "t-shared" };
+
+    const onQueueA = await logDeadLetter(mockLogger as any, {
+      id: "msg-6",
+      queue: "settlement",
+      payload,
+      reason: "Max retries exceeded",
+    });
+    const onQueueB = await logDeadLetter(mockLogger as any, {
+      id: "msg-7",
+      queue: "oracle",
+      payload,
+      reason: "Max retries exceeded",
+    });
+
+    expect(onQueueA).toEqual({ duplicate: false });
+    expect(onQueueB).toEqual({ duplicate: false });
   });
 });

--- a/apps/workers/src/consumers/dead-letter.ts
+++ b/apps/workers/src/consumers/dead-letter.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import type { ILogger } from "../../../../packages/shared/src/logger.js";
 import { redis } from "../../../../src/services/redis.js";
 
@@ -9,13 +10,57 @@ export interface DeadLetterMessage {
 }
 
 const DEAD_LETTER_STREAM_PREFIX = process.env.REDIS_KEY_PREFIX ?? "vatix:";
+/** How long a payload hash is remembered for dedupe purposes. */
+const DEDUPE_TTL_SECONDS = 24 * 60 * 60;
+
+/**
+ * Stable SHA-256 hash of the payload, used to recognize replays of the same
+ * failure as duplicates rather than distinct incidents.
+ */
+function computePayloadHash(payload: unknown): string {
+  return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+}
+
+function dedupeKey(queue: string, payloadHash: string): string {
+  return `${DEAD_LETTER_STREAM_PREFIX}dead-letter:dedupe:${queue}:${payloadHash}`;
+}
+
+/**
+ * Returns true if a message with this exact payload was already dead-lettered
+ * for this queue within the dedupe window, then (re)marks it as seen.
+ */
+async function checkAndMarkDuplicate(
+  logger: ILogger,
+  queue: string,
+  payloadHash: string
+): Promise<boolean> {
+  const key = dedupeKey(queue, payloadHash);
+  try {
+    const duplicate = await redis.exists(key);
+    await redis.set(key, "1", DEDUPE_TTL_SECONDS);
+    return duplicate;
+  } catch (error) {
+    logger.warn("Dead letter dedupe check failed", {
+      queue,
+      payloadHash,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
 
 export async function logDeadLetter(
   logger: ILogger,
   message: DeadLetterMessage
-): Promise<void> {
+): Promise<{ duplicate: boolean }> {
   const timestamp = new Date().toISOString();
   const stream = `${DEAD_LETTER_STREAM_PREFIX}dead-letter:${message.queue}`;
+  const payloadHash = computePayloadHash(message.payload);
+  const duplicate = await checkAndMarkDuplicate(
+    logger,
+    message.queue,
+    payloadHash
+  );
 
   try {
     await (
@@ -39,6 +84,10 @@ export async function logDeadLetter(
       typeof message.payload,
       "payload",
       JSON.stringify(message.payload),
+      "payloadHash",
+      payloadHash,
+      "duplicate",
+      String(duplicate),
       "timestamp",
       timestamp
     );
@@ -48,6 +97,8 @@ export async function logDeadLetter(
       queue: message.queue,
       reason: message.reason,
       payloadType: typeof message.payload,
+      payloadHash,
+      duplicate,
       timestamp,
       persisted: true,
       stream,
@@ -58,9 +109,13 @@ export async function logDeadLetter(
       queue: message.queue,
       reason: message.reason,
       payloadType: typeof message.payload,
+      payloadHash,
+      duplicate,
       timestamp,
       persisted: false,
       persistenceError: error instanceof Error ? error.message : String(error),
     });
   }
+
+  return { duplicate };
 }

--- a/docs/dead-letter-log.md
+++ b/docs/dead-letter-log.md
@@ -33,21 +33,34 @@ const message: DeadLetterMessage = {
   reason: "Max retries exceeded",
 };
 
-logDeadLetter(logger, message);
-// => logger.error("Job dead-lettered", { messageId, queue, reason, payloadType, timestamp })
+await logDeadLetter(logger, message);
+// => logger.error("Job dead-lettered", { messageId, queue, reason, payloadType, payloadHash, duplicate, timestamp })
+// => { duplicate: false }
 ```
 
 **Log fields emitted:**
 
-| Field         | Source                     | Description                              |
-| ------------- | -------------------------- | ---------------------------------------- |
-| `messageId`   | `message.id`               | Correlates with upstream job ID          |
-| `queue`       | `message.queue`            | Which queue the message came from        |
-| `reason`      | `message.reason`           | Why the message was dead-lettered        |
-| `payloadType` | `typeof message.payload`   | JS type of the payload (e.g. `"object"`) |
-| `timestamp`   | `new Date().toISOString()` | When the dead letter was recorded        |
+| Field         | Source                                       | Description                                                           |
+| ------------- | -------------------------------------------- | --------------------------------------------------------------------- |
+| `messageId`   | `message.id`                                 | Correlates with upstream job ID                                       |
+| `queue`       | `message.queue`                              | Which queue the message came from                                     |
+| `reason`      | `message.reason`                             | Why the message was dead-lettered                                     |
+| `payloadType` | `typeof message.payload`                     | JS type of the payload (e.g. `"object"`)                              |
+| `payloadHash` | SHA-256 of `JSON.stringify(message.payload)` | Stable content hash used for dedupe                                   |
+| `duplicate`   | dedupe check result                          | `true` if this exact payload+queue was already dead-lettered recently |
+| `timestamp`   | `new Date().toISOString()`                   | When the dead letter was recorded                                     |
 
 > **Note:** The `payload` value is intentionally **not** logged to avoid leaking sensitive data. `payloadType` gives operators enough context to distinguish missing payloads from structured ones. If you need payload details, inspect the dead letter store or enable `debug`-level logging upstream.
+
+## Dedupe via Payload Hash
+
+Every dead-lettered message is hashed (`sha256(JSON.stringify(payload))`) before it's persisted. `logDeadLetter` uses that hash to check a Redis key (`{prefix}dead-letter:dedupe:{queue}:{payloadHash}`) with a 24-hour TTL:
+
+- If the key already exists, the message is a **duplicate** — the same payload was already dead-lettered for that queue within the last 24 hours (e.g. a retried burst of the same failure).
+- The dedupe key is (re)written on every attempt, refreshing the TTL.
+- Both the Redis stream entry and the structured log record `payloadHash` and `duplicate`, so replays can filter out or collapse duplicates when triaging.
+- `logDeadLetter` returns `{ duplicate: boolean }` so callers can react (e.g. suppress alerting on known duplicates) if needed.
+- The dedupe check is best-effort: if Redis is unreachable, the check fails soft (logged via `logger.warn`, treated as non-duplicate) rather than blocking the dead-letter write itself.
 
 ## When Messages Are Dead-Lettered
 
@@ -61,7 +74,12 @@ A message is sent to the dead letter log when:
 A Vitest test file is colocated at `apps/workers/src/consumers/dead-letter.test.ts`. It verifies:
 
 - `logDeadLetter` calls `logger.error` exactly once
-- Structured fields (`messageId`, `queue`, `reason`, `payloadType`, `timestamp`) are present in the log output
+- Structured fields (`messageId`, `queue`, `reason`, `payloadType`, `payloadHash`, `duplicate`, `timestamp`) are present in the log output
+- The first dead-lettered occurrence of a payload+queue resolves `{ duplicate: false }`
+- A repeat insert of the same payload+queue resolves `{ duplicate: true }`
+- Different payloads hash differently, and identical payloads on different queues are not treated as duplicates of each other
+
+The Redis service (`src/services/redis.js`) is mocked in tests via `vi.mock` + `vi.hoisted`, so dedupe behavior is verified without requiring a live Redis connection.
 
 Run tests:
 


### PR DESCRIPTION
Hashes each dead-lettered payload (sha256) and checks a Redis-backed dedupe key per queue+hash so replayed/retried failures can be recognized as duplicates instead of distinct incidents.

Closes #781