### PR TITLE
Reject Stellar network passphrase mismatches in oracle submission worker

### DIFF
--- a/apps/workers/src/oracle/stellar-config.test.ts
+++ b/apps/workers/src/oracle/stellar-config.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { resolveOracleStellarConfig } from "./stellar-config.js";
+import {
+  resolveOracleStellarConfig,
+  assertPassphraseMatchesDeployment,
+  StellarNetworkMismatchError,
+} from "./stellar-config.js";
 
 const BASE_ENV = {
   STELLAR_RPC_URL: "https://rpc.example.com",
@@ -50,5 +54,85 @@ describe("resolveOracleStellarConfig", () => {
       networkPassphrase: BASE_ENV.SOROBAN_NETWORK_PASSPHRASE,
       signerSecret: BASE_ENV.ORACLE_SECRET_KEY,
     });
+  });
+
+  it("defaults STELLAR_NETWORK to testnet and accepts the matching testnet passphrase", () => {
+    const config = resolveOracleStellarConfig({
+      ...BASE_ENV,
+      INDEXER_CONTRACT_ID: "CINDEXER",
+    });
+    expect(config?.networkPassphrase).toBe("Test SDF Network ; September 2015");
+  });
+
+  it("throws when the passphrase does not match the declared deployment network", () => {
+    expect(() =>
+      resolveOracleStellarConfig({
+        ...BASE_ENV,
+        INDEXER_CONTRACT_ID: "CINDEXER",
+        STELLAR_NETWORK: "mainnet",
+      })
+    ).toThrow(StellarNetworkMismatchError);
+  });
+
+  it("accepts the mainnet passphrase when STELLAR_NETWORK=mainnet", () => {
+    const config = resolveOracleStellarConfig({
+      ...BASE_ENV,
+      INDEXER_CONTRACT_ID: "CINDEXER",
+      STELLAR_NETWORK: "mainnet",
+      SOROBAN_NETWORK_PASSPHRASE:
+        "Public Global Stellar Network ; September 2015",
+    });
+    expect(config?.networkPassphrase).toBe(
+      "Public Global Stellar Network ; September 2015"
+    );
+  });
+
+  it("does not validate when the config is otherwise incomplete", () => {
+    const config = resolveOracleStellarConfig({
+      SOROBAN_NETWORK_PASSPHRASE: "not a real passphrase",
+      ORACLE_SECRET_KEY: BASE_ENV.ORACLE_SECRET_KEY,
+      STELLAR_NETWORK: "mainnet",
+      // STELLAR_RPC_URL and a contract id are missing, so resolution should
+      // short-circuit to undefined before the mismatch check ever runs.
+    });
+    expect(config).toBeUndefined();
+  });
+});
+
+describe("assertPassphraseMatchesDeployment", () => {
+  it("rejects a wrong passphrase for a known deployment network", () => {
+    expect(() =>
+      assertPassphraseMatchesDeployment(
+        "Test SDF Network ; September 2015",
+        "mainnet"
+      )
+    ).toThrow(/does not match STELLAR_NETWORK="mainnet"/);
+  });
+
+  it("accepts the correct passphrase for a known deployment network", () => {
+    expect(() =>
+      assertPassphraseMatchesDeployment(
+        "Test SDF Network ; September 2015",
+        "testnet"
+      )
+    ).not.toThrow();
+  });
+
+  it("is case-insensitive and trims the deployment network identifier", () => {
+    expect(() =>
+      assertPassphraseMatchesDeployment(
+        "Test SDF Network ; September 2015",
+        "  Testnet  "
+      )
+    ).not.toThrow();
+  });
+
+  it("does not throw for an unrecognized deployment network", () => {
+    expect(() =>
+      assertPassphraseMatchesDeployment(
+        "Standalone Network ; 2024",
+        "futurenet"
+      )
+    ).not.toThrow();
   });
 });

--- a/apps/workers/src/oracle/stellar-config.ts
+++ b/apps/workers/src/oracle/stellar-config.ts
@@ -8,11 +8,61 @@ export interface ResolvedOracleStellarConfig {
 }
 
 /**
+ * Known Stellar network passphrases, keyed by the deployment identifier used
+ * in STELLAR_NETWORK. Mirrors apps/indexer/src/config.ts's KNOWN_PASSPHRASES
+ * so the oracle worker recognizes the same set of networks.
+ */
+export const KNOWN_STELLAR_PASSPHRASES = {
+  testnet: "Test SDF Network ; September 2015",
+  mainnet: "Public Global Stellar Network ; September 2015",
+} as const;
+
+/** Thrown when a configured network passphrase doesn't match the deployment. */
+export class StellarNetworkMismatchError extends Error {
+  constructor(deploymentNetwork: string, expected: string, actual: string) {
+    super(
+      `SOROBAN_NETWORK_PASSPHRASE does not match STELLAR_NETWORK="${deploymentNetwork}": ` +
+        `expected "${expected}" but got "${actual}"`
+    );
+    this.name = "StellarNetworkMismatchError";
+  }
+}
+
+/**
+ * Throws StellarNetworkMismatchError when networkPassphrase doesn't match the
+ * passphrase known for deploymentNetwork. Unrecognized deployment networks
+ * (e.g. futurenet, a custom standalone network) are skipped rather than
+ * rejected, since we have no known-good passphrase to compare against.
+ */
+export function assertPassphraseMatchesDeployment(
+  networkPassphrase: string,
+  deploymentNetwork: string
+): void {
+  const normalized = deploymentNetwork.trim().toLowerCase();
+  const expected = (
+    KNOWN_STELLAR_PASSPHRASES as Record<string, string | undefined>
+  )[normalized];
+
+  if (expected && expected !== networkPassphrase) {
+    throw new StellarNetworkMismatchError(
+      normalized,
+      expected,
+      networkPassphrase
+    );
+  }
+}
+
+/**
  * Builds the on-chain submission config from env vars, or returns undefined
  * when any required var is missing (resolve_market calls are then disabled).
  * Contract ID resolution defers to the shared loader so this worker matches
  * the INDEXER_CONTRACT_ID-first precedence used by the indexer, instead of
  * re-implementing (and inverting) that precedence locally.
+ *
+ * Once all four vars are present, the resolved networkPassphrase must match
+ * the passphrase known for STELLAR_NETWORK (default "testnet") — this is
+ * what stops a misconfigured passphrase from silently submitting to the
+ * wrong network. See assertPassphraseMatchesDeployment.
  */
 export function resolveOracleStellarConfig(
   env: NodeJS.ProcessEnv
@@ -28,7 +78,14 @@ export function resolveOracleStellarConfig(
     contractId = undefined;
   }
 
-  return rpcUrl && contractId && networkPassphrase && signerSecret
-    ? { rpcUrl, contractId, networkPassphrase, signerSecret }
-    : undefined;
+  if (!(rpcUrl && contractId && networkPassphrase && signerSecret)) {
+    return undefined;
+  }
+
+  assertPassphraseMatchesDeployment(
+    networkPassphrase,
+    env.STELLAR_NETWORK ?? "testnet"
+  );
+
+  return { rpcUrl, contractId, networkPassphrase, signerSecret };
 }

