### PR TITLE
Oracle/finalization/indexer reliability: confidence validation, fail-closed metric, challenge-window & reorg test coverage

### DIFF
--- a/apps/indexer/src/ingestion.test.ts
+++ b/apps/indexer/src/ingestion.test.ts
@@ -55,6 +55,62 @@ function makeResolutionEvent(id: string): RawChainEvent {
   };
 }
 
+function makeForkResolutionEvent(
+  id: string,
+  ledger: number,
+  oracle: string
+): RawChainEvent {
+  const valueXdr = nativeToScVal({
+    market_id: "market-1",
+    outcome: "YES",
+    oracle,
+  }).toXDR("base64");
+
+  return {
+    id,
+    ledger,
+    ledgerClosedAt: "2024-01-01T00:00:00Z",
+    contractId: "CTEST",
+    type: "contract",
+    pagingToken: `token-${id}`,
+    valueXdr,
+    topicsXdr: [RESOLUTION_TOPIC],
+  };
+}
+
+/**
+ * Synthetic reorg fixture: two competing chain forks that report the same
+ * latest ledger sequence but a different ledger hash and a different
+ * resolution event for the same market/ledger. Used to exercise the
+ * hash-mismatch reorg branch (as opposed to a sequence regression) and to
+ * verify that the canonical fork's events are the ones re-ingested after the
+ * cursor rewinds.
+ */
+const SYNTHETIC_REORG_FIXTURE = {
+  forkA: {
+    hash: "hash-fork-a",
+    latestLedger: 100,
+    events: [
+      makeForkResolutionEvent(
+        "0000000050-0000000001-0000000000",
+        50,
+        "GORACLE_FORK_A"
+      ),
+    ],
+  },
+  forkB: {
+    hash: "hash-fork-b",
+    latestLedger: 100,
+    events: [
+      makeForkResolutionEvent(
+        "0000000050-0000000002-0000000000",
+        50,
+        "GORACLE_FORK_B"
+      ),
+    ],
+  },
+};
+
 function makeLogger(): ILogger {
   return {
     debug: vi.fn(),
@@ -519,6 +575,108 @@ describe("PollingIngestionLoop — stale cursor handling", () => {
         "Chain reorganisation detected — rewinding cursor",
         expect.anything()
       );
+    });
+
+    describe("synthetic reorg fixture — cursor rewind", () => {
+      const { forkA, forkB } = SYNTHETIC_REORG_FIXTURE;
+
+      it("detects a same-sequence hash-mismatch reorg and rewinds the cursor", async () => {
+        const loop = createLoop();
+
+        // Tick 1: ingest fork A and establish the sequence+hash baseline.
+        vi.mocked(eventFetcher.fetchByLedgerWindow).mockResolvedValueOnce({
+          events: forkA.events,
+          latestLedger: forkA.latestLedger,
+        });
+        vi.mocked(eventFetcher.getLatestLedgerInfo).mockResolvedValueOnce({
+          sequence: forkA.latestLedger,
+          hash: forkA.hash,
+        });
+        await (loop as unknown as { tick(): Promise<void> }).tick();
+
+        expect(batchWriter.write).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              kind: "resolution",
+              data: expect.objectContaining({
+                oracleAddress: "GORACLE_FORK_A",
+              }),
+            }),
+          ])
+        );
+
+        // Tick 2: the network now reports fork B — same sequence, different hash.
+        vi.mocked(eventFetcher.fetchByLedgerWindow).mockResolvedValueOnce({
+          events: forkB.events,
+          latestLedger: forkB.latestLedger,
+        });
+        vi.mocked(eventFetcher.getLatestLedgerInfo).mockResolvedValueOnce({
+          sequence: forkB.latestLedger,
+          hash: forkB.hash,
+        });
+        await (loop as unknown as { tick(): Promise<void> }).tick();
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          "Chain reorganisation detected — rewinding cursor",
+          expect.objectContaining({ event: "indexer.reorg.detected" })
+        );
+        // Fork B was not written blindly — the reorg tick only rewinds.
+        expect(batchWriter.write).toHaveBeenCalledTimes(1);
+
+        const cursorAfterReorg = (loop as unknown as { cursor: string }).cursor;
+        expect(Number(cursorAfterReorg)).toBeLessThan(forkA.latestLedger);
+      });
+
+      it("re-ingests the canonical fork's events once the cursor resumes past the rewind point", async () => {
+        const loop = createLoop();
+
+        vi.mocked(eventFetcher.fetchByLedgerWindow).mockResolvedValueOnce({
+          events: forkA.events,
+          latestLedger: forkA.latestLedger,
+        });
+        vi.mocked(eventFetcher.getLatestLedgerInfo).mockResolvedValueOnce({
+          sequence: forkA.latestLedger,
+          hash: forkA.hash,
+        });
+        await (loop as unknown as { tick(): Promise<void> }).tick();
+
+        vi.mocked(eventFetcher.fetchByLedgerWindow).mockResolvedValueOnce({
+          events: forkB.events,
+          latestLedger: forkB.latestLedger,
+        });
+        vi.mocked(eventFetcher.getLatestLedgerInfo).mockResolvedValueOnce({
+          sequence: forkB.latestLedger,
+          hash: forkB.hash,
+        });
+        await (loop as unknown as { tick(): Promise<void> }).tick(); // reorg tick — rewinds only
+
+        // Tick 3: the chain has since produced a new ledger on top of fork B
+        // (its tip is now canonical), so the latest sequence advances past
+        // the reorg point. Normal progression resumes from the rewound
+        // cursor and re-fetches fork B's canonical event for ledger 50.
+        vi.mocked(eventFetcher.fetchByLedgerWindow).mockResolvedValueOnce({
+          events: forkB.events,
+          latestLedger: forkB.latestLedger + 1,
+        });
+        vi.mocked(eventFetcher.getLatestLedgerInfo).mockResolvedValueOnce({
+          sequence: forkB.latestLedger + 1,
+          hash: "hash-fork-b-plus-one",
+        });
+        await (loop as unknown as { tick(): Promise<void> }).tick();
+
+        // tick 1 + tick 3 wrote; the reorg tick (2) wrote nothing.
+        expect(batchWriter.write).toHaveBeenCalledTimes(2);
+        expect(batchWriter.write).toHaveBeenLastCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              kind: "resolution",
+              data: expect.objectContaining({
+                oracleAddress: "GORACLE_FORK_B",
+              }),
+            }),
+          ])
+        );
+      });
     });
   });
 });

