### PR TITLE
feat(settlement): transactional position apply with poison-pill quarantine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -233,6 +233,12 @@ SETTLEMENT_CONTRACT_ID=
 # Only required when on-chain settlement is enabled (see SETTLEMENT_CONTRACT_ID).
 STELLAR_SECRET_KEY=
 
+# Optional: Number of permanent (non-retryable) settlement failures for the
+# same tradeId before it is quarantined (trades.settlement_status =
+# QUARANTINED) and skipped on future deliveries. See docs/queue-consumer.md.
+# Default: 1
+SETTLEMENT_QUARANTINE_THRESHOLD=1
+
 # -----------------------------------------------------------------------------
 # Audit streams (Redis)
 # -----------------------------------------------------------------------------

--- a/apps/workers/src/consumers/dead-letter.ts
+++ b/apps/workers/src/consumers/dead-letter.ts
@@ -7,6 +7,10 @@ export interface DeadLetterMessage {
   queue: string;
   payload: unknown;
   reason: string;
+  /** Machine-readable error code (e.g. "STELLAR_TX_BAD_AUTH") classifying the failure, when known (#870). */
+  errorCode?: string;
+  /** Failure classification: "transient" | "fatal" | "invalid_input" (#870). */
+  classification?: string;
 }
 
 const DEAD_LETTER_STREAM_PREFIX = process.env.REDIS_KEY_PREFIX ?? "vatix:";
@@ -88,6 +92,10 @@ export async function logDeadLetter(
       payloadHash,
       "duplicate",
       String(duplicate),
+      "errorCode",
+      message.errorCode ?? "UNKNOWN",
+      "classification",
+      message.classification ?? "unknown",
       "timestamp",
       timestamp
     );
