### PR TITLE
feat: implement reorg-safe cursor rewind, challenge window check, fail-closed oracle, and provider confidence storage

### DIFF
--- a/apps/indexer/src/eventFetcher.ts
+++ b/apps/indexer/src/eventFetcher.ts
@@ -65,6 +65,15 @@ export class EventFetcher {
   }
 
   /**
+   * Returns the sequence number and hash of the latest ledger from the RPC node.
+   * Used by the ingestion loop to detect chain reorganisations.
+   */
+  async getLatestLedgerInfo(): Promise<{ sequence: number; hash: string }> {
+    const info = await this.server.getLatestLedger();
+    return { sequence: info.sequence, hash: info.hash.id };
+  }
+
+  /**
    * Fetch all raw chain events within [startLedger, endLedger].
    * Handles multi-page responses and retries on transient failures.
    * Applies an extended ingestion backoff when the RPC endpoint has been

--- a/apps/indexer/src/ingestion.test.ts
+++ b/apps/indexer/src/ingestion.test.ts
@@ -83,6 +83,8 @@ describe("PollingIngestionLoop", () => {
     storage = {
       loadCursor: vi.fn().mockResolvedValue("10"),
       saveCursor: vi.fn().mockResolvedValue(undefined),
+      loadLedgerHash: vi.fn().mockResolvedValue(null),
+      saveLedgerHash: vi.fn().mockResolvedValue(undefined),
     };
     metrics = {
       setLatestIndexedLedgerSequence: vi.fn(),
@@ -94,6 +96,9 @@ describe("PollingIngestionLoop", () => {
     } as unknown as InternalIndexerMetricsService;
     eventFetcher = {
       fetchByLedgerWindow: vi.fn(),
+      getLatestLedgerInfo: vi
+        .fn()
+        .mockResolvedValue({ sequence: 200, hash: "abcd1234" }),
     } as unknown as EventFetcher;
     batchWriter = {
       write: vi.fn().mockResolvedValue({ written: 2, skipped: 0, errors: [] }),
@@ -346,6 +351,8 @@ describe("PollingIngestionLoop — stale cursor handling", () => {
     storage = {
       loadCursor: vi.fn().mockResolvedValue(null),
       saveCursor: vi.fn().mockResolvedValue(undefined),
+      loadLedgerHash: vi.fn().mockResolvedValue(null),
+      saveLedgerHash: vi.fn().mockResolvedValue(undefined),
     };
     metrics = {
       setLatestIndexedLedgerSequence: vi.fn(),
@@ -360,6 +367,9 @@ describe("PollingIngestionLoop — stale cursor handling", () => {
         events: [],
         latestLedger: 100,
       }),
+      getLatestLedgerInfo: vi
+        .fn()
+        .mockResolvedValue({ sequence: 100, hash: "efgh5678" }),
     } as unknown as EventFetcher;
     batchWriter = {
       write: vi.fn().mockResolvedValue({ written: 0, skipped: 0, errors: [] }),
@@ -450,5 +460,65 @@ describe("PollingIngestionLoop — stale cursor handling", () => {
     // Should not throw — processing should complete
     expect(result).toBeDefined();
     expect(typeof result.nextCursor).toBe("string");
+  });
+
+  describe("reorg detection", () => {
+    it("detects reorg when latest ledger sequence regresses", async () => {
+      const loop = createLoop();
+
+      // First tick establishes a baseline (latestLedger = 100)
+      let result = await runIngest(loop, "50");
+      expect(result.batchWriteSucceeded).toBe(true);
+
+      // Second tick returns a lower latestLedger → reorg detected
+      (
+        eventFetcher.fetchByLedgerWindow as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
+        events: [],
+        latestLedger: 80, // regressed from 100
+      });
+
+      result = await runIngest(loop, "50");
+      expect(result.batchWriteSucceeded).toBe(false);
+      expect(Number(result.nextCursor)).toBe(0); // rewound by 100 (windowSize 100 * 1)
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Chain reorganisation detected — rewinding cursor",
+        expect.objectContaining({
+          event: "indexer.reorg.detected",
+        })
+      );
+    });
+
+    it("does not trigger reorg on normal progression", async () => {
+      const loop = createLoop();
+
+      await runIngest(loop, "50");
+
+      // Normal: latestLedger increased
+      (
+        eventFetcher.fetchByLedgerWindow as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({
+        events: [],
+        latestLedger: 150,
+      });
+
+      const result = await runIngest(loop, "50");
+      expect(result.batchWriteSucceeded).toBe(true);
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        "Chain reorganisation detected — rewinding cursor",
+        expect.anything()
+      );
+    });
+
+    it("skips reorg detection on first tick (no baseline)", async () => {
+      const loop = createLoop();
+
+      const result = await runIngest(loop, null);
+      expect(result.batchWriteSucceeded).toBe(true);
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        "Chain reorganisation detected — rewinding cursor",
+        expect.anything()
+      );
+    });
   });
 });

--- a/apps/indexer/src/ingestion.ts
+++ b/apps/indexer/src/ingestion.ts
@@ -15,6 +15,13 @@ import {
   MarketCreatedParseError,
 } from "./types.js";
 
+/**
+ * Number of ledgers to rewind when a chain reorganisation is detected.
+ * Rewinding by a full window ensures the indexer re-processes enough
+ * history to catch any forked events.
+ */
+const REORG_REWIND_DEPTH_MULTIPLIER = 2;
+
 export interface IngestionLoop {
   start(initialCursor: string | null): Promise<void>;
   stop(): Promise<void>;
@@ -45,6 +52,11 @@ export class PollingIngestionLoop implements IngestionLoop {
   private batchesSinceLastHeartbeat = 0;
   private lastHeartbeatLedgerSequence: number | null = null;
 
+  /** Last known latest ledger sequence for reorg detection. */
+  private lastKnownLatestLedger: number | null = null;
+  /** Last known latest ledger hash for reorg detection. */
+  private lastKnownLatestHash: string | null = null;
+
   constructor(
     private readonly logger: ILogger,
     private readonly storage: CursorStorageClient,
@@ -61,12 +73,25 @@ export class PollingIngestionLoop implements IngestionLoop {
       this.metrics.setLatestIndexedLedgerSequence(initialLedger);
     }
 
+    // Load persisted ledger hash for reorg detection on startup
+    try {
+      this.lastKnownLatestHash = await this.storage.loadLedgerHash();
+    } catch {
+      this.logger.warn(
+        "Failed to load persisted ledger hash — reorg detection will initialise on first tick",
+        {}
+      );
+    }
+
     this.logger.info("Indexer ingestion loop starting", {
       startCursor: initialCursor,
       intervalMs: this.intervalMs,
       checkpointFlushEveryBatches: this.checkpointFlushEveryBatches,
       ledgerWindowSize: this.deps.ledgerWindowSize,
       contractId: this.deps.contractId,
+      lastKnownHash: this.lastKnownLatestHash
+        ? `${this.lastKnownLatestHash.slice(0, 16)}…`
+        : null,
     });
 
     await this.tick();
@@ -172,6 +197,13 @@ export class PollingIngestionLoop implements IngestionLoop {
     }
 
     await this.storage.saveCursor(this.cursor);
+
+    // Persist the latest known ledger hash alongside the cursor so that
+    // reorg detection survives restarts.
+    if (this.lastKnownLatestHash) {
+      await this.storage.saveLedgerHash(this.lastKnownLatestHash);
+    }
+
     this.successfulBatchesSinceLastCheckpoint = 0;
     this.logger.debug("Persisted indexer checkpoint cursor", {
       cursor: this.cursor,
@@ -201,6 +233,21 @@ export class PollingIngestionLoop implements IngestionLoop {
 
     this.batchesSinceLastHeartbeat = 0;
     this.lastHeartbeatLedgerSequence = latestIndexedLedgerSequence;
+  }
+
+  /**
+   * Fetches the current latest ledger hash from the RPC node.
+   * Returns null on transient errors so that reorg detection degrades
+   * gracefully rather than throwing.
+   */
+  private async fetchLatestLedgerHash(): Promise<string | null> {
+    try {
+      const info = await this.deps.eventFetcher.getLatestLedgerInfo();
+      return info.hash;
+    } catch {
+      this.logger.warn("Failed to fetch latest ledger hash for reorg check", {});
+      return null;
+    }
   }
 
   private async ingestFromCursor(
@@ -250,6 +297,59 @@ export class PollingIngestionLoop implements IngestionLoop {
     // Track the latest network ledger for lag computation (Issue #713)
     if (latestLedger > 0) {
       this.metrics.setLatestNetworkLedgerSequence(latestLedger);
+    }
+
+    // ── Reorg detection ──────────────────────────────────────────────────
+    // After fetching the events window, check whether the chain has undergone
+    // a reorganisation by comparing the latest ledger sequence (and hash)
+    // against the last known values.  A reorg is detected when:
+    //   • The network's latest ledger sequence has decreased, OR
+    //   • The sequence is the same but the hash differs.
+    // On detection the cursor is rewound to a safe depth so that forked events
+    // are re-fetched and the canonical chain state is re-indexed.
+    if (latestLedger > 0 && this.lastKnownLatestLedger !== null) {
+      const reorgDetected =
+        latestLedger < this.lastKnownLatestLedger ||
+        (latestLedger === this.lastKnownLatestLedger &&
+          this.lastKnownLatestHash !== null &&
+          this.lastKnownLatestHash !== (await this.fetchLatestLedgerHash()));
+
+      if (reorgDetected) {
+        const rewindLedgers =
+          this.deps.ledgerWindowSize * REORG_REWIND_DEPTH_MULTIPLIER;
+        const currentSeq = Number(this.cursor ?? 0);
+        const safeSequence = Math.max(0, currentSeq - rewindLedgers);
+
+        this.logger.warn("Chain reorganisation detected — rewinding cursor", {
+          event: "indexer.reorg.detected",
+          lastKnownLatestLedger: this.lastKnownLatestLedger,
+          lastKnownLatestHash: this.lastKnownLatestHash,
+          currentLatestLedger: latestLedger,
+          cursorBefore: this.cursor,
+          rewindLedgers,
+          safeSequence,
+        });
+
+        this.metrics.setLatestIndexedLedgerSequence(safeSequence);
+        this.lastKnownLatestLedger = latestLedger;
+
+        return {
+          nextCursor: String(safeSequence),
+          lastIndexedLedgerSequence: safeSequence,
+          batchWriteSucceeded: false,
+        };
+      }
+    }
+
+    // Update known ledger info after successful fetch
+    if (latestLedger > 0) {
+      this.lastKnownLatestLedger = latestLedger;
+      try {
+        const ledgerInfo = await this.deps.eventFetcher.getLatestLedgerInfo();
+        this.lastKnownLatestHash = ledgerInfo.hash;
+      } catch {
+        // Non-fatal: hash tracking is best-effort for reorg detection
+      }
     }
 
     if (startLedger > latestLedger) {

--- a/apps/indexer/src/storage.ts
+++ b/apps/indexer/src/storage.ts
@@ -4,16 +4,25 @@ import type { ILogger } from "../../../packages/shared/src/logger.js";
 export interface CursorStorageClient {
   loadCursor(): Promise<string | null>;
   saveCursor(cursor: string): Promise<void>;
+  /** Load the last known ledger hash for reorg detection. */
+  loadLedgerHash(): Promise<string | null>;
+  /** Persist the ledger hash associated with the current cursor. */
+  saveLedgerHash(hash: string): Promise<void>;
 }
+
+const CURSOR_KEY_HASH_SUFFIX = ":ledger_hash";
 
 export class PrismaCursorStorageClient implements CursorStorageClient {
   private readonly prisma = getPrismaClient();
+  private readonly hashCursorKey: string;
 
   constructor(
     private readonly networkId: string,
     private readonly cursorKey: string,
     private readonly logger?: ILogger
-  ) {}
+  ) {
+    this.hashCursorKey = `${cursorKey}${CURSOR_KEY_HASH_SUFFIX}`;
+  }
 
   async loadCursor(): Promise<string | null> {
     const row = await this.prisma.indexerCursor.findUnique({
@@ -60,6 +69,52 @@ export class PrismaCursorStorageClient implements CursorStorageClient {
       cursorValue: cursor,
       networkId: this.networkId,
       cursorKey: this.cursorKey,
+    });
+  }
+
+  async loadLedgerHash(): Promise<string | null> {
+    const row = await this.prisma.indexerCursor.findUnique({
+      where: {
+        networkId_cursorKey: {
+          networkId: this.networkId,
+          cursorKey: this.hashCursorKey,
+        },
+      },
+      select: {
+        cursorValue: true,
+      },
+    });
+
+    const hash = row?.cursorValue ?? null;
+    this.logger?.debug("Ledger hash loaded", {
+      networkId: this.networkId,
+      cursorKey: this.hashCursorKey,
+      hashFound: hash !== null,
+    });
+    return hash;
+  }
+
+  async saveLedgerHash(hash: string): Promise<void> {
+    await this.prisma.indexerCursor.upsert({
+      where: {
+        networkId_cursorKey: {
+          networkId: this.networkId,
+          cursorKey: this.hashCursorKey,
+        },
+      },
+      create: {
+        networkId: this.networkId,
+        cursorKey: this.hashCursorKey,
+        cursorValue: hash,
+      },
+      update: {
+        cursorValue: hash,
+      },
+    });
+    this.logger?.info("Ledger hash saved", {
+      event: "indexer.ledger_hash.saved",
+      cursorKey: this.hashCursorKey,
+      networkId: this.networkId,
     });
   }
 }

--- a/apps/oracle/main.test.ts
+++ b/apps/oracle/main.test.ts
@@ -157,6 +157,49 @@ describe("apps/oracle/main poll()", () => {
     expect(mockQueue.enqueue).not.toHaveBeenCalled();
   });
 
+  it("persists the provider confidence score on the OracleReport row", async () => {
+    mockPrisma.market.findMany.mockResolvedValue([
+      { id: "market-1", oracleAddress: "GORACLE1" },
+    ]);
+    mockOracleService.resolve.mockResolvedValue({
+      ...RESOLVED_RESULT,
+      confidence: 0.87,
+    });
+
+    await poll();
+
+    expect(mockPrisma.oracleReport.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          confidence: 0.87,
+          source: "GORACLE1",
+        }),
+      })
+    );
+  });
+
+  it("persists the confidence value from the fallback provider when primary fails", async () => {
+    mockPrisma.market.findMany.mockResolvedValue([
+      { id: "market-1", oracleAddress: "GORACLE1" },
+    ]);
+    mockOracleService.resolve.mockResolvedValue({
+      ...RESOLVED_RESULT,
+      source: "fallback-1",
+      confidence: 0.72,
+    });
+
+    await poll();
+
+    expect(mockPrisma.oracleReport.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          confidence: 0.72,
+          source: "GORACLE1", // source is oracleAddress, not provider name
+        }),
+      })
+    );
+  });
+
   it("logs and continues when one market fails to resolve, without aborting the batch", async () => {
     mockPrisma.market.findMany.mockResolvedValue([
       { id: "market-fail", oracleAddress: "GFAIL" },

--- a/apps/oracle/oracle-service.test.ts
+++ b/apps/oracle/oracle-service.test.ts
@@ -293,6 +293,74 @@ describe("OracleService", () => {
     });
   });
 
+  describe("fail closed — total provider outage", () => {
+    it("does not call enqueue callback when both primary and fallback fail", async () => {
+      const failingPrimary = createMockAdapter("primary", true);
+      const failingFallback = createMockAdapter("fallback", true);
+      const enqueueCallback = vi.fn().mockResolvedValue(undefined);
+
+      const service = new OracleService({
+        primaryAdapter: failingPrimary,
+        fallbackAdapter: failingFallback,
+        enableFallback: true,
+        enqueueCallback,
+      });
+
+      await expect(
+        service.resolve({
+          marketId: "market-001",
+          oracleAddress:
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        })
+      ).rejects.toThrow("All providers failed");
+
+      // Enqueue must never be called when all providers fail
+      expect(enqueueCallback).not.toHaveBeenCalled();
+    });
+
+    it("increments totalOutageCount metric on total provider failure", async () => {
+      const failingPrimary = createMockAdapter("primary", true);
+      const failingFallback = createMockAdapter("fallback", true);
+
+      const service = new OracleService({
+        primaryAdapter: failingPrimary,
+        fallbackAdapter: failingFallback,
+        enableFallback: true,
+      });
+
+      await expect(
+        service.resolve({
+          marketId: "market-001",
+          oracleAddress:
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        })
+      ).rejects.toThrow();
+
+      const metrics = service.getMetrics();
+      expect(metrics.totalOutageCount).toBe(1);
+      expect(metrics.primaryFailureCount).toBe(1);
+      expect(metrics.fallbackFailureCount).toBe(1);
+    });
+
+    it("does not increment totalOutageCount when primary succeeds", async () => {
+      const service = new OracleService({
+        primaryAdapter,
+        fallbackAdapter,
+        enableFallback: true,
+      });
+
+      await service.resolve({
+        marketId: "market-001",
+        oracleAddress:
+          "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      });
+
+      const metrics = service.getMetrics();
+      expect(metrics.totalOutageCount).toBe(0);
+      expect(metrics.primarySuccessCount).toBe(1);
+    });
+  });
+
   describe("enqueue callback", () => {
     it("should invoke enqueue callback on successful resolution", async () => {
       const enqueueCallback = vi.fn().mockResolvedValue(undefined);

--- a/apps/oracle/oracle-service.ts
+++ b/apps/oracle/oracle-service.ts
@@ -61,6 +61,8 @@ export interface OracleMetrics {
   totalAttempts: number;
   /** Total retry attempts across all primary resolutions */
   retryCount: number;
+  /** Total provider outage events — all providers (primary + fallback) failed */
+  totalOutageCount: number;
 }
 
 /**
@@ -97,6 +99,7 @@ export class OracleService {
     fallbackFailureCount: 0,
     totalAttempts: 0,
     retryCount: 0,
+    totalOutageCount: 0,
   };
 
   constructor(config: OracleServiceConfig) {
@@ -215,8 +218,12 @@ export class OracleService {
       return result;
     } catch (fallbackError) {
       this.metrics.fallbackFailureCount++;
-      this.logger.error("Fallback provider failed", {
+      this.metrics.totalOutageCount++;
+      this.logger.error("All providers unreachable — total provider outage", {
+        event: "oracle.total_outage",
         marketId: request.marketId,
+        primaryFailureCount: this.metrics.primaryFailureCount,
+        fallbackFailureCount: this.metrics.fallbackFailureCount,
         error:
           fallbackError instanceof Error
             ? fallbackError.message
@@ -266,6 +273,7 @@ export class OracleService {
       fallbackFailureCount: 0,
       totalAttempts: 0,
       retryCount: 0,
+      totalOutageCount: 0,
     };
   }
 

--- a/apps/workers/src/finalization/job.test.ts
+++ b/apps/workers/src/finalization/job.test.ts
@@ -530,6 +530,64 @@ describe("FinalizationJob", () => {
     });
   });
 
+  describe("challenge window gating", () => {
+    it("skips a candidate that is still within the challenge window", async () => {
+      const recentCandidate = makeCandidate({
+        id: "recent",
+        createdAt: new Date(Date.now() - 1000), // created 1 second ago
+      });
+      const prisma = makePrisma([recentCandidate]);
+
+      // Challenge window of 1 hour → recent candidate is still within it
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: 3600,
+      });
+      const result = await job.run();
+
+      expect(result.totalCandidates).toBe(1);
+      expect(result.finalizedCount).toBe(0);
+      expect(result.skippedCount).toBe(1);
+      expect(result.candidates[0].status).toBe("skipped");
+    });
+
+    it("finalizes a candidate that is past the challenge window", async () => {
+      const oldCandidate = makeCandidate({
+        id: "old",
+        createdAt: new Date(Date.now() - 7200_000), // created 2 hours ago
+      });
+      const prisma = makePrisma([oldCandidate]);
+
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: 3600, // 1 hour window
+      });
+      const result = await job.run();
+
+      expect(result.totalCandidates).toBe(1);
+      expect(result.finalizedCount).toBe(1);
+      expect(result.skippedCount).toBe(0);
+    });
+
+    it("uses isChallengeWindowOpen utility for the per-candidate check", async () => {
+      // A candidate that is exactly at the edge of the window boundary:
+      // createdAt exactly challengeWindowSeconds ago → window JUST closed
+      const edgeCandidate = makeCandidate({
+        id: "edge",
+        createdAt: new Date(Date.now() - 3600_000), // created exactly 1 hour ago
+      });
+      const prisma = makePrisma([edgeCandidate]);
+
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: 3600, // 1 hour window
+      });
+
+      // At the exact boundary (now >= opensAt && now < closesAt):
+      // closesAt = proposedAt + 3600s = now. Since the upper bound is
+      // exclusive (now < closesAt), the window is now closed → finalize.
+      const result = await job.run();
+      expect(result.finalizedCount).toBe(1);
+    });
+  });
+
   describe("CHALLENGED and REJECTED paths", () => {
     it("only queries PROPOSED candidates and ignores CHALLENGED/REJECTED", async () => {
       const findMany = vi.fn().mockResolvedValue([]);

--- a/apps/workers/src/finalization/job.ts
+++ b/apps/workers/src/finalization/job.ts
@@ -4,6 +4,7 @@ import type {
   FinalizationJobResult,
   FinalizationCandidateResult,
 } from "./types.js";
+import { isChallengeWindowOpen } from "../../../../src/oracle/challengeWindow.js";
 
 /**
  * Configuration for a single FinalizationJob run.
@@ -138,6 +139,34 @@ export class FinalizationJob {
           remainingCandidates: candidates.length - results.length,
         });
         break;
+      }
+
+      // ── Challenge window verification ──────────────────────────────────
+      // Explicitly check that the candidate's challenge window has closed
+      // before finalizing.  This is a defense-in-depth check against clock
+      // skew or concurrent schedule edge cases; the query-level
+      // `createdAt: { lte: windowCutoff }` filter is the primary gate.
+      if (
+        isChallengeWindowOpen(
+          candidate.createdAt,
+          this.challengeWindowSeconds,
+          new Date()
+        )
+      ) {
+        this.logger.info("Candidate still within challenge window — skipping", {
+          candidateId: candidate.id,
+          marketId: candidate.marketId,
+          createdAt: candidate.createdAt.toISOString(),
+          challengeWindowSeconds: this.challengeWindowSeconds,
+        });
+
+        results.push({
+          candidateId: candidate.id,
+          marketId: candidate.marketId,
+          proposedOutcome: candidate.proposedOutcome,
+          status: "skipped",
+        });
+        continue;
       }
 
       this.logger.info("Finalization candidate eligible", {

--- a/docs/indexer-ledger-cursor.md
+++ b/docs/indexer-ledger-cursor.md
@@ -50,7 +50,62 @@ The cursor is not written to the database on every tick — frequent small write
 unnecessary load. Instead it is flushed after a configurable number of successful batches
 (`INDEXER_CHECKPOINT_FLUSH_EVERY_BATCHES`) and unconditionally on graceful shutdown.
 
-## Recovery
+## Reorg safety
+
+When the Stellar network undergoes a chain reorganisation, ledgers that were
+previously considered final may be replaced. The indexer detects reorgs and
+rewinds its cursor to a safe depth so that forked events are re-fetched from
+the canonical chain.
+
+### Detection mechanism
+
+1. After each successful ingestion tick the indexer calls the Stellar RPC
+   `getLatestLedger()` endpoint and stores the **sequence number** and **hash**
+   of the latest ledger in both memory and PostgreSQL (via
+   `PrismaCursorStorageClient.saveLedgerHash()`).
+
+2. On every subsequent tick, immediately after fetching the events window, the
+   indexer compares the latest ledger from the RPC response against the stored
+   values. A reorg is flagged when any of the following holds:
+
+   - **Sequence regressed**: The current latest ledger sequence is **lower**
+     than the last known sequence (the chain rolled back).
+   - **Hash mismatch at same sequence**: The sequence is unchanged but the
+     hash differs (the chain content changed without advancing the tip).
+
+3. When a reorg is detected, the cursor is rewound by
+   `ledgerWindowSize × 2` ledgers (never below 0). The current tick returns
+   immediately without processing events; the next tick re-fetches from the
+   rewound position.
+
+```typescript
+// apps/indexer/src/ingestion.ts (conceptual)
+const rewindLedgers = ledgerWindowSize * REORG_REWIND_DEPTH_MULTIPLIER;
+const safeSequence = Math.max(0, currentSeq - rewindLedgers);
+// → cursor set to safeSequence, next tick re-fetches from there
+```
+
+### Cursor hash persistence
+
+The hash is stored in the same `indexer_cursors` table using a derived cursor
+key (`${cursorKey}:ledger_hash`). This allows the reorg detection to survive
+a full restart of the indexer process. If no persisted hash is found on
+startup, detection is deferred until the first successful tick establishes a
+baseline.
+
+### Recovery
+
+After a reorg rewind the indexer re-processes the affected ledgers. Any events
+that were already persisted (trades, resolutions, deposits) are **skipped**
+via `indexer_processed_events` idempotency keys — duplicate rows are never
+inserted. Events that existed only on the forked branch are naturally absent
+from the new window and produce no dust in the database.
+
+```sql
+-- The ledger hash is stored under a derived key
+SELECT cursor_value FROM indexer_cursors
+WHERE network_id = 'testnet' AND cursor_key = 'ingestion:ledger_hash';
+```
 
 If the cursor row is absent (e.g. first run, or after manual deletion) the indexer starts from
 ledger 0 and scans forward. To reset the indexer to a specific ledger, delete or update the


### PR DESCRIPTION
## Closes #715 
## Closes #716  
## Closes #717  
## Closes #718

### What does this PR do?

Implements four targeted issues from the Stellar Wave program:

**#715 - Reorg-safe cursor rewind policy (indexer)**
- Adds  to  for fetching ledger hash
- Extends  with / for hash persistence
- Implements reorg detection in  using sequence regression and hash mismatch checks
- On reorg detection, rewinds cursor by  and logs the event
- Persists ledger hash alongside cursor on checkpoint flush so detection survives restarts
- Updates  with full Reorg safety section
- Adds unit tests for reorg detection scenarios

**#716 - Wire ResolutionCandidate challenge window check (oracle/finalization)**
- Imports  utility from  into 
- Adds a defense-in-depth per-candidate challenge window check before finalizing
- Candidates still within the window are reported as "skipped" with a clear log message
- Adds unit tests covering window-edge, recent, and past-window candidates

**#717 - Fail closed when all providers unreachable (oracle)**
- Adds  metric to  tracking total provider outages
- Increments  and logs a structured  event when both primary and fallback fail
- Verifies enqueue callback is never invoked on total provider failure (fail-closed)
- Adds unit tests for fail-closed behavior and metric verification

**#718 - Store provider confidence on OracleReport row (oracle)**
- Confirms  column already exists on  model
- Verifies  is already written on report creation in 
- Adds explicit integration tests verifying confidence value is persisted from both primary and fallback providers