--- a/apps/oracle/main.test.ts
+++ b/apps/oracle/main.test.ts
@@ -200,6 +200,43 @@ describe("apps/oracle/main poll()", () => {
     );
   });
 
+  it("rejects an out-of-range confidence score instead of inserting the OracleReport", async () => {
+    mockPrisma.market.findMany.mockResolvedValue([
+      { id: "market-1", oracleAddress: "GORACLE1" },
+    ]);
+    mockOracleService.resolve.mockResolvedValue({
+      ...RESOLVED_RESULT,
+      confidence: 1.5,
+    });
+
+    await poll();
+
+    expect(mockPrisma.oracleReport.create).not.toHaveBeenCalled();
+    expect(mockQueue.enqueue).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Failed to resolve market",
+      expect.objectContaining({
+        marketId: "market-1",
+        error: expect.stringContaining("out of range"),
+      })
+    );
+  });
+
+  it("rejects a negative confidence score instead of inserting the OracleReport", async () => {
+    mockPrisma.market.findMany.mockResolvedValue([
+      { id: "market-1", oracleAddress: "GORACLE1" },
+    ]);
+    mockOracleService.resolve.mockResolvedValue({
+      ...RESOLVED_RESULT,
+      confidence: -0.1,
+    });
+
+    await poll();
+
+    expect(mockPrisma.oracleReport.create).not.toHaveBeenCalled();
+    expect(mockQueue.enqueue).not.toHaveBeenCalled();
+  });
+
   it("logs and continues when one market fails to resolve, without aborting the batch", async () => {
     mockPrisma.market.findMany.mockResolvedValue([
       { id: "market-fail", oracleAddress: "GFAIL" },

--- a/apps/oracle/main.ts
+++ b/apps/oracle/main.ts
@@ -86,6 +86,17 @@ export async function poll(): Promise<void> {
     try {
       const result = await oracleService.resolve(request);
 
+      if (
+        typeof result.confidence !== "number" ||
+        !Number.isFinite(result.confidence) ||
+        result.confidence < 0 ||
+        result.confidence > 1
+      ) {
+        throw new Error(
+          `Resolved confidence ${result.confidence} is out of range [0, 1]`
+        );
+      }
+
       const report = signResolutionReport(
         {
           marketId: market.id,

--- a/apps/oracle/oracle-service.test.ts
+++ b/apps/oracle/oracle-service.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { OracleService } from "./oracle-service.js";
 import { PrimaryAdapter } from "./primary-adapter.js";
 import { FallbackAdapter } from "./fallback-adapter.js";
+import { oracleFailClosedTotal } from "../../src/services/metrics.js";
 import type {
   ProviderAdapter,
   ProviderResult,
@@ -340,6 +341,30 @@ describe("OracleService", () => {
       expect(metrics.totalOutageCount).toBe(1);
       expect(metrics.primaryFailureCount).toBe(1);
       expect(metrics.fallbackFailureCount).toBe(1);
+    });
+
+    it("emits the vatix_oracle_fail_closed_total prometheus counter on total provider failure", async () => {
+      const failingPrimary = createMockAdapter("primary", true);
+      const failingFallback = createMockAdapter("fallback", true);
+
+      const service = new OracleService({
+        primaryAdapter: failingPrimary,
+        fallbackAdapter: failingFallback,
+        enableFallback: true,
+      });
+
+      const before = (await oracleFailClosedTotal.get()).values[0]?.value ?? 0;
+
+      await expect(
+        service.resolve({
+          marketId: "market-001",
+          oracleAddress:
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        })
+      ).rejects.toThrow();
+
+      const after = (await oracleFailClosedTotal.get()).values[0]?.value ?? 0;
+      expect(after).toBe(before + 1);
     });
 
     it("does not increment totalOutageCount when primary succeeds", async () => {

--- a/apps/oracle/oracle-service.ts
+++ b/apps/oracle/oracle-service.ts
@@ -17,6 +17,7 @@ import { withRetry, RetryConfig, isRetryableError } from "./retry-utils.js";
 import type { ILogger } from "../../packages/shared/src/logger.js";
 import type { SubmissionQueueItem } from "./submission-queue.js";
 import { SubmissionQueue } from "./submission-queue.js";
+import { oracleFailClosedTotal } from "../../src/services/metrics.js";
 
 /**
  * Callback invoked when a resolution succeeds and should be enqueued.
@@ -219,6 +220,7 @@ export class OracleService {
     } catch (fallbackError) {
       this.metrics.fallbackFailureCount++;
       this.metrics.totalOutageCount++;
+      oracleFailClosedTotal.inc();
       this.logger.error("All providers unreachable — total provider outage", {
         event: "oracle.total_outage",
         marketId: request.marketId,

--- a/apps/workers/src/finalization/job.test.ts
+++ b/apps/workers/src/finalization/job.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { FinalizationJob, FinalizationValidationError } from "./job.js";
 import type { FinalizationJobConfig, FinalizationCandidate } from "./job.js";
 import type {
@@ -588,6 +588,112 @@ describe("FinalizationJob", () => {
     });
   });
 
+  describe("challenge window boundaries (deterministic clock)", () => {
+    const NOW = new Date("2026-01-01T12:00:00.000Z");
+    const WINDOW_SECONDS = 3600; // 1 hour
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("passes a windowCutoff of now - challengeWindowSeconds to the candidate query", async () => {
+      const prisma = makePrisma([]);
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: WINDOW_SECONDS,
+      });
+
+      await job.run();
+
+      expect(prisma.resolutionCandidate.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            createdAt: { lte: new Date("2026-01-01T11:00:00.000Z") },
+          }),
+        })
+      );
+    });
+
+    it("skips a candidate created 1ms after the cutoff (still inside the window)", async () => {
+      const candidate = makeCandidate({
+        id: "just-inside",
+        createdAt: new Date("2026-01-01T11:00:00.001Z"), // closes 1ms after NOW
+      });
+      const prisma = makePrisma([candidate]);
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: WINDOW_SECONDS,
+      });
+
+      const result = await job.run();
+
+      expect(result.candidates[0].status).toBe("skipped");
+    });
+
+    it("finalizes a candidate whose window closes at exactly now (exclusive upper bound)", async () => {
+      const candidate = makeCandidate({
+        id: "exact-close",
+        createdAt: new Date("2026-01-01T11:00:00.000Z"), // closes exactly at NOW
+      });
+      const prisma = makePrisma([candidate]);
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: WINDOW_SECONDS,
+      });
+
+      const result = await job.run();
+
+      expect(result.candidates[0].status).toBe("finalized");
+    });
+
+    it("finalizes a candidate created 1ms before the cutoff (just past the window)", async () => {
+      const candidate = makeCandidate({
+        id: "just-outside",
+        createdAt: new Date("2026-01-01T10:59:59.999Z"), // closes 1ms before NOW
+      });
+      const prisma = makePrisma([candidate]);
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: WINDOW_SECONDS,
+      });
+
+      const result = await job.run();
+
+      expect(result.candidates[0].status).toBe("finalized");
+    });
+
+    it("skips a candidate proposed at exactly now (window just opened)", async () => {
+      const candidate = makeCandidate({
+        id: "just-opened",
+        createdAt: new Date(NOW),
+      });
+      const prisma = makePrisma([candidate]);
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: WINDOW_SECONDS,
+      });
+
+      const result = await job.run();
+
+      expect(result.candidates[0].status).toBe("skipped");
+    });
+
+    it("finalizes immediately when challengeWindowSeconds is 0", async () => {
+      const candidate = makeCandidate({
+        id: "zero-window",
+        createdAt: new Date(NOW),
+      });
+      const prisma = makePrisma([candidate]);
+      const job = new FinalizationJob(prisma, makeLogger(), {
+        challengeWindowSeconds: 0,
+      });
+
+      const result = await job.run();
+
+      expect(result.candidates[0].status).toBe("finalized");
+    });
+  });
+
   describe("CHALLENGED and REJECTED paths", () => {
     it("only queries PROPOSED candidates and ignores CHALLENGED/REJECTED", async () => {
       const findMany = vi.fn().mockResolvedValue([]);
@@ -648,14 +754,18 @@ describe("FinalizationJob", () => {
 
         // Each $transaction call advances fake time by 200 ms
         const { tx } = makeTx();
-        const transaction = vi.fn().mockImplementation(
-          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
-            await vi.advanceTimersByTimeAsync(200);
-            return fn(tx);
-          }
-        );
+        const transaction = vi
+          .fn()
+          .mockImplementation(
+            async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
+              await vi.advanceTimersByTimeAsync(200);
+              return fn(tx);
+            }
+          );
         const prisma = {
-          resolutionCandidate: { findMany: vi.fn().mockResolvedValue(candidates) },
+          resolutionCandidate: {
+            findMany: vi.fn().mockResolvedValue(candidates),
+          },
           $transaction: transaction,
         } as unknown as PrismaClient;
 

--- a/docs/indexer-ledger-cursor.md
+++ b/docs/indexer-ledger-cursor.md
@@ -93,6 +93,21 @@ a full restart of the indexer process. If no persisted hash is found on
 startup, detection is deferred until the first successful tick establishes a
 baseline.
 
+### Test coverage
+
+`apps/indexer/src/ingestion.test.ts` (`reorg detection` → `synthetic reorg
+fixture — cursor rewind`) exercises this policy against a synthetic
+`SYNTHETIC_REORG_FIXTURE` of two competing forks (`forkA`/`forkB`) that
+report the **same ledger sequence with different hashes**:
+
+- Ingesting fork A establishes the sequence+hash baseline.
+- Ingesting fork B at the same sequence triggers the hash-mismatch branch
+  (not the sequence-regression branch, which is covered separately) and
+  rewinds the cursor without writing fork B's events.
+- Once the chain advances past the fork point, the next tick re-fetches and
+  persists fork B's canonical events — proving the rewind actually results
+  in re-ingestion of the winning fork, not just a cursor decrement.
+
 ### Recovery
 
 After a reorg rewind the indexer re-processes the affected ledgers. Any events

--- a/src/services/metrics.ts
+++ b/src/services/metrics.ts
@@ -26,3 +26,15 @@ export const orderbookHydratedMarketsGauge = new client.Gauge({
   help: "Number of (market, outcome) order books currently hydrated in memory",
   registers: [metricsRegistry],
 });
+
+/**
+ * Incremented by OracleService whenever every provider (primary + fallback)
+ * fails for a resolution request and the oracle fails closed — i.e. no
+ * OracleReport is written and nothing is submitted on-chain (#717 fail-closed
+ * behavior, #810 observability).
+ */
+export const oracleFailClosedTotal = new client.Counter({
+  name: "vatix_oracle_fail_closed_total",
+  help: "Total number of times the oracle failed closed after all providers were unreachable",
+  registers: [metricsRegistry],
+});


### PR DESCRIPTION
## Summary

Closes #809
Closes #810 
Closes #811 
Closes #812

Four scoped reliability items from the Oracle/Resolution/Indexer safety pass:

- **#809 — Validate confidence score range before OracleReport insert**
  Added a `[0, 1]` range guard in `apps/oracle/main.ts` right before the `OracleReport` insert (finite check + bounds check). An out-of-range confidence throws into the existing per-market try/catch, so the bad market is logged and skipped without aborting the batch or enqueuing on-chain submission. Tests added for `>1` and `<0`.

- **#810 — Emit metric when oracle fail-closed triggers**
  Fail-closed behavior already existed (total outage → no insert/enqueue), but was only tracked via an in-memory counter nobody scraped. Added a Prometheus counter `vatix_oracle_fail_closed_total` (`src/services/metrics.ts`, exposed on `GET /metrics`) and incremented it at the exact fail-closed trigger point in `OracleService.resolveWithFallback`. Test asserts the counter increments on total provider failure.

- **#811 — Unit test finalization against challenge window boundaries**
  Challenge-window enforcement in the finalization job already existed; added deterministic (fake-clock) boundary tests in `job.test.ts`: exact `windowCutoff` value passed to the query, 1ms-inside-window (skipped), exactly-at-close (finalized, exclusive upper bound), 1ms-past-close (finalized), exactly-at-open (skipped), and a zero-length window (finalized immediately). Test-only change.

- **#812 — Synthetic reorg fixture for cursor rewind tests**
  Reorg detection/rewind already existed but only had test coverage for the sequence-regression path. Added `SYNTHETIC_REORG_FIXTURE` (two forks at the same ledger sequence with different hashes/events) to `ingestion.test.ts`, covering the previously-untested hash-mismatch branch and proving the rewind results in re-ingestion of the canonical fork's data, not just a cursor decrement. Documented the fixture in `docs/indexer-ledger-cursor.md`.

## Changes

- `apps/oracle/main.ts`, `apps/oracle/main.test.ts`
- `apps/oracle/oracle-service.ts`, `apps/oracle/oracle-service.test.ts`
- `src/services/metrics.ts`
- `apps/workers/src/finalization/job.test.ts`
- `apps/indexer/src/ingestion.test.ts`
- `docs/indexer-ledger-cursor.md`

## Test plan

- [x] `apps/oracle/main.test.ts` — 14 tests pass
- [x] `apps/oracle/oracle-service.test.ts` — full suite passes, including new fail-closed metric test
- [x] `apps/workers/src/finalization/job.test.ts` — 39/40 pass (1 pre-existing `maxRunMs` flake, confirmed present on unmodified `dev`, unrelated to this change)
- [x] `apps/indexer/src/ingestion.test.ts` — 17/19 pass (2 pre-existing failures from a stale `TRADE_TOPIC` test fixture unrelated to reorg logic, confirmed present on unmodified `dev`)
- [x] `tsc --noEmit` — no new errors introduced by this branch
