### PR TITLE
Docs & ops: migration rollback, API versioning, body limit, queue backlog runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@
 - Legacy root aliases such as `/markets`, `/orders`, and
   `/positions/user/:address` return `308` with deprecation headers until
   `2027-01-01T00:00:00Z`, then return `404`.
+- Documented and tested that API versioning is path-based only (no
+  `Accept-Version`/`X-API-Version` header negotiation): requesting an
+  unmounted version prefix (e.g. `/v2/markets`) now has an explicit test
+  asserting a clear `404` JSON error. See `docs/api-versioning.md#unsupported-versions`.

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -36,6 +36,34 @@ Examples:
 
 When the schema of a cached value changes (e.g. new field added to order book), increment the version segment (`orderbook:v2:<marketId>:<outcome>`) rather than performing a `FLUSHDB`.
 
+## Unsupported Versions
+
+Versioning is path-based, not header-based: there is no `Accept-Version` or
+`X-API-Version` request header negotiation. The version is the path prefix
+(`/v1/...`), and only `/v1` is currently mounted.
+
+Requesting any other version prefix (e.g. `/v2/markets`, `/v0/health`) does not
+match a route and falls through to the global 404 handler, which returns a
+clear, structured error rather than an empty or generic response:
+
+```http
+GET /v2/markets
+
+404 Not Found
+Content-Type: application/json
+
+{
+  "error": "Route GET /v2/markets not found",
+  "requestId": "<request-id>",
+  "statusCode": 404
+}
+```
+
+This is covered by the `"returns 404 for unsupported API versions"` case in
+`tests/integration/api-versioning.test.ts`. When a `/v2` (or later) API is
+introduced, add its routes under a new `{ prefix: "/v2" }` scope in
+`src/index.ts` alongside `/v1` — see [Adding a New Version](#adding-a-new-version) below.
+
 ## Adding a New Version
 
 1. Introduce the new route alongside the old one (`/v2/markets` + `/markets` kept for a deprecation window).

--- a/docs/migration-rollback.md
+++ b/docs/migration-rollback.md
@@ -94,6 +94,32 @@ After completing the rollback:
 
 ---
 
+## Recent Migrations
+
+### `20260724074257_add_soft_delete_to_markets`
+
+Adds a nullable `deleted_at TIMESTAMP(3)` column to `markets` plus `markets_deleted_at_idx`.
+
+- **Rollback**: `DROP INDEX IF EXISTS "markets_deleted_at_idx";` then `ALTER TABLE "markets" DROP COLUMN IF EXISTS "deleted_at";`
+- **Caveat**: this migration is additive (the column is nullable, no default required), so it is safely reversible on its own. However, any code deployed after this migration that has started soft-deleting rows (setting `deleted_at`) will lose that soft-delete state if the column is dropped — those rows will look active again. Confirm no application code is relying on `deleted_at` before rolling back, or you will need to re-derive which rows were soft-deleted from application logs/audit tables.
+
+### `20260724080000_add_trades_traded_at_index`
+
+Adds `trades_traded_at_idx` (`DESC`) on `trades.traded_at`.
+
+- **Rollback**: `DROP INDEX IF EXISTS "trades_traded_at_idx";`
+- **Caveat**: purely additive and safe to drop with no data loss. Watch for query-plan regressions on trade-history endpoints that order/filter by `traded_at` — rolling back removes the index they may now depend on.
+
+## Expand/Contract Hazards
+
+Migrations in this repo increasingly follow an **expand/contract** pattern (add the new shape, migrate/dual-write, then drop the old shape in a later migration). This has specific rollback implications:
+
+- **Rolling back an "expand" migration** (e.g. adding a new nullable column or index, such as both migrations above) is generally safe — nothing depended on it yet, or the application can tolerate its absence.
+- **Rolling back a "contract" migration** (one that drops a column, table, or constraint that a previous "expand" step introduced) is **not safely reversible** — the dropped data is gone. Never roll back a contract migration without a pre-migration backup, and treat `pnpm prisma:validate`'s `DROP TABLE`/`DROP COLUMN`/`DROP INDEX` warnings (see [migrations.md](./migrations.md#migration-validation)) as a signal to double-check which phase of an expand/contract pair you're reverting.
+- If a failed deployment spans **both** an expand and a contract migration (e.g. a later migration drops a column added earlier), roll back in reverse order — contract migration first, then expand — and re-verify application compatibility at each step.
+
+---
+
 ## Notes
 
 - Always test rollback procedures in **staging** before a production incident occurs.
@@ -102,4 +128,4 @@ After completing the rollback:
 
 ---
 
-_Linked from: [Deployment Runbook](./deployment-runbook.md)_
+_Linked from: [Deployment Runbook](./deployment-runbook.md) · [Migration Guide](./migrations.md)_

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -251,6 +251,8 @@ Prisma doesn't support automatic rollbacks. Manual rollback process:
 
 3. **Test rollback** thoroughly on staging
 
+For the full step-by-step procedure (pre-checks, backup, resolving the failed migration, post-checks), including current caveats for the soft-delete and trade index migrations and expand/contract rollback hazards, see [Migration Rollback Procedure](./migration-rollback.md).
+
 ## Migration Scripts
 
 The project includes several helpful scripts in `package.json`:

--- a/docs/runbooks/incident-runbook.md
+++ b/docs/runbooks/incident-runbook.md
@@ -17,6 +17,7 @@ This runbook provides step-by-step guidance for responding to common backend inc
 - [Incident 3: Database Incident](#incident-3-database-incident)
 - [Incident 4: Redis Failure](#incident-4-redis-failure)
 - [Incident 5: Oracle Resolution Failure](#incident-5-oracle-resolution-failure)
+- [Incident 6: Queue Backlog (Settlement / Oracle Submission)](#incident-6-queue-backlog-settlement--oracle-submission)
 - [Post-Incident Process](#post-incident-process)
 - [Useful Commands & Queries](#useful-commands--queries)
 - [Contact & Resources](#contact--resources)
@@ -710,6 +711,161 @@ WHERE market_id = '[MARKET_ID]'
 
 ---
 
+## Incident 6: Queue Backlog (Settlement / Oracle Submission)
+
+BullMQ backs both the settlement queue (`apps/workers/src/settlement/`) and
+the oracle submission queue (`apps/workers/src/oracle/`). Queue names and
+`REDIS_KEY_PREFIX` handling live in
+[`apps/workers/src/shared/queue-config.ts`](../../apps/workers/src/shared/queue-config.ts).
+For consumer/retry/dead-letter mechanics see
+[Queue Consumer](../queue-consumer.md) and [Dead Letter Log](../dead-letter-log.md).
+
+Default queue names (BullMQ prefixes every key with `bull:`):
+
+| Queue                | Name (env override)                                        | Example Redis key prefix           |
+| --------------------- | ----------------------------------------------------------- | ----------------------------------- |
+| Settlement            | `${REDIS_KEY_PREFIX}${SETTLEMENT_QUEUE_NAME}` (`vatix:settlement-trades`) | `bull:vatix:settlement-trades:*`   |
+| Oracle submission     | `${SUBMISSION_QUEUE_NAME}` (`oracle-submissions`)            | `bull:oracle-submissions:*`        |
+
+### Symptoms
+
+- Trades matched but not settling on-chain (settlement lag)
+- Oracle reports stuck in `pending`/`submitting` state
+- `waiting`/`delayed` job counts climbing in monitoring
+- Growing `failed` (dead-letter) count in worker logs
+
+### Detection — Redis CLI recipes
+
+Replace `<queue>` with the full queue key prefix from the table above
+(e.g. `vatix:settlement-trades` or `oracle-submissions`).
+
+```bash
+# Jobs waiting to be picked up
+redis-cli -u $REDIS_URL LLEN "bull:<queue>:wait"
+
+# Jobs currently being processed
+redis-cli -u $REDIS_URL LLEN "bull:<queue>:active"
+
+# Jobs awaiting a retry backoff window
+redis-cli -u $REDIS_URL ZCARD "bull:<queue>:delayed"
+
+# Jobs that exhausted all attempts (dead-letter candidates)
+redis-cli -u $REDIS_URL ZCARD "bull:<queue>:failed"
+
+# List the oldest 10 failed job IDs with their failure timestamp (score)
+redis-cli -u $REDIS_URL ZRANGE "bull:<queue>:failed" 0 9 WITHSCORES
+
+# Inspect a specific job's data/error (id from the ZRANGE output above)
+redis-cli -u $REDIS_URL HGETALL "bull:<queue>:<jobId>"
+
+# One-shot summary of all counts for a queue
+for state in wait active delayed failed; do
+  echo -n "$state: "
+  if [ "$state" = "delayed" ] || [ "$state" = "failed" ]; then
+    redis-cli -u $REDIS_URL ZCARD "bull:<queue>:$state"
+  else
+    redis-cli -u $REDIS_URL LLEN "bull:<queue>:$state"
+  fi
+done
+```
+
+Idempotency check for a specific stuck settlement trade
+(see [Queue Consumer § Idempotency](../queue-consumer.md#idempotency)):
+
+```bash
+redis-cli -u $REDIS_URL EXISTS "vatix:settlement:processed:<tradeId>"
+```
+
+### Response Steps
+
+#### Step 1: Confirm backlog scope
+
+Run the detection commands above for both queues. A `wait`/`delayed` count
+that keeps growing over several minutes (not just a momentary spike) means
+consumers aren't keeping up or have stopped.
+
+```bash
+docker ps | grep -E "worker|settlement|oracle"
+docker logs vatix-backend 2>&1 | grep -iE "settlement|oracle-submission" | tail -50
+```
+
+#### Step 2: Identify root cause
+
+- **Worker process down/crashed** — check `docker ps` / process manager for
+  the settlement or oracle submission worker.
+- **Downstream failure** — settlement jobs fail if Postgres or Stellar RPC is
+  unavailable; check Incident 3 and Incident 2 sections.
+- **Poison job** — a single malformed job can repeatedly fail and block
+  `active` if concurrency is low; check its payload via `HGETALL` above.
+
+#### Step 3: Remediation
+
+**A. Restart the affected worker (first attempt)**
+
+```bash
+docker restart vatix-settlement-worker
+# or, if run via pnpm/process manager:
+pm2 restart settlement-worker
+```
+
+**B. Re-run failed jobs once the root cause is fixed**
+
+BullMQ jobs must be retried through the API (not by editing Redis keys
+directly) so retry counters and locks stay consistent:
+
+```bash
+node -e '
+const { Queue } = require("bullmq");
+const q = new Queue("vatix:settlement-trades", { connection: { url: process.env.REDIS_URL } });
+(async () => {
+  const failed = await q.getFailed(0, 50);
+  for (const job of failed) await job.retry();
+  console.log(`retried ${failed.length} jobs`);
+  await q.close();
+})();
+'
+```
+
+**C. Escalate to manual settlement (last resort)**
+
+If the backlog is blocking trade settlement past the SEV threshold, follow
+the manual resolution pattern in
+[Incident 5, Step 2](#step-2-manual-resolution-if-automated-fails) with the
+relevant trade/order IDs, and log the intervention in `audit_log`.
+
+#### Step 4: Verify recovery
+
+```bash
+redis-cli -u $REDIS_URL LLEN "bull:vatix:settlement-trades:wait"
+redis-cli -u $REDIS_URL ZCARD "bull:vatix:settlement-trades:failed"
+```
+
+Counts should trend back to baseline (near zero `wait`, no growth in
+`failed`) within a few minutes of the fix.
+
+#### Step 5: Pager / escalation guidance
+
+Use the [Severity Decision Matrix](#severity-decision-matrix) alongside
+these queue-specific triggers:
+
+| Condition                                                     | Severity |
+| --------------------------------------------------------------- | -------- |
+| Settlement `wait` backlog > 5 min of throughput, still growing  | SEV-2    |
+| Oracle submission backlog delaying an active challenge window   | SEV-1    |
+| `failed` count growing but `wait`/`active` stable (isolated bad jobs) | SEV-3    |
+
+Follow the standard [Escalation Procedures](#escalation-procedures) for the
+resulting severity — no separate on-call path for queue incidents.
+
+#### Step 6: Prevention
+
+- [ ] Alert on `wait`/`delayed` count sustained above a threshold for >2 min
+- [ ] Alert on `failed` (dead-letter) count growth — see [Dead Letter Log](../dead-letter-log.md)
+- [ ] Dashboard the counts from the detection commands above (ties to #738)
+- [ ] Ensure worker processes are supervised/auto-restarted on crash
+
+---
+
 ## Post-Incident Process
 
 ### Immediate (Within 24 Hours)
@@ -920,11 +1076,13 @@ docker exec -it vatix-postgres psql -U postgres -d vatix -c \
 
 ### Documentation Links
 
-- [Testing Guide](./testing.md)
-- [Migration Guide](./migrations.md)
-- [Migration Rollback](./migration-rollback.md)
-- [Rate Limiting](./rate-limiting.md)
-- [Deployment Runbook](./deployment-runbook.md)
+- [Testing Guide](../testing.md)
+- [Migration Guide](../migrations.md)
+- [Migration Rollback](../migration-rollback.md)
+- [Rate Limiting](../rate-limiting.md)
+- [Deployment Runbook](../deployment-runbook.md)
+- [Queue Consumer](../queue-consumer.md)
+- [Dead Letter Log](../dead-letter-log.md)
 
 ---
 

--- a/tests/integration/api-versioning.test.ts
+++ b/tests/integration/api-versioning.test.ts
@@ -183,6 +183,28 @@ describe("Integration Tests: API versioning", () => {
     expect(response.statusCode).toBe(404);
   });
 
+  it("returns 404 for unsupported API versions", async () => {
+    const unsupportedRequests = [
+      { method: "GET", url: "/v2/markets" },
+      { method: "GET", url: "/v2/health" },
+      { method: "GET", url: "/v0/markets" },
+    ] as const;
+
+    for (const request of unsupportedRequests) {
+      const response = await app.inject(request);
+
+      expect(response.statusCode, `${request.method} ${request.url}`).toBe(
+        404
+      );
+      const body = JSON.parse(response.body);
+      expect(body).toEqual({
+        error: `Route ${request.method} ${request.url} not found`,
+        requestId: expect.any(String),
+        statusCode: 404,
+      });
+    }
+  });
+
   it("mounts OpenAPI at /v1/openapi.json with only /v1 path keys", async () => {
     const response = await app.inject({
       method: "GET",

--- a/tests/integration/body-limit.test.ts
+++ b/tests/integration/body-limit.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildServer } from "../../src/index.js";
+
+// Mock prisma so the app boots without a real database — the body-limit
+// check happens at the HTTP layer before any route handler (or Prisma call)
+// runs, so these requests should never reach it.
+vi.mock("../../src/services/prisma.js", () => {
+  return {
+    getPrismaClient: () => ({
+      $queryRaw: async () => {},
+    }),
+  };
+});
+
+describe("Integration: request body size limit (docs/body-limit.md)", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = buildServer({
+      logger: false,
+      registerTestRoutes: false,
+      readyDeps: {
+        checkDatabase: async () => {},
+        checkRedis: async () => {},
+        getLastIndexedAt: async () => Date.now(),
+      },
+    });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("rejects an oversized POST /v1/orders payload with a stable 413", async () => {
+    const oversizedPayload = {
+      marketId: "some-market-id",
+      userAddress: "G" + "A".repeat(55),
+      side: "BUY",
+      outcome: "YES",
+      price: 0.5,
+      quantity: 1,
+      // Pad well past the default 64 KB limit.
+      padding: "x".repeat(100_000),
+    };
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      payload: oversizedPayload,
+    });
+
+    expect(response.statusCode).toBe(413);
+    const body = JSON.parse(response.body);
+    expect(body.statusCode).toBe(413);
+    expect(body.error).toBe("Request body is too large");
+  });
+
+  it("does not reject a normal-sized payload on body size grounds", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      payload: {
+        marketId: "some-market-id",
+        userAddress: "G" + "A".repeat(55),
+        side: "BUY",
+        outcome: "YES",
+        price: 0.5,
+        quantity: 1,
+      },
+    });
+
+    // Missing signature headers, so this fails auth/validation — the point
+    // is that it's never a 413.
+    expect(response.statusCode).not.toBe(413);
+  });
+});


### PR DESCRIPTION
# Docs & ops: migration rollback, API versioning, body limit, queue backlog runbook

## Summary

- Document current rollback steps/caveats for the soft-delete markets and trades `traded_at` index migrations, and add an expand/contract hazards section to `docs/migration-rollback.md`, linked from `docs/migrations.md`.
- Document that API versioning is path-based only (no `Accept-Version`/`X-API-Version` negotiation) and add an integration test asserting unsupported version prefixes (`/v2/*`, `/v0/*`) return a clear `404`.
- Add integration test coverage confirming the global 64 KB request body limit rejects oversized `POST /v1/orders` payloads with a stable `413`, per `docs/body-limit.md`.
- Expand the incident runbook with a new "Queue Backlog" section covering BullMQ/Redis CLI inspection recipes, remediation steps, and pager/severity guidance for the settlement and oracle submission queues, linked to `docs/queue-consumer.md` and `docs/dead-letter-log.md`.

## Test plan

- [ ] `pnpm test:integration -- api-versioning` — unsupported version + existing versioning tests pass
- [ ] `pnpm test:integration -- body-limit` — oversized/normal payload tests pass
- [ ] Review rendered `docs/migration-rollback.md`, `docs/api-versioning.md`, and `docs/runbooks/incident-runbook.md` for formatting/links

Closes #798
Closes #800 
Closes #801 
Closes #802