--- a/apps/workers/src/oracle/submission-worker.test.ts
+++ b/apps/workers/src/oracle/submission-worker.test.ts
@@ -471,6 +471,61 @@ describe("SubmissionWorker", () => {
     });
   });
 
+  describe("Stellar network passphrase validation", () => {
+    it("rejects construction when the configured passphrase does not match the deployment network", () => {
+      expect(
+        () =>
+          new SubmissionWorker(mockQueue as any, mockPrisma as any, {
+            submissionMaxRetries: 3,
+            consumerName: "test-consumer",
+            logger: mockLogger,
+            stellar: TEST_STELLAR_CONFIG, // testnet passphrase
+            stellarNetwork: "mainnet",
+          })
+      ).toThrow(/does not match STELLAR_NETWORK="mainnet"/);
+    });
+
+    it("submits on-chain in test doubles when the passphrase matches the deployment network", async () => {
+      const submission = createTestSubmission();
+      stellarMocks.getAccount.mockResolvedValueOnce({
+        accountId: () => "GSOURCEACCOUNT",
+      });
+      stellarMocks.prepareTransaction.mockResolvedValueOnce({
+        sign: vi.fn(),
+      });
+      stellarMocks.sendTransaction.mockResolvedValueOnce({
+        status: "PENDING",
+        hash: "txhash-correct-network",
+      });
+      stellarMocks.getTransaction.mockResolvedValueOnce({
+        status: "SUCCESS",
+        ledger: 7,
+      });
+      mockPrisma.oracleReport.create.mockResolvedValueOnce({ id: "report-1" });
+      mockPrisma.resolutionCandidate.upsert.mockResolvedValueOnce({
+        id: "candidate-1",
+      });
+      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
+
+      const stellarWorker = new SubmissionWorker(
+        mockQueue as any,
+        mockPrisma as any,
+        {
+          submissionMaxRetries: 3,
+          consumerName: "test-consumer",
+          logger: mockLogger,
+          stellar: TEST_STELLAR_CONFIG,
+          stellarNetwork: "testnet",
+        }
+      );
+
+      await stellarWorker.processSubmission(submission);
+
+      expect(stellarMocks.sendTransaction).toHaveBeenCalled();
+      expect(mockQueue.acknowledge).toHaveBeenCalledWith(submission);
+    });
+  });
+
   describe("Stellar RPC retry/backoff", () => {
     let stellarWorker: SubmissionWorker;
 

--- a/apps/workers/src/oracle/submission-worker.ts
+++ b/apps/workers/src/oracle/submission-worker.ts
@@ -31,6 +31,7 @@ import {
   type DeadLetterMessage,
 } from "../consumers/dead-letter.js";
 import { withRetry } from "../../../oracle/retry-utils.js";
+import { assertPassphraseMatchesDeployment } from "./stellar-config.js";
 
 /** Retry config for individual Stellar RPC calls (getAccount, prepareTransaction,
  *  sendTransaction). Bounded and short-lived so a transient RPC blip is absorbed
@@ -53,6 +54,12 @@ export interface SubmissionWorkerConfig {
   consumerName: string;
   logger: ILogger;
   stellar?: OracleStellarConfig;
+  /**
+   * Deployment network id (e.g. "testnet" | "mainnet"), used to verify that
+   * `stellar.networkPassphrase` matches this deployment. Defaults to the
+   * STELLAR_NETWORK env var, then "testnet".
+   */
+  stellarNetwork?: string;
 }
 
 /**
@@ -77,6 +84,13 @@ export class SubmissionWorker {
     this.consumerName = config.consumerName;
     this.logger = config.logger;
     this.stellarConfig = config.stellar;
+
+    if (this.stellarConfig) {
+      assertPassphraseMatchesDeployment(
+        this.stellarConfig.networkPassphrase,
+        config.stellarNetwork ?? process.env.STELLAR_NETWORK ?? "testnet"
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
resolveOracleStellarConfig and SubmissionWorker now validate that SOROBAN_NETWORK_PASSPHRASE matches the passphrase known for the deployment's STELLAR_NETWORK (testnet/mainnet), throwing StellarNetworkMismatchError on mismatch instead of silently building transactions against the wrong network.

Closes #780
Closes #737
Closes #738