### PR TITLE
Add snapshot corpus for matching engine fill scenarios

### DIFF
--- a/src/matching/__snapshots__/engine.fills.snapshot.test.ts.snap
+++ b/src/matching/__snapshots__/engine.fills.snapshot.test.ts.snap
@@ -1,0 +1,189 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matchOrder fill scenarios (snapshots) > fully fills a taker order against a single resting maker 1`] = `
+{
+  "positionDeltas": [
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GTAKER00000000000000000000000000000000000000000001",
+      "yesSharesDelta": 100,
+    },
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GMAKER00000000000000000000000000000000000000000001",
+      "yesSharesDelta": -100,
+    },
+  ],
+  "remainingOrder": null,
+  "trades": [
+    {
+      "buyOrderId": "taker-1",
+      "buyerAddress": "GTAKER00000000000000000000000000000000000000000001",
+      "id": "trade_taker-1_maker-1_100_1700000000000",
+      "marketId": "market-snap",
+      "outcome": "YES",
+      "price": 0.5,
+      "quantity": 100,
+      "sellOrderId": "maker-1",
+      "sellerAddress": "GMAKER00000000000000000000000000000000000000000001",
+      "timestamp": 1700000000000,
+    },
+  ],
+}
+`;
+
+exports[`matchOrder fill scenarios (snapshots) > partially fills a taker order and leaves a remaining resting order 1`] = `
+{
+  "positionDeltas": [
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GTAKER00000000000000000000000000000000000000000002",
+      "yesSharesDelta": 40,
+    },
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GMAKER00000000000000000000000000000000000000000002",
+      "yesSharesDelta": -40,
+    },
+  ],
+  "remainingOrder": {
+    "id": "taker-1",
+    "marketId": "market-snap",
+    "outcome": "YES",
+    "price": 0.5,
+    "quantity": 60,
+    "side": "BUY",
+    "timestamp": 1700000000000,
+    "userAddress": "GTAKER00000000000000000000000000000000000000000002",
+  },
+  "trades": [
+    {
+      "buyOrderId": "taker-1",
+      "buyerAddress": "GTAKER00000000000000000000000000000000000000000002",
+      "id": "trade_taker-1_maker-1_40_1700000000000",
+      "marketId": "market-snap",
+      "outcome": "YES",
+      "price": 0.45,
+      "quantity": 40,
+      "sellOrderId": "maker-1",
+      "sellerAddress": "GMAKER00000000000000000000000000000000000000000002",
+      "timestamp": 1700000000000,
+    },
+  ],
+}
+`;
+
+exports[`matchOrder fill scenarios (snapshots) > returns no trades and the original order unchanged when nothing crosses 1`] = `
+{
+  "positionDeltas": [],
+  "remainingOrder": {
+    "id": "taker-1",
+    "marketId": "market-snap",
+    "outcome": "YES",
+    "price": 0.5,
+    "quantity": 100,
+    "side": "BUY",
+    "timestamp": 1700000000000,
+    "userAddress": "GTAKER00000000000000000000000000000000000000000004",
+  },
+  "trades": [],
+}
+`;
+
+exports[`matchOrder fill scenarios (snapshots) > skips a self-trade and matches the next resting order at the same price 1`] = `
+{
+  "positionDeltas": [
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GSAMEUSER0000000000000000000000000000000000000001",
+      "yesSharesDelta": 100,
+    },
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GMAKER00000000000000000000000000000000000000000006",
+      "yesSharesDelta": -100,
+    },
+  ],
+  "remainingOrder": null,
+  "trades": [
+    {
+      "buyOrderId": "taker-1",
+      "buyerAddress": "GSAMEUSER0000000000000000000000000000000000000001",
+      "id": "trade_taker-1_maker-1_100_1700000000000",
+      "marketId": "market-snap",
+      "outcome": "YES",
+      "price": 0.5,
+      "quantity": 100,
+      "sellOrderId": "maker-1",
+      "sellerAddress": "GMAKER00000000000000000000000000000000000000000006",
+      "timestamp": 1700000000000,
+    },
+  ],
+}
+`;
+
+exports[`matchOrder fill scenarios (snapshots) > sweeps multiple price levels in price-time priority 1`] = `
+{
+  "positionDeltas": [
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GTAKER00000000000000000000000000000000000000000003",
+      "yesSharesDelta": 90,
+    },
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GMAKER00000000000000000000000000000000000000000003",
+      "yesSharesDelta": -30,
+    },
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GMAKER00000000000000000000000000000000000000000004",
+      "yesSharesDelta": -50,
+    },
+    {
+      "noSharesDelta": 0,
+      "userAddress": "GMAKER00000000000000000000000000000000000000000005",
+      "yesSharesDelta": -10,
+    },
+  ],
+  "remainingOrder": null,
+  "trades": [
+    {
+      "buyOrderId": "taker-1",
+      "buyerAddress": "GTAKER00000000000000000000000000000000000000000003",
+      "id": "trade_taker-1_maker-1_30_1700000000000",
+      "marketId": "market-snap",
+      "outcome": "YES",
+      "price": 0.4,
+      "quantity": 30,
+      "sellOrderId": "maker-1",
+      "sellerAddress": "GMAKER00000000000000000000000000000000000000000003",
+      "timestamp": 1700000000000,
+    },
+    {
+      "buyOrderId": "taker-1",
+      "buyerAddress": "GTAKER00000000000000000000000000000000000000000003",
+      "id": "trade_taker-1_maker-2_50_1700000000000",
+      "marketId": "market-snap",
+      "outcome": "YES",
+      "price": 0.45,
+      "quantity": 50,
+      "sellOrderId": "maker-2",
+      "sellerAddress": "GMAKER00000000000000000000000000000000000000000004",
+      "timestamp": 1700000000000,
+    },
+    {
+      "buyOrderId": "taker-1",
+      "buyerAddress": "GTAKER00000000000000000000000000000000000000000003",
+      "id": "trade_taker-1_maker-3_10_1700000000000",
+      "marketId": "market-snap",
+      "outcome": "YES",
+      "price": 0.5,
+      "quantity": 10,
+      "sellOrderId": "maker-3",
+      "sellerAddress": "GMAKER00000000000000000000000000000000000000000005",
+      "timestamp": 1700000000000,
+    },
+  ],
+}
+`;

--- a/src/matching/engine.fills.snapshot.test.ts
+++ b/src/matching/engine.fills.snapshot.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { matchOrder, MatchingOrder } from "./engine.js";
+import { OrderBook, Order as BookOrder } from "./orderbook.js";
+
+/**
+ * Snapshot corpus for matching engine fill scenarios (#729).
+ *
+ * `matchOrder` stamps trades with `Date.now()`, so `Date.now` is frozen for
+ * every scenario below to keep snapshots stable across runs and machines.
+ */
+describe("matchOrder fill scenarios (snapshots)", () => {
+  const FIXED_NOW = 1_700_000_000_000;
+  const marketId = "market-snap";
+  const outcome = 0; // YES
+
+  let orderBook: OrderBook;
+
+  const createBookOrder = (
+    id: string,
+    side: "bid" | "ask",
+    price: number,
+    quantity: number,
+    timestamp: number,
+    userAddress: string
+  ): BookOrder => ({
+    id,
+    userAddress,
+    side,
+    price,
+    quantity,
+    timestamp,
+    marketId,
+    outcome,
+  });
+
+  const createMatchingOrder = (
+    id: string,
+    side: "BUY" | "SELL",
+    price: number,
+    quantity: number,
+    userAddress: string
+  ): MatchingOrder => ({
+    id,
+    userAddress,
+    side,
+    price,
+    quantity,
+    marketId,
+    outcome: "YES",
+    timestamp: FIXED_NOW,
+  });
+
+  beforeEach(() => {
+    orderBook = new OrderBook(marketId, outcome);
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fully fills a taker order against a single resting maker", () => {
+    orderBook.addOrder(
+      createBookOrder(
+        "maker-1",
+        "ask",
+        0.5,
+        100,
+        FIXED_NOW - 1000,
+        "GMAKER00000000000000000000000000000000000000000001"
+      )
+    );
+
+    const taker = createMatchingOrder(
+      "taker-1",
+      "BUY",
+      0.5,
+      100,
+      "GTAKER00000000000000000000000000000000000000000001"
+    );
+
+    const result = matchOrder(taker, orderBook);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it("partially fills a taker order and leaves a remaining resting order", () => {
+    orderBook.addOrder(
+      createBookOrder(
+        "maker-1",
+        "ask",
+        0.45,
+        40,
+        FIXED_NOW - 1000,
+        "GMAKER00000000000000000000000000000000000000000002"
+      )
+    );
+
+    const taker = createMatchingOrder(
+      "taker-1",
+      "BUY",
+      0.5,
+      100,
+      "GTAKER00000000000000000000000000000000000000000002"
+    );
+
+    const result = matchOrder(taker, orderBook);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it("sweeps multiple price levels in price-time priority", () => {
+    orderBook.addOrder(
+      createBookOrder(
+        "maker-1",
+        "ask",
+        0.4,
+        30,
+        FIXED_NOW - 3000,
+        "GMAKER00000000000000000000000000000000000000000003"
+      )
+    );
+    orderBook.addOrder(
+      createBookOrder(
+        "maker-2",
+        "ask",
+        0.45,
+        50,
+        FIXED_NOW - 2000,
+        "GMAKER00000000000000000000000000000000000000000004"
+      )
+    );
+    orderBook.addOrder(
+      createBookOrder(
+        "maker-3",
+        "ask",
+        0.5,
+        50,
+        FIXED_NOW - 1000,
+        "GMAKER00000000000000000000000000000000000000000005"
+      )
+    );
+
+    const taker = createMatchingOrder(
+      "taker-1",
+      "BUY",
+      0.5,
+      90,
+      "GTAKER00000000000000000000000000000000000000000003"
+    );
+
+    const result = matchOrder(taker, orderBook);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it("skips a self-trade and matches the next resting order at the same price", () => {
+    const sameUser = "GSAMEUSER0000000000000000000000000000000000000001";
+
+    orderBook.addOrder(
+      createBookOrder("self-1", "ask", 0.5, 100, FIXED_NOW - 2000, sameUser)
+    );
+    orderBook.addOrder(
+      createBookOrder(
+        "maker-1",
+        "ask",
+        0.5,
+        100,
+        FIXED_NOW - 1000,
+        "GMAKER00000000000000000000000000000000000000000006"
+      )
+    );
+
+    const taker = createMatchingOrder("taker-1", "BUY", 0.5, 100, sameUser);
+
+    const result = matchOrder(taker, orderBook);
+
+    expect(result).toMatchSnapshot();
+    // The self-trade order must be removed from the book without producing a trade,
+    // and the taker must match the next resting order instead.
+    expect(result.trades[0].sellOrderId).toBe("maker-1");
+    expect(orderBook.getOrderCount()).toBe(0);
+  });
+
+  it("returns no trades and the original order unchanged when nothing crosses", () => {
+    orderBook.addOrder(
+      createBookOrder(
+        "maker-1",
+        "ask",
+        0.6,
+        100,
+        FIXED_NOW - 1000,
+        "GMAKER00000000000000000000000000000000000000000007"
+      )
+    );
+
+    const taker = createMatchingOrder(
+      "taker-1",
+      "BUY",
+      0.5,
+      100,
+      "GTAKER00000000000000000000000000000000000000000004"
+    );
+
+    const result = matchOrder(taker, orderBook);
+
+    expect(result).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Covers full fill, partial fill, multi-level price-time-priority sweep, self-trade skip, and no-match cases via toMatchSnapshot() on the full MatchResult. Date.now() is frozen per test so trade IDs/timestamps stay deterministic across runs. Runs as part of the existing unit test suite (picked up by vitest's **/*.test.ts glob, no CI config changes needed).

Closes #729