### PR TITLE
Fail workers readiness probe when Redis is unreachable

### DIFF
--- a/apps/workers/src/routes/ready.test.ts
+++ b/apps/workers/src/routes/ready.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+
+const mocks = vi.hoisted(() => ({
+  queryRaw: vi.fn(async () => [{ "?column?": 1 }]),
+  healthCheck: vi.fn(async () => true),
+}));
+
+vi.mock("../../../../src/services/prisma.js", () => ({
+  getPrismaClient: () => ({
+    $queryRaw: mocks.queryRaw,
+  }),
+}));
+
+vi.mock("../../../../src/services/redis.js", () => ({
+  redis: {
+    healthCheck: mocks.healthCheck,
+  },
+}));
+
+import { readyRoutes } from "./ready.js";
+
+function buildServer() {
+  const server = Fastify({ logger: false });
+  server.register(readyRoutes);
+  return server;
+}
+
+describe("GET /ready (workers)", () => {
+  beforeEach(() => {
+    mocks.queryRaw.mockReset().mockResolvedValue([{ "?column?": 1 }]);
+    mocks.healthCheck.mockReset().mockResolvedValue(true);
+  });
+
+  it("returns 200 and ready:true when Redis and the database are up", async () => {
+    const server = buildServer();
+    const res = await server.inject({ method: "GET", url: "/ready" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ready).toBe(true);
+    expect(body.dependencies.database.status).toBe("ok");
+    expect(body.dependencies.redis.status).toBe("ok");
+  });
+
+  it("returns 503 and ready:false when Redis is down", async () => {
+    mocks.healthCheck.mockResolvedValue(false);
+
+    const server = buildServer();
+    const res = await server.inject({ method: "GET", url: "/ready" });
+
+    expect(res.statusCode).toBe(503);
+    const body = res.json();
+    expect(body.ready).toBe(false);
+    expect(body.dependencies.redis.status).toBe("error");
+    expect(body.dependencies.redis.error).toContain("PONG");
+    expect(body.dependencies.database.status).toBe("ok");
+  });
+
+  it("returns 503 and ready:false when the Redis health check throws", async () => {
+    mocks.healthCheck.mockRejectedValue(new Error("connection refused"));
+
+    const server = buildServer();
+    const res = await server.inject({ method: "GET", url: "/ready" });
+
+    expect(res.statusCode).toBe(503);
+    const body = res.json();
+    expect(body.ready).toBe(false);
+    expect(body.dependencies.redis.status).toBe("error");
+    expect(body.dependencies.redis.error).toContain("connection refused");
+  });
+
+  it("returns 503 when the database is down even if Redis is up", async () => {
+    mocks.queryRaw.mockRejectedValue(new Error("db unreachable"));
+
+    const server = buildServer();
+    const res = await server.inject({ method: "GET", url: "/ready" });
+
+    expect(res.statusCode).toBe(503);
+    const body = res.json();
+    expect(body.ready).toBe(false);
+    expect(body.dependencies.database.status).toBe("error");
+    expect(body.dependencies.redis.status).toBe("ok");
+  });
+});

--- a/apps/workers/src/routes/ready.ts
+++ b/apps/workers/src/routes/ready.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { getPrismaClient } from "../../../../src/services/prisma.js";
+import { redis } from "../../../../src/services/redis.js";
 
 interface ReadyResponse {
   ready: boolean;
@@ -7,6 +8,7 @@ interface ReadyResponse {
   timestamp: string;
   dependencies: {
     database: { status: "ok" | "error"; error?: string };
+    redis: { status: "ok" | "error"; error?: string };
   };
 }
 
@@ -23,7 +25,20 @@ export async function readyRoutes(fastify: FastifyInstance) {
       dbError = err instanceof Error ? err.message : String(err);
     }
 
-    const ready = dbStatus === "ok";
+    let redisStatus: "ok" | "error" = "ok";
+    let redisError: string | undefined;
+
+    try {
+      const pong = await redis.healthCheck();
+      if (!pong) {
+        throw new Error("Redis PING did not return PONG");
+      }
+    } catch (err) {
+      redisStatus = "error";
+      redisError = err instanceof Error ? err.message : String(err);
+    }
+
+    const ready = dbStatus === "ok" && redisStatus === "ok";
 
     return reply.status(ready ? 200 : 503).send({
       ready,
@@ -33,6 +48,10 @@ export async function readyRoutes(fastify: FastifyInstance) {
         database: {
           status: dbStatus,
           ...(dbError ? { error: dbError } : {}),
+        },
+        redis: {
+          status: redisStatus,
+          ...(redisError ? { error: redisError } : {}),
         },
       },
     });

--- a/docs/health-probes.md
+++ b/docs/health-probes.md
@@ -16,6 +16,26 @@ We expose two main endpoints to monitor the state of the API server:
    - **Behavior:** Returns `200 OK` if the database is reachable and the index freshness is under the staleness threshold. Returns `503 Service Unavailable` if the database is unreachable or the indexer has stalled.
    - **Action on Failure:** Stop routing traffic to the container (remove it from the load balancer pool). Do **not** restart the container.
 
+### Workers Readiness Probe (`GET /ready`)
+
+Each worker process (`apps/workers/src/routes/ready.ts`) exposes its own `/ready` route, checked independently of the API's `/v1/ready`:
+
+- **Goal:** Determine if a queue consumer worker is able to reach its dependencies — Postgres and Redis (the queue/stream backend the consumer reads from). A worker that can't reach Redis can't consume or dead-letter jobs, so it should stop receiving traffic/orchestration signals even while the process itself is alive.
+- **Behavior:** Runs `SELECT 1` against Postgres and `redis.healthCheck()` (a `PING`) against Redis. Returns `200 OK` with `ready: true` only when both succeed. Returns `503 Service Unavailable` with `ready: false` if either dependency fails, with the failing dependency's `status` set to `"error"` and an `error` message attached.
+- **Response shape:**
+  ```json
+  {
+    "ready": true,
+    "service": "vatix-workers",
+    "timestamp": "2026-07-28T00:00:00.000Z",
+    "dependencies": {
+      "database": { "status": "ok" },
+      "redis": { "status": "ok" }
+    }
+  }
+  ```
+- **Action on Failure:** Stop routing traffic/orchestration signals to the worker (remove it from its pool). Do **not** restart the container — a Redis outage is external and restarting won't fix it.
+
 ---
 
 ## Configuration Reference


### PR DESCRIPTION
The worker /ready route only checked Postgres, so a Redis/queue outage never surfaced there even though a worker can't consume or dead-letter jobs without Redis. Adds a redis.healthCheck() ping alongside the DB check and documents the probe's behavior.

Closes #782