### PR TITLE
Matching test coverage, market-status guard, shared error envelope, NODE_ENV docs

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -16,6 +16,12 @@ We use a validation layer that checks configurations immediately upon initializa
 - **Database Credentials:** `DATABASE_URL`
 - **Authentication Keys:** `JWT_SECRET`
 
+> **`NODE_ENV` is a closed enum:** only `development`, `test`, or `production`
+> are accepted (defaults to `development` when unset). Any other value —
+> typos like `staging` or `prod` included — fails validation and the process
+> exits before it can bind a port. See [env-validation.md](./env-validation.md)
+> for the exact error message and full schema.
+
 ## Local Setup
 
 1. **Copy the Template:** Always ensure your local `.env` file matches the structure defined in `.env.example`.

--- a/docs/error-handler.md
+++ b/docs/error-handler.md
@@ -8,23 +8,24 @@ a consistent JSON envelope.
 ## Error Envelope
 
 Every error response uses the `ErrorEnvelope` shape defined in
-`src/types/errors.ts`:
+`packages/shared/src/errors.ts` (re-exported as `ErrorResponse` from
+`src/types/errors.ts` for API consumers):
 
-| Field        | Type     | Description                                                 |
-| ------------ | -------- | ----------------------------------------------------------- |
-| `code`       | `string` | Stable snake_case identifier (safe to switch on in clients) |
-| `message`    | `string` | Human-readable description                                  |
-| `error`      | `string` | Duplicate of `message` for legacy clients                   |
-| `statusCode` | `number` | HTTP status (mirrors the response status line)              |
-| `requestId`  | `string` | Correlates the response with server logs                    |
-| `metadata`   | `object` | Optional — present for `ValidationError` field details      |
-| `stack`      | `string` | Optional — included only outside production for 5xx errors  |
+| Field        | Type     | Description                                                |
+| ------------ | -------- | ---------------------------------------------------------- |
+| `code`       | `string` | Stable identifier (safe to switch on in clients)           |
+| `message`    | `string` | Human-readable description                                 |
+| `error`      | `string` | Duplicate of `message` for legacy clients                  |
+| `statusCode` | `number` | HTTP status (mirrors the response status line)             |
+| `requestId`  | `string` | Correlates the response with server logs                   |
+| `fields`     | `object` | Optional — present for `ValidationError` field details     |
+| `stack`      | `string` | Optional — included only outside production for 5xx errors |
 
 Example (development, 404):
 
 ```json
 {
-  "code": "not_found",
+  "code": "NOT_FOUND",
   "message": "Market not found",
   "error": "Market not found",
   "statusCode": 404,

--- a/packages/shared/src/errors.test.ts
+++ b/packages/shared/src/errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { createErrorEnvelope } from "./errors.js";
+
+describe("createErrorEnvelope", () => {
+  it("builds the standard envelope shape, mirroring message into error", () => {
+    const envelope = createErrorEnvelope({
+      code: "NOT_FOUND",
+      message: "Market not found",
+      statusCode: 404,
+      requestId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    });
+
+    expect(envelope).toEqual({
+      code: "NOT_FOUND",
+      message: "Market not found",
+      error: "Market not found",
+      statusCode: 404,
+      requestId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    });
+  });
+
+  it("omits fields and stack when not supplied", () => {
+    const envelope = createErrorEnvelope({
+      code: "INTERNAL_ERROR",
+      message: "boom",
+      statusCode: 500,
+      requestId: "req-1",
+    });
+
+    expect(envelope).not.toHaveProperty("fields");
+    expect(envelope).not.toHaveProperty("stack");
+  });
+
+  it("includes fields when supplied (e.g. ValidationError)", () => {
+    const envelope = createErrorEnvelope({
+      code: "VALIDATION_ERROR",
+      message: "bad input",
+      statusCode: 400,
+      requestId: "req-2",
+      fields: { email: "invalid" },
+    });
+
+    expect(envelope.fields).toEqual({ email: "invalid" });
+  });
+
+  it("includes stack when supplied", () => {
+    const envelope = createErrorEnvelope({
+      code: "INTERNAL_ERROR",
+      message: "boom",
+      statusCode: 500,
+      requestId: "req-3",
+      stack: "Error: boom\n  at somewhere",
+    });
+
+    expect(envelope.stack).toBe("Error: boom\n  at somewhere");
+  });
+});

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,0 +1,44 @@
+// Standard API error envelope shared by the API and indexer (#793).
+// See docs/error-handler.md for the canonical shape and examples.
+
+export interface ErrorEnvelope {
+  code: string;
+  message: string;
+  error: string;
+  statusCode: number;
+  requestId: string;
+  fields?: Record<string, string>;
+  stack?: string;
+}
+
+export interface CreateErrorEnvelopeInput {
+  code: string;
+  message: string;
+  statusCode: number;
+  requestId: string;
+  fields?: Record<string, string>;
+  stack?: string;
+}
+
+/** Builds an `ErrorEnvelope`, omitting optional fields that weren't supplied. */
+export function createErrorEnvelope(
+  input: CreateErrorEnvelopeInput
+): ErrorEnvelope {
+  const envelope: ErrorEnvelope = {
+    code: input.code,
+    message: input.message,
+    error: input.message,
+    statusCode: input.statusCode,
+    requestId: input.requestId,
+  };
+
+  if (input.fields) {
+    envelope.fields = input.fields;
+  }
+
+  if (input.stack) {
+    envelope.stack = input.stack;
+  }
+
+  return envelope;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -27,3 +27,6 @@ export {
 } from "./config.js";
 
 export { resolveCorsAllowedOrigins } from "./cors.js";
+
+export type { ErrorEnvelope, CreateErrorEnvelopeInput } from "./errors.js";
+export { createErrorEnvelope } from "./errors.js";

--- a/src/api/middleware/errorHandler.ts
+++ b/src/api/middleware/errorHandler.ts
@@ -9,6 +9,7 @@ import {
   ForbiddenError,
 } from "./errors.js";
 import type { ErrorResponse } from "../../types/errors.js";
+import { createErrorEnvelope } from "../../../packages/shared/src/errors.js";
 import { config } from "../../config.js";
 
 function resolveCode(error: Error, statusCode: number): string {
@@ -72,18 +73,16 @@ export function errorHandler(
     errorMessage = "Internal server error";
   }
 
-  const response: ErrorResponse = {
-    error: errorMessage,
+  const response: ErrorResponse = createErrorEnvelope({
     message: errorMessage,
     code: resolveCode(error, statusCode),
     requestId,
     statusCode,
-  };
-
-  // Add field details for ValidationError
-  if (error instanceof ValidationError && error.fields) {
-    response.fields = error.fields;
-  }
+    fields:
+      error instanceof ValidationError && error.fields
+        ? error.fields
+        : undefined,
+  });
 
   // Send error response
   reply.status(statusCode).send(response);

--- a/src/api/middleware/errors.ts
+++ b/src/api/middleware/errors.ts
@@ -60,3 +60,13 @@ export class ServiceUnavailableError extends AppError {
     super(message, 503, "service_unavailable");
   }
 }
+
+export class MarketNotActiveError extends AppError {
+  constructor(marketId: string, status: string) {
+    super(
+      `Market ${marketId} is ${status.toLowerCase()}, orders cannot be placed`,
+      409,
+      "market_not_active"
+    );
+  }
+}

--- a/src/matching/matching-service.test.ts
+++ b/src/matching/matching-service.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   ValidationError,
   ServiceUnavailableError,
+  MarketNotActiveError,
+  MarketNotFoundError,
 } from "../api/middleware/errors.js";
 
 // Mock dependencies
@@ -258,6 +260,11 @@ describe("MatchingService", () => {
     });
 
     it("placeOrder proceeds normally when the flag is enabled (default)", async () => {
+      mockPrismaClient.market.findUnique.mockResolvedValue({
+        id: "market-1",
+        status: "ACTIVE",
+        deletedAt: null,
+      });
       mockPrismaClient.order.findMany.mockResolvedValue([]);
       mockTx.order.create.mockResolvedValue({
         id: "order-2",
@@ -270,6 +277,80 @@ describe("MatchingService", () => {
         matchingService.placeOrder(orderInput)
       ).resolves.toBeDefined();
       expect(mockTx.order.create).toHaveBeenCalled();
+    });
+  });
+
+  describe("placeOrder market status check (#792)", () => {
+    const orderInput = {
+      marketId: "market-1",
+      userAddress: "GUSER1234567890123456789012345678901234567890123456",
+      side: "BUY" as const,
+      outcome: "YES" as const,
+      price: 0.5,
+      quantity: 10,
+    };
+
+    it("rejects with MarketNotActiveError when the market is CANCELLED", async () => {
+      mockPrismaClient.market.findUnique.mockResolvedValue({
+        id: "market-1",
+        status: "CANCELLED",
+        deletedAt: null,
+      });
+
+      await expect(matchingService.placeOrder(orderInput)).rejects.toThrow(
+        MarketNotActiveError
+      );
+      // Rejected before any book/order state was touched.
+      expect(mockPrismaClient.order.findMany).not.toHaveBeenCalled();
+      expect(mockPrismaClient.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("rejects with MarketNotActiveError when the market is RESOLVED", async () => {
+      mockPrismaClient.market.findUnique.mockResolvedValue({
+        id: "market-1",
+        status: "RESOLVED",
+        deletedAt: null,
+      });
+
+      await expect(matchingService.placeOrder(orderInput)).rejects.toThrow(
+        MarketNotActiveError
+      );
+    });
+
+    it("uses a stable error code regardless of the rejection reason", async () => {
+      mockPrismaClient.market.findUnique.mockResolvedValue({
+        id: "market-1",
+        status: "CANCELLED",
+        deletedAt: null,
+      });
+
+      const error = await matchingService
+        .placeOrder(orderInput)
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(MarketNotActiveError);
+      expect(error.code).toBe("market_not_active");
+      expect(error.statusCode).toBe(409);
+    });
+
+    it("rejects with MarketNotFoundError when the market does not exist", async () => {
+      mockPrismaClient.market.findUnique.mockResolvedValue(null);
+
+      await expect(matchingService.placeOrder(orderInput)).rejects.toThrow(
+        MarketNotFoundError
+      );
+    });
+
+    it("rejects with MarketNotFoundError when the market is soft-deleted", async () => {
+      mockPrismaClient.market.findUnique.mockResolvedValue({
+        id: "market-1",
+        status: "ACTIVE",
+        deletedAt: new Date(),
+      });
+
+      await expect(matchingService.placeOrder(orderInput)).rejects.toThrow(
+        MarketNotFoundError
+      );
     });
   });
 

--- a/src/matching/matching-service.ts
+++ b/src/matching/matching-service.ts
@@ -16,6 +16,8 @@ import { getPrismaClient } from "../services/prisma.js";
 import {
   ValidationError,
   ServiceUnavailableError,
+  MarketNotFoundError,
+  MarketNotActiveError,
 } from "../api/middleware/errors.js";
 import { orderbookHydratedMarketsGauge } from "../services/metrics.js";
 
@@ -281,6 +283,11 @@ class MatchingService {
    * Rejects with 503 when the matching engine is disabled via
    * MATCHING_ENGINE_ENABLED=false (#744). Order cancellation is unaffected —
    * users can still withdraw resting orders while matching is paused.
+   *
+   * Re-checks market status inside the per-book mutex (#792), even though
+   * routes already call assertValidOrder before this. A market can flip to
+   * CANCELLED/RESOLVED while an order is queued behind the mutex, so the
+   * service itself must reject rather than trust the pre-check.
    */
   async placeOrder(input: OrderInput): Promise<PlaceOrderResult> {
     if (!isMatchingEngineEnabled()) {
@@ -291,6 +298,19 @@ class MatchingService {
 
     return this.getOrCreateMutex(bookKey).run(async () => {
       const prisma = getPrismaClient();
+
+      const market = await prisma.market.findUnique({
+        where: { id: input.marketId },
+      });
+
+      if (!market || market.deletedAt !== null) {
+        throw new MarketNotFoundError(input.marketId);
+      }
+
+      if (market.status !== "ACTIVE") {
+        throw new MarketNotActiveError(input.marketId, market.status);
+      }
+
       const book = await this.getOrHydrateBook(input.marketId, input.outcome);
 
       // Self-trade check

--- a/src/matching/orderbook.test.ts
+++ b/src/matching/orderbook.test.ts
@@ -412,6 +412,29 @@ describe("OrderBook", () => {
       expect(snap.asks[1].quantity).toBe(150);
     });
 
+    it("should reflect the resting remainder in a snapshot after a partial fill (#791)", () => {
+      orderBook.addOrder(createOrder("maker-1", "ask", 50, 100, 1000));
+
+      // Simulate a partial fill: taker only takes 40 of the 100 resting quantity,
+      // leaving 60 resting on the book at the same price level.
+      const filled = 40;
+      const updated = orderBook.updateOrderQuantity("maker-1", 100 - filled);
+
+      expect(updated).toBe(true);
+      expect(orderBook.getOrderCount()).toBe(1);
+
+      const resting = orderBook.getOrdersAtPrice("ask", 50);
+      expect(resting.length).toBe(1);
+      expect(resting[0].id).toBe("maker-1");
+      expect(resting[0].quantity).toBe(60);
+
+      const snap = orderBook.snapshot();
+      expect(snap.orderCount).toBe(1);
+      expect(snap.asks.length).toBe(1);
+      expect(snap.asks[0].price).toBe(50);
+      expect(snap.asks[0].quantity).toBe(60);
+    });
+
     it("should iterate orders in price-time priority", () => {
       orderBook.addOrder(createOrder("1", "bid", 55, 100, 1000));
       orderBook.addOrder(createOrder("2", "bid", 50, 100, 2000));

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,10 +1,4 @@
-// Error response format
+// Error response format — re-exports the shared envelope (#793) so API
+// consumers keep importing from `../types/errors.js` unchanged.
 
-export interface ErrorResponse {
-  error: string;
-  code: string;
-  message: string;
-  requestId: string;
-  statusCode: number;
-  fields?: Record<string, string>;
-}
+export type { ErrorEnvelope as ErrorResponse } from "../../packages/shared/src/errors.js";


### PR DESCRIPTION
## Summary

- **#791** — Adds an orderbook snapshot test locking partial-fill remainder behavior. `src/matching/orderbook.test.ts` now covers a partial fill via `updateOrderQuantity`, asserting the resting remainder through both `getOrdersAtPrice` and `snapshot()`.
- **#792** — The matching service now re-validates market status itself, inside the per-book mutex, instead of relying solely on the route-level pre-check. Closes a TOCTOU gap where a market could flip to `CANCELLED`/`RESOLVED` while an order was queued. Adds `MarketNotActiveError` (stable `market_not_active` code, 409) alongside the existing `MarketNotFoundError`.
- **#793** — `packages/shared` now exports a typed `ErrorEnvelope` type and `createErrorEnvelope()` helper for the standard API error JSON shape, so it can be reused by the API and indexer. `src/api/middleware/errorHandler.ts` builds responses through the helper; `src/types/errors.ts` re-exports the shared type as `ErrorResponse` for existing consumers. Fixed two docs/code drift issues in `docs/error-handler.md` (`metadata` → `fields`, example `code` casing) so the documented sample matches actual output.
- **#794** — No code gap found: `src/env.ts` and `packages/shared/src/config.ts` already enforce `NODE_ENV` as a closed enum (`development | test | production`) and already have test coverage. Added the missing documentation note to `docs/environment_variables.md` explaining the enum constraint and boot-fail behavior.

## Changes

- `src/matching/orderbook.test.ts` — partial-fill remainder snapshot test
- `src/matching/matching-service.ts` / `.test.ts` — market status guard in `placeOrder`
- `src/api/middleware/errors.ts` — `MarketNotActiveError`
- `packages/shared/src/errors.ts` / `.test.ts` (new) — `ErrorEnvelope`, `createErrorEnvelope()`
- `packages/shared/src/index.ts` — export the new type/helper
- `src/types/errors.ts` — re-export shared `ErrorEnvelope` as `ErrorResponse`
- `src/api/middleware/errorHandler.ts` — use `createErrorEnvelope()`
- `docs/error-handler.md`, `docs/environment_variables.md` — doc fixes/additions

## Test plan

- [x] `orderbook.test.ts`, `matching-service.test.ts`, `errors.test.ts`, `errorHandler.test.ts`, `env.test.ts`, `config.test.ts` all pass
- [x] `tsc --noEmit` shows no new type errors
- [x] Confirmed via `git stash` that pre-existing failures (`positions.test.ts` TS error, `adminGuard.test.ts` missing `DATABASE_URL`, a flaky `stellarAuth.test.ts` signature test) predate this branch and are unrelated

Closes #791
Closes #792
Closes #793
Closes #794