@@ -99,6 +107,8 @@ export async function logDeadLetter(
       payloadType: typeof message.payload,
       payloadHash,
       duplicate,
+      errorCode: message.errorCode,
+      classification: message.classification,
       timestamp,
       persisted: true,
       stream,
@@ -111,6 +121,8 @@ export async function logDeadLetter(
       payloadType: typeof message.payload,
       payloadHash,
       duplicate,
+      errorCode: message.errorCode,
+      classification: message.classification,
       timestamp,
       persisted: false,
       persistenceError: error instanceof Error ? error.message : String(error),

--- a/apps/workers/src/settlement/consumer.ts
+++ b/apps/workers/src/settlement/consumer.ts
@@ -13,10 +13,14 @@ import "dotenv/config";
 import { Worker, type Job } from "bullmq";
 import { redis } from "../../../../src/services/redis.js";
 import { createLogger } from "../../../indexer/src/logger.js";
-import { disconnectPrisma } from "../../../../src/services/prisma.js";
+import {
+  getPrismaClient,
+  disconnectPrisma,
+} from "../../../../src/services/prisma.js";
 import {
   SettlementWorker,
   type SettlementStellarConfig,
+  type SettlementPrismaClient,
 } from "./settlement-worker.js";
 import type { QueueJob } from "../consumers/queue-consumer.js";
 import {
@@ -28,6 +32,11 @@ import { createShutdown } from "../../../../packages/shared/src/shutdown.js";
 const MAX_ATTEMPTS = 3;
 const PROCESSING_TIMEOUT_MS = 30_000;
 const IDEMPOTENCY_TTL_SECONDS = 86_400;
+/** Permanent failures for the same tradeId before it is quarantined (#870). */
+const QUARANTINE_THRESHOLD = (() => {
+  const parsed = Number(process.env.SETTLEMENT_QUARANTINE_THRESHOLD);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+})();
 
 async function bootstrap(): Promise<void> {
   const logLevel = (process.env.LOG_LEVEL ?? "info") as Parameters<
@@ -59,12 +68,18 @@ async function bootstrap(): Promise<void> {
     );
   }
 
-  const settlementWorker = new SettlementWorker(redis, logger, {
-    maxAttempts: MAX_ATTEMPTS,
-    processingTimeoutMs: PROCESSING_TIMEOUT_MS,
-    idempotencyTtlSeconds: IDEMPOTENCY_TTL_SECONDS,
-    stellar,
-  });
+  const settlementWorker = new SettlementWorker(
+    redis,
+    logger,
+    {
+      maxAttempts: MAX_ATTEMPTS,
+      processingTimeoutMs: PROCESSING_TIMEOUT_MS,
+      idempotencyTtlSeconds: IDEMPOTENCY_TTL_SECONDS,
+      stellar,
+      quarantineThreshold: QUARANTINE_THRESHOLD,
+    },
+    getPrismaClient() as unknown as SettlementPrismaClient
+  );
 
   const worker = new Worker<Record<string, unknown>>(
     queueName,

--- a/apps/workers/src/settlement/settlement-worker.test.ts
+++ b/apps/workers/src/settlement/settlement-worker.test.ts
@@ -4,6 +4,8 @@ import {
   type SettlementWorkerConfig,
   type SettlementRedisClient,
   type SettlementStellarConfig,
+  type SettlementPrismaClient,
+  type SettlementTradeRow,
 } from "./settlement-worker.js";
 import type { QueueJob } from "../consumers/queue-consumer.js";
 import type { ILogger } from "../../../../packages/shared/src/logger.js";
@@ -128,8 +130,66 @@ function makeRedisClient(
     exists: vi.fn().mockResolvedValue(false),
     set: vi.fn().mockResolvedValue(undefined),
     setnx: vi.fn().mockResolvedValue(true),
+    del: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
+}
+
+/**
+ * Builds a mock SettlementPrismaClient backed by an in-memory map of trade
+ * rows keyed by tradeId. `$transaction` runs the callback against the same
+ * mock (no real isolation), which is sufficient to exercise the read-then-
+ * write logic in applySettlement/recordPermanentFailure.
+ */
+function makeMockPrisma(
+  seedTrades: Record<string, Partial<SettlementTradeRow>> = {}
+): {
+  prisma: SettlementPrismaClient;
+  trades: Map<string, SettlementTradeRow>;
+} {
+  const trades = new Map<string, SettlementTradeRow>();
+  for (const [tradeId, overrides] of Object.entries(seedTrades)) {
+    trades.set(tradeId, {
+      tradeId,
+      settlementStatus: "PENDING",
+      settlementFailureCount: 0,
+      quarantinedAt: null,
+      ...overrides,
+    });
+  }
+
+  const trade = {
+    findUnique: vi.fn(async ({ where }: { where: { tradeId: string } }) => {
+      return trades.get(where.tradeId) ?? null;
+    }),
+    update: vi.fn(
+      async ({
+        where,
+        data,
+      }: {
+        where: { tradeId: string };
+        data: Record<string, unknown>;
+      }) => {
+        const existing = trades.get(where.tradeId);
+        if (!existing) throw new Error("trade not found");
+        const updated = { ...existing, ...data } as SettlementTradeRow;
+        trades.set(where.tradeId, updated);
+        return updated;
+      }
+    ),
+    count: vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
+      return [...trades.values()].filter((t) =>
+        Object.entries(where).every(([key, value]) => (t as any)[key] === value)
+      ).length;
+    }),
+  };
+
+  const prisma: SettlementPrismaClient = {
+    trade,
+    $transaction: vi.fn(async (fn) => fn(prisma)),
+  };
+
+  return { prisma, trades };
 }
 
 function makeConfig(
@@ -316,7 +376,7 @@ describe("SettlementWorker", () => {
 
     it("does not dead-letter when attempts are below max", async () => {
       redisClient = makeRedisClient({
-        exists: vi.fn().mockRejectedValue(new Error("transient")),
+        setnx: vi.fn().mockRejectedValue(new Error("ECONNRESET: transient")),
       });
       worker = new SettlementWorker(
         redisClient,
@@ -332,6 +392,192 @@ describe("SettlementWorker", () => {
         logger.error as ReturnType<typeof vi.fn>
       ).mock.calls.filter((call) => call[0] === "Job dead-lettered");
       expect(deadLetterCalls).toHaveLength(0);
+    });
+
+    it("releases the idempotency lock so a retryable failure can be redelivered", async () => {
+      redisClient = makeRedisClient({
+        setnx: vi.fn().mockRejectedValue(new Error("ECONNRESET: transient")),
+      });
+      worker = new SettlementWorker(
+        redisClient,
+        logger,
+        makeConfig({ maxAttempts: 3 })
+      );
+
+      const job = makeJob({ attempts: 1 });
+
+      await expect(worker.process(job)).rejects.toThrow();
+
+      expect(redisClient.del).toHaveBeenCalledWith(
+        "settlement:processed:trade-abc-123"
+      );
+    });
+
+    it("fails fast (does not retry) and dead-letters immediately on a permanent error", async () => {
+      redisClient = makeRedisClient({
+        setnx: vi
+          .fn()
+          .mockRejectedValue(new Error("400 Bad Request: bad auth signature")),
+      });
+      worker = new SettlementWorker(
+        redisClient,
+        logger,
+        makeConfig({ maxAttempts: 3 })
+      );
+
+      const job = makeJob({ attempts: 1 });
+
+      await expect(worker.process(job)).rejects.toThrow();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "Job dead-lettered",
+        expect.objectContaining({
+          messageId: job.id,
+          queue: "settlement",
+        })
+      );
+    });
+  });
+
+  describe("process — transactional settlement apply (#870)", () => {
+    it("marks the trade SETTLED in a single Prisma transaction on success", async () => {
+      const { prisma, trades } = makeMockPrisma({
+        "trade-abc-123": { settlementStatus: "PENDING" },
+      });
+      worker = new SettlementWorker(redisClient, logger, makeConfig(), prisma);
+
+      const job = makeJob();
+      await worker.process(job);
+
+      expect(prisma.$transaction).toHaveBeenCalled();
+      const updated = trades.get("trade-abc-123")!;
+      expect(updated.settlementStatus).toBe("SETTLED");
+    });
+
+    it("rolls back and leaves the trade unsettled when the mid-transaction write fails", async () => {
+      const { prisma, trades } = makeMockPrisma({
+        "trade-abc-123": { settlementStatus: "PENDING" },
+      });
+      (prisma.trade.update as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("connection lost mid-write")
+      );
+
+      worker = new SettlementWorker(redisClient, logger, makeConfig(), prisma);
+
+      const job = makeJob();
+      await expect(worker.process(job)).rejects.toThrow(
+        "connection lost mid-write"
+      );
+
+      // No observable half-applied settlement: status is unchanged from PENDING.
+      const unchanged = trades.get("trade-abc-123")!;
+      expect(unchanged.settlementStatus).toBe("PENDING");
+    });
+
+    it("is idempotent when the trade is already SETTLED", async () => {
+      const { prisma, trades } = makeMockPrisma({
+        "trade-abc-123": { settlementStatus: "SETTLED" },
+      });
+      worker = new SettlementWorker(redisClient, logger, makeConfig(), prisma);
+
+      const job = makeJob();
+      await expect(worker.process(job)).resolves.not.toThrow();
+
+      expect(prisma.trade.update).not.toHaveBeenCalled();
+      expect(trades.get("trade-abc-123")!.settlementStatus).toBe("SETTLED");
+    });
+  });
+
+  describe("process — poison-pill quarantine (#870)", () => {
+    it("quarantines a trade after the configured number of permanent failures", async () => {
+      const { prisma, trades } = makeMockPrisma({
+        "trade-abc-123": {
+          settlementStatus: "PENDING",
+          settlementFailureCount: 1,
+        },
+      });
+      redisClient = makeRedisClient({
+        setnx: vi
+          .fn()
+          .mockRejectedValue(new Error("400 Bad Request: bad auth signature")),
+      });
+      worker = new SettlementWorker(
+        redisClient,
+        logger,
+        makeConfig({ quarantineThreshold: 2 }),
+        prisma
+      );
+
+      const job = makeJob();
+      await expect(worker.process(job)).rejects.toThrow();
+
+      const trade = trades.get("trade-abc-123")!;
+      expect(trade.settlementFailureCount).toBe(2);
+      expect(trade.settlementStatus).toBe("QUARANTINED");
+      expect(trade.quarantinedAt).not.toBeNull();
+    });
+
+    it("does not quarantine on a transient failure, only counts permanent ones", async () => {
+      const { prisma, trades } = makeMockPrisma({
+        "trade-abc-123": { settlementStatus: "PENDING" },
+      });
+      redisClient = makeRedisClient({
+        setnx: vi.fn().mockRejectedValue(new Error("ECONNRESET: transient")),
+      });
+      worker = new SettlementWorker(
+        redisClient,
+        logger,
+        makeConfig({ quarantineThreshold: 1 }),
+        prisma
+      );
+
+      const job = makeJob();
+      await expect(worker.process(job)).rejects.toThrow();
+
+      const trade = trades.get("trade-abc-123")!;
+      expect(trade.settlementFailureCount).toBe(0);
+      expect(trade.settlementStatus).toBe("PENDING");
+    });
+
+    it("skips a quarantined trade without touching Redis or Stellar", async () => {
+      const { prisma } = makeMockPrisma({
+        "trade-abc-123": {
+          settlementStatus: "QUARANTINED",
+          quarantinedAt: new Date("2026-01-01T00:00:00Z"),
+        },
+      });
+      worker = new SettlementWorker(redisClient, logger, makeConfig(), prisma);
+
+      const job = makeJob();
+      await expect(worker.process(job)).resolves.not.toThrow();
+
+      expect(redisClient.setnx).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Settlement job skipped (trade quarantined)",
+        expect.objectContaining({ tradeId: "trade-abc-123" })
+      );
+    });
+
+    it("reports quarantine depth via getQuarantineDepth()", async () => {
+      const { prisma } = makeMockPrisma({
+        "trade-1": { settlementStatus: "QUARANTINED" },
+        "trade-2": { settlementStatus: "QUARANTINED" },
+        "trade-3": { settlementStatus: "SETTLED" },
+      });
+      worker = new SettlementWorker(redisClient, logger, makeConfig(), prisma);
+
+      await expect(worker.getQuarantineDepth()).resolves.toBe(2);
+    });
+
+    it("tracks retry classification counts across failures", async () => {
+      redisClient = makeRedisClient({
+        setnx: vi.fn().mockRejectedValue(new Error("ECONNRESET: transient")),
+      });
+      worker = new SettlementWorker(redisClient, logger, makeConfig());
+
+      await expect(worker.process(makeJob())).rejects.toThrow();
+
+      expect(worker.getRetryClassificationCounts().transient).toBe(1);
     });
   });
 });

--- a/apps/workers/src/settlement/settlement-worker.ts
+++ b/apps/workers/src/settlement/settlement-worker.ts
@@ -6,6 +6,7 @@ import {
   rpc as StellarRpc,
   xdr,
 } from "@stellar/stellar-sdk";
+import { UnrecoverableError } from "bullmq";
 import { z } from "zod";
 import type { ILogger } from "../../../../packages/shared/src/logger.js";
 import {
@@ -15,7 +16,13 @@ import {
 } from "../consumers/queue-consumer.js";
 import { logDeadLetter } from "../consumers/dead-letter.js";
 import { withRetry } from "../../../oracle/retry-utils.js";
-import { classifySettlementError, annotateError } from "./error-codes.js";
+import {
+  classifySettlementError,
+  annotateError,
+  isRetryable,
+  type SettlementErrorInfo,
+  type SettlementErrorStatus,
+} from "./error-codes.js";
 
 /** Retry config for individual Stellar RPC calls (getAccount, prepareTransaction,
  *  sendTransaction). Bounded and short-lived so a transient RPC blip is absorbed
@@ -79,6 +86,14 @@ export interface SettlementWorkerConfig {
   processingTimeoutMs: number;
   idempotencyTtlSeconds: number;
   stellar?: SettlementStellarConfig;
+  /**
+   * Number of permanent (non-retryable) failures for the same tradeId before
+   * the trade is quarantined and no longer reprocessed automatically (#870).
+   * Defaults to 1 — a permanent error will not self-heal on retry, so a single
+   * occurrence is generally sufficient, but this stays configurable so
+   * repeated manual replays (via scripts/replay-dlq.ts) are also bounded.
+   */
+  quarantineThreshold?: number;
 }
 
 export interface SettlementStellarConfig {
@@ -96,6 +111,37 @@ export interface SettlementRedisClient {
    * Returns true when the key was set, false when it already existed.
    */
   setnx: (key: string, value: string, ttl?: number) => Promise<boolean>;
+  /** Delete a key. Used to release the idempotency lock after a failed
+   *  attempt so a legitimate retry or replay can reprocess the trade (#870). */
+  del: (key: string) => Promise<void>;
+}
+
+/** Row shape read/written by the settlement worker on the `trades` table. */
+export interface SettlementTradeRow {
+  tradeId: string;
+  settlementStatus: "PENDING" | "SETTLED" | "QUARANTINED";
+  settlementFailureCount: number;
+  quarantinedAt: Date | null;
+}
+
+/**
+ * Minimal Prisma surface the settlement worker needs to apply settlement
+ * mutations transactionally and record poison-pill quarantine state (#870).
+ * Kept narrow (rather than depending on the full generated PrismaClient type)
+ * so unit tests can inject a lightweight mock, mirroring SettlementRedisClient.
+ */
+export interface SettlementPrismaClient {
+  trade: {
+    findUnique(args: {
+      where: { tradeId: string };
+    }): Promise<SettlementTradeRow | null>;
+    update(args: {
+      where: { tradeId: string };
+      data: Record<string, unknown>;
+    }): Promise<unknown>;
+    count(args: { where: Record<string, unknown> }): Promise<number>;
+  };
+  $transaction<T>(fn: (tx: SettlementPrismaClient) => Promise<T>): Promise<T>;
 }
 
 export class SettlementWorker {
@@ -104,21 +150,49 @@ export class SettlementWorker {
   private readonly logger: ILogger;
   private readonly redisClient: SettlementRedisClient;
   private readonly stellarConfig?: SettlementStellarConfig;
+  private readonly prisma?: SettlementPrismaClient;
+  private readonly quarantineThreshold: number;
+  private readonly retryClassificationCounts: Record<
+    SettlementErrorStatus,
+    number
+  > = {
+    transient: 0,
+    fatal: 0,
+    invalid_input: 0,
+  };
 
   constructor(
     redisClient: SettlementRedisClient,
     logger: ILogger,
-    config: SettlementWorkerConfig
+    config: SettlementWorkerConfig,
+    prisma?: SettlementPrismaClient
   ) {
     this.redisClient = redisClient;
     this.logger = logger;
     this.idempotencyTtlSeconds = config.idempotencyTtlSeconds;
     this.stellarConfig = config.stellar;
+    this.prisma = prisma;
+    this.quarantineThreshold = config.quarantineThreshold ?? 1;
     this.consumerConfig = {
       queueName: "settlement",
       maxAttempts: config.maxAttempts,
       processingTimeoutMs: config.processingTimeoutMs,
     };
+  }
+
+  /** Snapshot of failures classified so far, grouped by retry disposition (#870). */
+  getRetryClassificationCounts(): Readonly<
+    Record<SettlementErrorStatus, number>
+  > {
+    return { ...this.retryClassificationCounts };
+  }
+
+  /** Count of trades currently held in quarantine, for operator dashboards (#870). */
+  async getQuarantineDepth(): Promise<number> {
+    if (!this.prisma) return 0;
+    return this.prisma.trade.count({
+      where: { settlementStatus: "QUARANTINED" },
+    });
   }
 
   async process(job: QueueJob): Promise<void> {
@@ -127,12 +201,16 @@ export class SettlementWorker {
         this.handleJob(j)
       );
     } catch (error) {
+      const tradeId = this.extractTradeId(job);
       const errorInfo = classifySettlementError(error);
       const annotated = annotateError(error, errorInfo);
+      const permanent = !isRetryable(errorInfo);
+
+      this.retryClassificationCounts[errorInfo.status]++;
 
       this.logger.info("Settlement job error classified", {
         jobId: job.id,
-        tradeId: (job.payload as Record<string, unknown>)?.tradeId,
+        tradeId,
         errorCode: errorInfo.code,
         errorStatus: errorInfo.status,
         reason: errorInfo.message,
@@ -140,14 +218,52 @@ export class SettlementWorker {
         maxAttempts: this.consumerConfig.maxAttempts,
       });
 
-      if (job.attempts >= this.consumerConfig.maxAttempts) {
+      // Release the idempotency lock so a legitimate retry (BullMQ redelivery)
+      // or a manual replay (scripts/replay-dlq.ts) can actually reprocess the
+      // trade instead of silently no-op'ing as "already processed" — the lock
+      // is only meant to mark completed work, not in-flight attempts (#870).
+      if (tradeId) {
+        await this.releaseIdempotencyLock(tradeId);
+      }
+
+      let quarantined = false;
+      if (tradeId && permanent) {
+        quarantined = await this.recordPermanentFailure(tradeId, errorInfo);
+      }
+
+      // Permanent errors are dead-lettered on first occurrence (they will not
+      // self-heal on retry); transient errors only once retries are exhausted.
+      if (permanent || job.attempts >= this.consumerConfig.maxAttempts) {
         await logDeadLetter(this.logger, {
           id: job.id,
           queue: this.consumerConfig.queueName,
           payload: job.payload,
           reason: errorInfo.message,
+          errorCode: errorInfo.code,
+          classification: errorInfo.status,
         });
       }
+
+      if (permanent) {
+        this.logger.warn("Settlement job failed permanently, not retrying", {
+          jobId: job.id,
+          tradeId,
+          errorCode: errorInfo.code,
+          quarantined,
+        });
+        // UnrecoverableError tells BullMQ to stop retrying immediately,
+        // regardless of `attempts`, so a poison pill fails fast instead of
+        // occupying the single processing slot through the full backoff
+        // schedule and delaying unrelated jobs behind it (#870).
+        const unrecoverable = new UnrecoverableError(annotated.message);
+        Object.assign(unrecoverable, {
+          settlementErrorCode: errorInfo.code,
+          settlementErrorStatus: errorInfo.status,
+          settlementErrorRetryable: false,
+        });
+        throw unrecoverable;
+      }
+
       throw annotated;
     }
   }
@@ -166,6 +282,24 @@ export class SettlementWorker {
 
     const payload = parseResult.data as SettlementJobPayload;
     const { tradeId } = payload;
+
+    // Poison-pill quarantine gate (#870): a previously quarantined trade is
+    // held aside for manual review — skip it without re-running Stellar RPC
+    // calls or blocking the (single-concurrency) worker on newer jobs for
+    // other trades/markets.
+    if (this.prisma) {
+      const existing = await this.prisma.trade.findUnique({
+        where: { tradeId },
+      });
+      if (existing?.settlementStatus === "QUARANTINED") {
+        this.logger.warn("Settlement job skipped (trade quarantined)", {
+          tradeId,
+          jobId: job.id,
+          quarantinedAt: existing.quarantinedAt,
+        });
+        return;
+      }
+    }
 
     const idempotencyKey = `settlement:processed:${tradeId}`;
 
@@ -194,8 +328,9 @@ export class SettlementWorker {
       quantity: payload.quantity,
     });
 
+    let txHash: string | null = null;
     if (this.stellarConfig) {
-      await this.executeOnChain(payload);
+      txHash = await this.executeOnChain(payload);
     } else {
       this.logger.warn(
         "No Stellar config provided — settlement recorded off-chain only",
@@ -203,13 +338,122 @@ export class SettlementWorker {
       );
     }
 
+    // Apply the settlement outcome for this tradeId atomically (#870). A
+    // failure here rolls back the whole transaction — no observable
+    // half-applied settlement — and re-throws so the job is retried/
+    // classified by the normal error path in process().
+    await this.applySettlement(tradeId, txHash);
+
     this.logger.info("Settlement job completed", {
       tradeId,
       marketId: payload.marketId,
     });
   }
 
-  private async executeOnChain(payload: SettlementJobPayload): Promise<void> {
+  /**
+   * Atomically applies the settlement outcome for a tradeId (#870). Reads the
+   * trade row and writes its terminal settlement state as a single Prisma
+   * transaction so a mid-transaction failure leaves no partial update.
+   * A no-op (transactionally safe) when no Prisma client was configured, so
+   * callers that only need on-chain settlement continue to work unchanged.
+   */
+  private async applySettlement(
+    tradeId: string,
+    txHash: string | null
+  ): Promise<void> {
+    if (!this.prisma) return;
+
+    await this.prisma.$transaction(async (tx) => {
+      const existing = await tx.trade.findUnique({ where: { tradeId } });
+
+      if (!existing) {
+        this.logger.warn("Settlement apply skipped — trade row not found", {
+          tradeId,
+        });
+        return;
+      }
+
+      if (existing.settlementStatus === "SETTLED") {
+        // Already applied by a prior attempt (e.g. process crashed after
+        // commit but before the job was acknowledged) — idempotent no-op.
+        return;
+      }
+
+      await tx.trade.update({
+        where: { tradeId },
+        data: {
+          settlementStatus: "SETTLED",
+          settledAt: new Date(),
+          settlementTxHash: txHash,
+          settlementErrorCode: null,
+          settlementFailureCount: 0,
+          quarantinedAt: null,
+        },
+      });
+    });
+  }
+
+  /**
+   * Records a permanent (non-retryable) failure against the trade row and
+   * quarantines it once `quarantineThreshold` such failures have accumulated
+   * (#870). Runs as a single Prisma transaction (read-then-write) so the
+   * failure count and quarantine flag never diverge under concurrent writers.
+   * Returns whether this call caused the trade to become quarantined.
+   */
+  private async recordPermanentFailure(
+    tradeId: string,
+    errorInfo: SettlementErrorInfo
+  ): Promise<boolean> {
+    if (!this.prisma) return false;
+
+    let quarantined = false;
+
+    await this.prisma.$transaction(async (tx) => {
+      const existing = await tx.trade.findUnique({ where: { tradeId } });
+
+      // Nothing to quarantine — either the trade doesn't exist yet, or it
+      // already settled successfully (this failure was a late/duplicate
+      // delivery racing a successful attempt).
+      if (!existing || existing.settlementStatus === "SETTLED") return;
+
+      const failureCount = existing.settlementFailureCount + 1;
+      quarantined = failureCount >= this.quarantineThreshold;
+
+      await tx.trade.update({
+        where: { tradeId },
+        data: {
+          settlementFailureCount: failureCount,
+          settlementErrorCode: errorInfo.code,
+          settlementStatus: quarantined
+            ? "QUARANTINED"
+            : existing.settlementStatus,
+          quarantinedAt: quarantined ? new Date() : existing.quarantinedAt,
+        },
+      });
+    });
+
+    return quarantined;
+  }
+
+  /** Best-effort release of the idempotency lock; never throws (#870). */
+  private async releaseIdempotencyLock(tradeId: string): Promise<void> {
+    try {
+      await this.redisClient.del(`settlement:processed:${tradeId}`);
+    } catch (error) {
+      this.logger.warn("Failed to release settlement idempotency lock", {
+        tradeId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /** Safely extracts tradeId from a job payload of unknown shape. */
+  private extractTradeId(job: QueueJob): string | undefined {
+    const value = (job.payload as Record<string, unknown> | undefined)?.tradeId;
+    return typeof value === "string" ? value : undefined;
+  }
+
+  private async executeOnChain(payload: SettlementJobPayload): Promise<string> {
     const { rpcUrl, contractId, networkPassphrase, signerSecret } =
       this.stellarConfig!;
 
@@ -291,7 +535,7 @@ export class SettlementWorker {
           hash: sendResult.hash,
           ledger: txStatus.ledger,
         });
-        return;
+        return sendResult.hash;
       }
       if (txStatus.status === StellarRpc.Api.GetTransactionStatus.FAILED) {
         throw new Error(

--- a/docs/queue-consumer.md
+++ b/docs/queue-consumer.md
@@ -133,7 +133,42 @@ The settlement worker (`apps/workers/src/settlement/`) consumes the Redis settle
 
 ### Idempotency
 
-Before processing, the worker checks `settlement:processed:{tradeId}` in Redis. If the key exists the job is acknowledged and skipped. On successful processing the key is written with a 24-hour TTL so duplicate deliveries are silently discarded.
+Before processing, the worker atomically claims `settlement:processed:{tradeId}` in Redis via `SETNX`. If the key already exists the job is acknowledged and skipped. The lock is only meant to mark a _fully completed_ job — if the handler throws for any reason (transient RPC error, mid-transaction DB failure, permanent validation error), the lock is released (`DEL`) as part of error handling in `SettlementWorker.process()` before the error is re-thrown. This guarantees a legitimate retry (BullMQ redelivery) or a manual replay (`scripts/replay-dlq.ts`) actually reprocesses the trade instead of silently no-op'ing as "already processed" (#870).
+
+### Transactional Settlement Apply (#870)
+
+Once on-chain settlement succeeds (or immediately, if no Stellar config is present), the worker applies the terminal settlement state for that `tradeId` — `settlementStatus`, `settledAt`, `settlementTxHash` on the `trades` row — as a single Prisma transaction (`SettlementWorker.applySettlement`). The transaction reads the current row and writes the new state together; if the write fails partway through, the transaction rolls back and nothing is observably half-applied. The apply is idempotent: a trade already `SETTLED` is a no-op on redelivery.
+
+### Error Classification → Retry / Quarantine (#870)
+
+Every thrown error is classified via `classifySettlementError()` (`apps/workers/src/settlement/error-codes.ts`) into `transient`, `fatal`, or `invalid_input`. Only `transient` errors are retried by BullMQ's own backoff (`DEFAULT_JOB_OPTIONS`, 3 attempts). A `fatal` or `invalid_input` classification is **permanent**:
+
+- The job is dead-lettered immediately (not only after `maxAttempts`).
+- The worker throws a BullMQ `UnrecoverableError`, so the queue stops retrying immediately instead of burning the full backoff schedule on a message that cannot self-heal — this keeps a single poison job from occupying the worker's processing slot and delaying unrelated trades/markets behind it.
+- The trade's `settlementFailureCount` is incremented; once it reaches `quarantineThreshold` (default `1`, configurable via `SETTLEMENT_QUARANTINE_THRESHOLD`), the trade is marked `QUARANTINED` with `quarantinedAt` and `settlementErrorCode` set.
+
+A `QUARANTINED` trade is skipped on any future delivery (checked before the idempotency lock and before any Stellar RPC call) — quarantine is scoped to that one `tradeId`, so it never blocks jobs for other trades or markets.
+
+### Inspecting and Replaying Quarantined Trades
+
+Quarantined trades are queryable directly:
+
+```sql
+SELECT trade_id, market_id, settlement_status, settlement_error_code,
+       settlement_failure_count, quarantined_at
+FROM trades
+WHERE settlement_status = 'QUARANTINED'
+ORDER BY quarantined_at DESC;
+```
+
+The dead-letter entry for the same failure (Redis stream `{prefix}dead-letter:settlement`) carries the same `errorCode`/`classification` plus the original payload, for full context on why the trade was quarantined.
+
+To safely replay after fixing the root cause (e.g. correcting a bad payload upstream, restoring Stellar account funding):
+
+1. Confirm the underlying cause is resolved (check `settlement_error_code`).
+2. Reset the row so the worker will process it again: `UPDATE trades SET settlement_status = 'PENDING', settlement_failure_count = 0, quarantined_at = NULL WHERE trade_id = '<tradeId>';`
+3. Replay the dead-lettered job: `pnpm tsx scripts/replay-dlq.ts --queue settlement --dry-run` first to preview, then without `--dry-run` to re-enqueue.
+4. Since quarantine re-triggers after `quarantineThreshold` permanent failures, a replay that hits the same root cause will quarantine again — treat repeated quarantine of the same `tradeId` as a signal to escalate rather than keep replaying.
 
 ### Flow
 
@@ -143,19 +178,25 @@ MatchingService.placeOrder()
     └─ settlementQueue.enqueue(job)   ← fire-and-forget
            │
            ▼
-      Redis Stream (SETTLEMENT_QUEUE_NAME)
+      BullMQ queue (SETTLEMENT_QUEUE_NAME)
            │
            ▼
-      settlement consumer (XREADGROUP)
+      settlement consumer (BullMQ Worker)
            │
-           ├─ idempotency check (EXISTS settlement:processed:{tradeId})
+           ├─ quarantine check (trades.settlementStatus === QUARANTINED)
+           │       └─ quarantined → skip, ACK
+           │
+           ├─ idempotency check (SETNX settlement:processed:{tradeId})
            │       └─ already processed → ACK, skip
            │
            └─ processJob() → handler
-                   ├─ success → SET idempotency key → ACK
-                   └─ error
-                         ├─ attempts < maxAttempts → warn, leave PENDING
-                         └─ attempts >= maxAttempts → logDeadLetter(), ACK
+                   ├─ success → applySettlement() [Prisma tx] → ACK
+                   └─ error → classify (transient | fatal | invalid_input)
+                         ├─ transient, attempts < maxAttempts → release lock, warn, retry
+                         ├─ transient, attempts >= maxAttempts → release lock, logDeadLetter(), ACK
+                         └─ fatal | invalid_input (permanent) → release lock,
+                            recordPermanentFailure() [Prisma tx, may quarantine],
+                            logDeadLetter(), throw UnrecoverableError → ACK (no further retries)
 ```
 
 ## Related Documentation

--- a/prisma/migrations/20260729150000_add_trade_settlement_status/migration.sql
+++ b/prisma/migrations/20260729150000_add_trade_settlement_status/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "SettlementStatus" AS ENUM ('PENDING', 'SETTLED', 'QUARANTINED');
+
+-- AlterTable
+ALTER TABLE "trades"
+  ADD COLUMN "settlement_status" "SettlementStatus" NOT NULL DEFAULT 'PENDING',
+  ADD COLUMN "settled_at" TIMESTAMP(3),
+  ADD COLUMN "settlement_tx_hash" VARCHAR(64),
+  ADD COLUMN "settlement_error_code" VARCHAR(64),
+  ADD COLUMN "settlement_failure_count" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "quarantined_at" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "trades_settlement_status_idx" ON "trades"("settlement_status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,15 @@ enum OracleReportStatus {
   FAILED
 }
 
+/// Lifecycle of a trade's on-chain settlement apply (#870).
+/// PENDING: not yet settled. SETTLED: settle_trade confirmed and applied.
+/// QUARANTINED: exhausted permanent-failure threshold; held for manual replay.
+enum SettlementStatus {
+  PENDING
+  SETTLED
+  QUARANTINED
+}
+
 model Market {
   id             String       @id @default(uuid())
   question       String
@@ -259,12 +268,21 @@ model Trade {
   tradedAt      DateTime @map("traded_at")
   createdAt     DateTime @default(now()) @map("created_at")
 
+  /// Settlement consumer apply state (#870) — set by apps/workers/src/settlement.
+  settlementStatus       SettlementStatus @default(PENDING) @map("settlement_status")
+  settledAt              DateTime?        @map("settled_at")
+  settlementTxHash       String?          @map("settlement_tx_hash") @db.VarChar(64)
+  settlementErrorCode    String?          @map("settlement_error_code") @db.VarChar(64)
+  settlementFailureCount Int              @default(0) @map("settlement_failure_count")
+  quarantinedAt          DateTime?        @map("quarantined_at")
+
   @@index([marketId])
   @@index([buyerAddress])
   @@index([sellerAddress])
   @@index([buyerAddress, tradedAt(sort: Desc)])
   @@index([sellerAddress, tradedAt(sort: Desc)])
   @@index([tradedAt(sort: Desc)])
+  @@index([settlementStatus])
   @@map("trades")
 }
 


### PR DESCRIPTION
## Summary

Closes #870

Guarantees each settlement job applies its trade's terminal settlement state as a single DB transaction, classifies failures as retryable vs permanent, and quarantines poison-pill trades out of the hot path with operator-visible DLQ metadata.

- **Transactional apply**: `SettlementWorker.applySettlement()` writes `settlementStatus`/`settledAt`/`settlementTxHash` for a `tradeId` as a single Prisma transaction (read-then-write). A mid-transaction failure rolls back entirely — no half-applied settlement — and the job is retried through the normal error path.
- **Error classification → retry / DLQ / quarantine**: reuses the existing `classifySettlementError` (transient / fatal / invalid_input). Permanent errors are dead-lettered immediately and thrown as a BullMQ `UnrecoverableError`, so a poison job fails fast instead of occupying the worker's single processing slot through the full backoff schedule and delaying unrelated trades/markets behind it.
- **Poison-pill quarantine**: permanent failures increment `trades.settlementFailureCount`; once it reaches `quarantineThreshold` (default `1`, configurable via `SETTLEMENT_QUARANTINE_THRESHOLD`) the trade is marked `QUARANTINED` with `quarantinedAt` + `settlementErrorCode`. A quarantined trade is skipped on any future delivery before touching Redis or Stellar — scoped to that one `tradeId`, so it never blocks other trades/markets.
- **Idempotency fix**: the Redis "processed" lock was previously claimed (`SETNX`) before work started but never released on failure, so a job that failed after claiming the lock would be silently skipped on every subsequent retry instead of actually reprocessing. The lock is now released on any failure path.
- **DLQ metadata**: `DeadLetterMessage` now carries `errorCode`/`classification` so DLQ entries are queryable by failure class, not just a free-text reason.
- **Metrics**: added `getRetryClassificationCounts()` and `getQuarantineDepth()` on the worker for quarantine-depth and retry-classification observability.
- **Schema**: added `SettlementStatus` enum and `settlementStatus`/`settledAt`/`settlementTxHash`/`settlementErrorCode`/`settlementFailureCount`/`quarantinedAt` columns + index on `trades`, with migration `20260729150000_add_trade_settlement_status`.
- **Docs**: `docs/queue-consumer.md` documents the transactional apply, the error-classification → retry/quarantine mapping, and a runbook for inspecting/replaying quarantined trades via `scripts/replay-dlq.ts`.

## Testing/validation performed

- `pnpm prisma:generate` / `pnpm prisma:deploy` against a local Postgres — new migration applies cleanly.
- `pnpm test:run` (unit) and `pnpm test:integration` — no new failures vs. a clean `dev` checkout (verified by diffing results against the unmodified branch); settlement/consumer suite: 73/73 passing, including new coverage for mid-tx rollback, permanent-failure quarantine after N occurrences, transient-failure lock release/redelivery, and quarantine skip-without-Stellar-call.
- `pnpm tsc --noEmit` (root, apps, packages) — no new errors introduced (two pre-existing, unrelated failures on `dev` HEAD were confirmed present before this change too: `apps/indexer/src/eventFetcher.ts` and `src/api/routes/positions.test.ts`).
- `pnpm format:check` — matches the pre-existing baseline exactly (no new formatting issues).
- Pre-commit hook (`lint-staged`: prettier + `tsc-files --noEmit` + `prisma validate`) passed.

## Link to issue

https://github.com/Vatix-Protocol/vatix-backend/issues/870

## Risks / follow-ups

- Two CI-relevant checks (`pnpm prisma:validate`'s migration/schema diff, due to a pre-existing `trades.outcome` type mismatch between `schema.prisma` and its migration; and the two pre-existing `tsc` errors above) already fail on `dev` HEAD independent of this PR — confirmed by testing against an unmodified checkout. This PR does not touch those areas per scope (settlement consumer only) and introduces no new drift.
- `quarantineThreshold` defaults to `1` (a permanent error is assumed non-self-healing). If a noisier default is preferred operationally, it's configurable via `SETTLEMENT_QUARANTINE_THRESHOLD` without code changes.