### PR TITLE
feat(matching): serializable cancel-vs-match race integrity for orders

### DIFF
--- a/prisma/migrations/20260729160000_add_order_version/migration.sql
+++ b/prisma/migrations/20260729160000_add_order_version/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "orders" ADD COLUMN "version" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,6 +103,10 @@ model Order {
   quantity       Int
   filledQuantity Int         @default(0) @map("filled_quantity")
   status         OrderStatus @default(OPEN)
+  /// Optimistic-concurrency counter (#866). Every status/filledQuantity write
+  /// increments this; writers condition their UPDATE on the version they
+  /// read so a cancel racing a match (or vice versa) can never both "win".
+  version        Int         @default(0)
   createdAt      DateTime    @default(now()) @map("created_at")
 
   market Market @relation(fields: [marketId], references: [id], onDelete: Cascade)

--- a/src/api/middleware/errors.ts
+++ b/src/api/middleware/errors.ts
@@ -60,3 +60,15 @@ export class ServiceUnavailableError extends AppError {
     super(message, 503, "service_unavailable");
   }
 }
+
+/**
+ * Thrown when an order's optimistic-concurrency version (or terminal status)
+ * no longer matches what the caller read, because a concurrent cancel or
+ * match already applied a conflicting write (#866). Retryable: the caller
+ * should re-fetch current state and retry the operation.
+ */
+export class OrderConflictError extends AppError {
+  constructor(message = "Order was concurrently modified; please retry") {
+    super(message, 409, "order_conflict");
+  }
+}

--- a/src/matching/matching-service.test.ts
+++ b/src/matching/matching-service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   ValidationError,
   ServiceUnavailableError,
+  OrderConflictError,
 } from "../api/middleware/errors.js";
 
 // Mock dependencies
@@ -52,6 +53,7 @@ const mockTx = {
   order: {
     findUnique: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
     create: vi.fn(),
   },
   trade: {
@@ -87,6 +89,7 @@ import {
   matchingService,
   isMatchingEngineEnabled,
 } from "./matching-service.js";
+import { matchOrder } from "./engine.js";
 import { orderbookHydratedMarketsGauge } from "../services/metrics.js";
 
 describe("MatchingService", () => {
@@ -97,6 +100,9 @@ describe("MatchingService", () => {
     mockPrismaClient.$transaction.mockImplementation(
       (cb: (tx: any) => Promise<any>) => cb(mockTx)
     );
+    // Default: conditional updates succeed (one row affected). Individual
+    // tests override this to simulate a version/status conflict.
+    mockTx.order.updateMany.mockResolvedValue({ count: 1 });
   });
 
   describe("cancelOrder", () => {
@@ -111,8 +117,18 @@ describe("MatchingService", () => {
       quantity: 100,
       filledQuantity: 0,
       status: "OPEN",
+      version: 0,
       createdAt: now,
     };
+
+    beforeEach(() => {
+      // Outer (non-transactional) pre-read used to pick the per-book mutex
+      // before entering the transaction (#866).
+      mockPrismaClient.order.findUnique.mockResolvedValue({
+        marketId: sampleOrder.marketId,
+        outcome: sampleOrder.outcome,
+      });
+    });
 
     it("should cancel an OPEN order and release collateral", async () => {
       mockTx.order.findUnique.mockResolvedValue(sampleOrder);
@@ -120,10 +136,6 @@ describe("MatchingService", () => {
         marketId: "market-1",
         userAddress: sampleOrder.userAddress,
         lockedCollateral: "50",
-      });
-      mockTx.order.update.mockResolvedValue({
-        ...sampleOrder,
-        status: "CANCELLED",
       });
 
       const result = await matchingService.cancelOrder(
@@ -135,9 +147,14 @@ describe("MatchingService", () => {
       expect(mockTx.order.findUnique).toHaveBeenCalledWith({
         where: { id: "order-1" },
       });
-      expect(mockTx.order.update).toHaveBeenCalledWith({
-        where: { id: "order-1" },
-        data: { status: "CANCELLED" },
+      // Conditional cancel: guarded on the version/status just read.
+      expect(mockTx.order.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: "order-1",
+          version: 0,
+          status: { in: ["OPEN", "PARTIALLY_FILLED"] },
+        },
+        data: { status: "CANCELLED", version: { increment: 1 } },
       });
       // Collateral should be released: 100 * 0.5 = 50, so locked goes from 50 to 0
       expect(mockTx.userPosition.update).toHaveBeenCalledWith(
@@ -164,14 +181,17 @@ describe("MatchingService", () => {
       await expect(
         matchingService.cancelOrder("order-1", sampleOrder.userAddress)
       ).rejects.toThrow(ValidationError);
+      expect(mockTx.order.updateMany).not.toHaveBeenCalled();
     });
 
     it("should reject cancelling a non-existent order", async () => {
-      mockTx.order.findUnique.mockResolvedValue(null);
+      mockPrismaClient.order.findUnique.mockResolvedValue(null);
 
       await expect(
         matchingService.cancelOrder("nonexistent", sampleOrder.userAddress)
       ).rejects.toThrow(ValidationError);
+      // Rejected before ever entering the mutex/transaction.
+      expect(mockPrismaClient.$transaction).not.toHaveBeenCalled();
     });
 
     it("should reject cancelling another user's order", async () => {
@@ -183,6 +203,7 @@ describe("MatchingService", () => {
           "GOTHER1234567890123456789012345678901234567890123456"
         )
       ).rejects.toThrow(ValidationError);
+      expect(mockTx.order.updateMany).not.toHaveBeenCalled();
     });
 
     it("should cancel a PARTIALLY_FILLED order and release remaining collateral", async () => {
@@ -198,10 +219,6 @@ describe("MatchingService", () => {
         userAddress: sampleOrder.userAddress,
         lockedCollateral: "35",
       });
-      mockTx.order.update.mockResolvedValue({
-        ...partiallyFilled,
-        status: "CANCELLED",
-      });
 
       const result = await matchingService.cancelOrder(
         "order-1",
@@ -215,6 +232,60 @@ describe("MatchingService", () => {
           data: expect.objectContaining({
             lockedCollateral: 0,
           }),
+        })
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // Optimistic-concurrency conflict path (#866)
+    // -----------------------------------------------------------------------
+
+    it("throws OrderConflictError when the order version no longer matches (already filled/cancelled concurrently)", async () => {
+      mockTx.order.findUnique.mockResolvedValue(sampleOrder);
+      // Simulate a concurrent writer (fill or cancel) winning the race: the
+      // conditional UPDATE affects zero rows.
+      mockTx.order.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        matchingService.cancelOrder("order-1", sampleOrder.userAddress)
+      ).rejects.toThrow(OrderConflictError);
+
+      // No collateral should be released for a cancel that didn't apply.
+      expect(mockTx.userPosition.update).not.toHaveBeenCalled();
+    });
+
+    it("invalidates the in-memory book on a version conflict", async () => {
+      mockTx.order.findUnique.mockResolvedValue(sampleOrder);
+      mockTx.order.updateMany.mockResolvedValue({ count: 0 });
+
+      const books: Map<string, unknown> = (matchingService as any).books;
+      books.set(`${sampleOrder.marketId}:${sampleOrder.outcome}`, {
+        removeOrder: vi.fn(),
+      });
+
+      await expect(
+        matchingService.cancelOrder("order-1", sampleOrder.userAddress)
+      ).rejects.toThrow(OrderConflictError);
+
+      expect(books.has(`${sampleOrder.marketId}:${sampleOrder.outcome}`)).toBe(
+        false
+      );
+    });
+
+    it("never releases negative collateral even if lockedCollateral is already below the release amount", async () => {
+      mockTx.order.findUnique.mockResolvedValue(sampleOrder);
+      mockTx.userPosition.findUnique.mockResolvedValue({
+        marketId: "market-1",
+        userAddress: sampleOrder.userAddress,
+        // Less than the 50 that would normally be released for this order.
+        lockedCollateral: "10",
+      });
+
+      await matchingService.cancelOrder("order-1", sampleOrder.userAddress);
+
+      expect(mockTx.userPosition.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ lockedCollateral: 0 }),
         })
       );
     });
@@ -270,6 +341,99 @@ describe("MatchingService", () => {
         matchingService.placeOrder(orderInput)
       ).resolves.toBeDefined();
       expect(mockTx.order.create).toHaveBeenCalled();
+    });
+  });
+
+  describe("placeOrder — maker order conflict (#866)", () => {
+    const orderInput = {
+      marketId: "market-1",
+      userAddress: "GTAKER123456789012345678901234567890123456789012345A",
+      side: "BUY" as const,
+      outcome: "YES" as const,
+      price: 0.5,
+      quantity: 10,
+    };
+
+    const trade = {
+      id: "trade-1",
+      marketId: "market-1",
+      outcome: "YES" as const,
+      buyerAddress: orderInput.userAddress,
+      sellerAddress: "GMAKER123456789012345678901234567890123456789012345A",
+      buyOrderId: "maker-order-1",
+      sellOrderId: "maker-order-1",
+      price: 0.5,
+      quantity: 10,
+      timestamp: Date.now(),
+    };
+
+    beforeEach(() => {
+      mockPrismaClient.order.findMany.mockResolvedValue([]);
+      mockTx.order.create.mockResolvedValue({
+        id: "taker-order-1",
+        ...orderInput,
+        status: "FILLED",
+        filledQuantity: orderInput.quantity,
+      });
+      vi.mocked(matchOrder).mockReturnValueOnce({
+        trades: [trade],
+        remainingOrder: null,
+        positionDeltas: [],
+      });
+    });
+
+    it("rolls back and rejects with OrderConflictError when the maker order is no longer open", async () => {
+      mockTx.order.findUnique.mockResolvedValue({
+        quantity: 10,
+        filledQuantity: 0,
+        status: "CANCELLED",
+        version: 3,
+      });
+
+      await expect(matchingService.placeOrder(orderInput)).rejects.toThrow(
+        OrderConflictError
+      );
+      // Nothing else should have been written once the maker conflict fired.
+      expect(mockTx.trade.upsert).not.toHaveBeenCalled();
+      expect(mockTx.userPosition.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rolls back and rejects with OrderConflictError when the maker's updateMany affects zero rows", async () => {
+      mockTx.order.findUnique.mockResolvedValue({
+        quantity: 10,
+        filledQuantity: 0,
+        status: "OPEN",
+        version: 3,
+      });
+      mockTx.order.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(matchingService.placeOrder(orderInput)).rejects.toThrow(
+        OrderConflictError
+      );
+      expect(mockTx.trade.upsert).not.toHaveBeenCalled();
+    });
+
+    it("invalidates the in-memory book so the next call rehydrates from the DB", async () => {
+      mockTx.order.findUnique.mockResolvedValue({
+        quantity: 10,
+        filledQuantity: 0,
+        status: "OPEN",
+        version: 3,
+      });
+      mockTx.order.updateMany.mockResolvedValue({ count: 0 });
+
+      const books: Map<string, unknown> = (matchingService as any).books;
+      books.set("market-1:YES", {
+        removeOrder: vi.fn(),
+        addOrder: vi.fn(),
+        getOrdersByUser: vi.fn().mockReturnValue([]),
+      });
+
+      await expect(matchingService.placeOrder(orderInput)).rejects.toThrow(
+        OrderConflictError
+      );
+
+      expect(books.has("market-1:YES")).toBe(false);
     });
   });
 

--- a/src/matching/matching-service.ts
+++ b/src/matching/matching-service.ts
@@ -16,6 +16,7 @@ import { getPrismaClient } from "../services/prisma.js";
 import {
   ValidationError,
   ServiceUnavailableError,
+  OrderConflictError,
 } from "../api/middleware/errors.js";
 import { orderbookHydratedMarketsGauge } from "../services/metrics.js";
 
@@ -118,95 +119,154 @@ class MatchingService {
   /**
    * Cancel an open order and release its locked collateral.
    *
+   * Runs under the same per-book mutex as `placeOrder` (#866) so a cancel
+   * can never interleave in-memory with a match for the same book on this
+   * instance. That mutex is a single-instance optimization only — the
+   * authoritative safety net is the version-conditioned UPDATE below: it
+   * conditions on the exact (version, status) this call read, so even a
+   * true concurrent writer (another process, or a match whose in-memory
+   * work raced ahead of its DB commit) can only ever have one of the two
+   * conflicting writes succeed. The loser gets OrderConflictError (409),
+   * a documented, retryable error code.
+   *
    * 1. Validates the order exists, belongs to the caller, and is cancellable.
-   * 2. Removes it from the in-memory order book (if present).
-   * 3. Updates the DB row to CANCELLED status.
-   * 4. Decrements the user's lockedCollateral for that market.
+   * 2. Updates the DB row to CANCELLED status, conditioned on version+status.
+   * 3. Decrements the user's lockedCollateral for that market (remaining
+   *    unfilled quantity only; never below zero).
+   * 4. Removes it from the in-memory order book, only after the DB commit.
    *
    * @returns The cancelled order row.
    */
   async cancelOrder(orderId: string, userAddress: string): Promise<any> {
     const prisma = getPrismaClient();
 
-    return prisma.$transaction(async (tx) => {
-      const order = await tx.order.findUnique({
-        where: { id: orderId },
+    // marketId/outcome are immutable once an order is created, so this
+    // lookup is safe to do before acquiring the per-book mutex — it only
+    // determines *which* mutex to take.
+    const orderRef = await prisma.order.findUnique({
+      where: { id: orderId },
+      select: { marketId: true, outcome: true },
+    });
+
+    if (!orderRef) {
+      throw new ValidationError("Order not found", {
+        orderId: "Order not found",
       });
+    }
 
-      if (!order) {
-        throw new ValidationError("Order not found", {
-          orderId: "Order not found",
-        });
-      }
+    const marketId = orderRef.marketId;
+    const outcome = orderRef.outcome as Outcome;
+    const bookKey = this.getBookKey(marketId, outcome);
 
-      if (order.userAddress !== userAddress) {
-        throw new ValidationError("Order does not belong to this user", {
-          orderId: "Order does not belong to this user",
-        });
-      }
+    return this.getOrCreateMutex(bookKey).run(async () => {
+      let cancelledOrder: any;
 
-      if (order.status !== "OPEN" && order.status !== "PARTIALLY_FILLED") {
-        throw new ValidationError(
-          `Order cannot be cancelled (status: ${order.status.toLowerCase()})`,
-          {
-            orderId: `Order cannot be cancelled (status: ${order.status.toLowerCase()})`,
+      try {
+        cancelledOrder = await prisma.$transaction(async (tx) => {
+          const order = await tx.order.findUnique({
+            where: { id: orderId },
+          });
+
+          if (!order) {
+            throw new ValidationError("Order not found", {
+              orderId: "Order not found",
+            });
           }
-        );
+
+          if (order.userAddress !== userAddress) {
+            throw new ValidationError("Order does not belong to this user", {
+              orderId: "Order does not belong to this user",
+            });
+          }
+
+          if (order.status !== "OPEN" && order.status !== "PARTIALLY_FILLED") {
+            throw new ValidationError(
+              `Order cannot be cancelled (status: ${order.status.toLowerCase()})`,
+              {
+                orderId: `Order cannot be cancelled (status: ${order.status.toLowerCase()})`,
+              }
+            );
+          }
+
+          // Conditional cancel: only applies if the row is still exactly the
+          // version/status we just read. Zero rows affected means a
+          // concurrent writer (fill or cancel) already landed first.
+          const cancelResult = await tx.order.updateMany({
+            where: {
+              id: orderId,
+              version: order.version,
+              status: { in: ["OPEN", "PARTIALLY_FILLED"] },
+            },
+            data: {
+              status: "CANCELLED",
+              version: { increment: 1 },
+            },
+          });
+
+          if (cancelResult.count === 0) {
+            throw new OrderConflictError(
+              "Order was concurrently filled or cancelled; please retry"
+            );
+          }
+
+          // Release locked collateral for the remaining unfilled quantity only.
+          const remainingQty = order.quantity - order.filledQuantity;
+          const collateralPerUnit =
+            order.side === "BUY"
+              ? Number(order.price)
+              : 1 - Number(order.price);
+          const collateralToRelease =
+            Math.round(collateralPerUnit * remainingQty * 1e8) / 1e8;
+
+          if (collateralToRelease > 0) {
+            const position = await tx.userPosition.findUnique({
+              where: {
+                marketId_userAddress: {
+                  marketId: order.marketId,
+                  userAddress,
+                },
+              },
+            });
+
+            if (position) {
+              // Never release more than is actually locked.
+              const newLocked = Math.max(
+                0,
+                Number(position.lockedCollateral) - collateralToRelease
+              );
+              await tx.userPosition.update({
+                where: {
+                  marketId_userAddress: {
+                    marketId: order.marketId,
+                    userAddress,
+                  },
+                },
+                data: {
+                  lockedCollateral: newLocked,
+                },
+              });
+            }
+          }
+
+          return { ...order, status: "CANCELLED", version: order.version + 1 };
+        });
+      } catch (error) {
+        if (error instanceof OrderConflictError) {
+          // Our in-memory book may be stale relative to the write that beat
+          // us (e.g. a fill applied by another instance) — evict it so the
+          // next operation for this book rehydrates fresh from the DB.
+          this.invalidateBook(marketId, outcome);
+        }
+        throw error;
       }
 
-      // 2. Remove from in-memory order book
-      const bookKey = this.getBookKey(order.marketId, order.outcome as Outcome);
+      // Only mutate the in-memory book once the cancel is durably committed.
       const book = this.books.get(bookKey);
       if (book) {
-        const bookSide = order.side === "BUY" ? "bid" : "ask";
         book.removeOrder(orderId);
       }
 
-      // 3. Update DB
-      const remainingQty = order.quantity - order.filledQuantity;
-
-      // 4. Release locked collateral (decrement)
-      const collateralPerUnit =
-        order.side === "BUY" ? Number(order.price) : 1 - Number(order.price);
-      const collateralToRelease =
-        Math.round(collateralPerUnit * remainingQty * 1e8) / 1e8;
-
-      const updatedOrder = await tx.order.update({
-        where: { id: orderId },
-        data: { status: "CANCELLED" },
-      });
-
-      if (collateralToRelease > 0) {
-        // Decrement lockedCollateral for this user+market
-        const position = await tx.userPosition.findUnique({
-          where: {
-            marketId_userAddress: {
-              marketId: order.marketId,
-              userAddress,
-            },
-          },
-        });
-
-        if (position) {
-          const newLocked = Math.max(
-            0,
-            Number(position.lockedCollateral) - collateralToRelease
-          );
-          await tx.userPosition.update({
-            where: {
-              marketId_userAddress: {
-                marketId: order.marketId,
-                userAddress,
-              },
-            },
-            data: {
-              lockedCollateral: newLocked,
-            },
-          });
-        }
-      }
-
-      return updatedOrder;
+      return cancelledOrder;
     });
   }
 
@@ -366,11 +426,30 @@ class MatchingService {
 
             const makerOrder = await tx.order.findUnique({
               where: { id: maker },
-              select: { quantity: true, filledQuantity: true },
+              select: {
+                quantity: true,
+                filledQuantity: true,
+                status: true,
+                version: true,
+              },
             });
 
             if (!makerOrder) {
               throw new Error(`Maker order not found: ${maker}`);
+            }
+
+            // The in-memory book that produced this match may be stale
+            // relative to the DB (e.g. the maker order was cancelled, or
+            // filled by another instance, after this book last hydrated).
+            // Reject rather than fill a maker order that is no longer open
+            // (#866) — no fill may commit against a canceled maker order.
+            if (
+              makerOrder.status !== "OPEN" &&
+              makerOrder.status !== "PARTIALLY_FILLED"
+            ) {
+              throw new OrderConflictError(
+                `Maker order ${maker} is no longer open (status: ${makerOrder.status.toLowerCase()}); please retry`
+              );
             }
 
             const newFilledQty = makerOrder.filledQuantity + trade.quantity;
@@ -384,13 +463,29 @@ class MatchingService {
               makerStatus = "FILLED";
             }
 
-            await tx.order.update({
-              where: { id: maker },
+            // Conditional update: only applies if the maker order is still
+            // exactly the version/status just read. Zero rows affected means
+            // a concurrent cancel (or another fill) beat this transaction to
+            // it — the whole placeOrder transaction rolls back, so there is
+            // one winner per maker order version and never a double-fill.
+            const makerUpdate = await tx.order.updateMany({
+              where: {
+                id: maker,
+                version: makerOrder.version,
+                status: { in: ["OPEN", "PARTIALLY_FILLED"] },
+              },
               data: {
                 filledQuantity: newFilledQty,
                 status: makerStatus,
+                version: { increment: 1 },
               },
             });
+
+            if (makerUpdate.count === 0) {
+              throw new OrderConflictError(
+                `Maker order ${maker} was concurrently modified; please retry`
+              );
+            }
           }
 
           // Persist trades as source of truth (idempotent on trade.id)

--- a/tests/integration/concurrent-orders.test.ts
+++ b/tests/integration/concurrent-orders.test.ts
@@ -454,4 +454,169 @@ describe("Concurrent order placement — same order book", () => {
     );
     expect(makerFilledQty).toBe(totalFilled);
   });
+
+  // -------------------------------------------------------------------------
+  // Cancel-vs-match race integrity (#866)
+  // -------------------------------------------------------------------------
+
+  describe("cancel-vs-match race integrity", () => {
+    it("never lets a fill commit against a canceled maker order (parallel cancel + aggressive taker)", async () => {
+      const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+      const maker = addresses[2];
+      const restingQty = 100;
+      const price = 0.5;
+
+      const makerOrder = await testUtils.createTestOrder(market.id, maker, {
+        side: "SELL",
+        outcome: "YES",
+        price,
+        quantity: restingQty,
+        filledQuantity: 0,
+        status: "OPEN",
+      });
+
+      // Collateral locked by a SELL order is (1 - price) * quantity.
+      await testUtils.createTestPosition(market.id, maker, {
+        lockedCollateral: (1 - price) * restingQty,
+      });
+
+      // An aggressive taker sized to fully consume the maker in one shot —
+      // so if the match wins the race, the maker ends up terminally FILLED
+      // (not left PARTIALLY_FILLED, which would make a subsequent cancel of
+      // the remainder legitimate rather than a genuine conflict).
+      const takerPayload = {
+        marketId: market.id,
+        userAddress: addresses[0],
+        side: "BUY" as const,
+        outcome: "YES" as const,
+        price,
+        quantity: restingQty,
+      };
+
+      const [cancelRes, takerRes] = await Promise.all([
+        app.inject({
+          method: "DELETE",
+          url: `/v1/orders/${makerOrder.id}`,
+          payload: { userAddress: maker },
+        }),
+        app.inject({
+          method: "POST",
+          url: "/v1/orders",
+          headers: authHeaders(keypairs[0], takerPayload),
+          payload: takerPayload,
+        }),
+      ]);
+
+      expect(takerRes.statusCode).toBe(201);
+      const takerFilled = JSON.parse(takerRes.body).filledQuantity as number;
+
+      const finalMaker = await prisma.order.findUnique({
+        where: { id: makerOrder.id },
+      });
+      expect(finalMaker).not.toBeNull();
+
+      // No trade may ever be recorded against a canceled maker order.
+      const trades = await prisma.trade.findMany({
+        where: { sellOrderId: makerOrder.id },
+      });
+
+      if (finalMaker!.status === "CANCELLED") {
+        // Cancel won: the match must not have landed anything on this maker.
+        expect(cancelRes.statusCode).toBe(200);
+        expect(finalMaker!.filledQuantity).toBe(0);
+        expect(takerFilled).toBe(0);
+        expect(trades).toHaveLength(0);
+      } else {
+        // Match won first (aggressive size fully fills the maker in one
+        // shot), so the cancel attempt must not have succeeded.
+        expect(finalMaker!.status).toBe("FILLED");
+        expect(finalMaker!.filledQuantity).toBe(restingQty);
+        expect(takerFilled).toBe(restingQty);
+        expect(cancelRes.statusCode).not.toBe(200);
+        expect(trades).toHaveLength(1);
+      }
+    });
+
+    it("locked collateral never goes negative across many interleaved cancel/fill pairs on the same maker", async () => {
+      const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+      const maker = addresses[2];
+      const price = 0.5;
+      const restingQty = 40;
+      const numOrders = 4;
+
+      const makerOrders = [];
+      for (let i = 0; i < numOrders; i++) {
+        makerOrders.push(
+          await testUtils.createTestOrder(market.id, maker, {
+            side: "SELL",
+            outcome: "YES",
+            price,
+            quantity: restingQty,
+            filledQuantity: 0,
+            status: "OPEN",
+          })
+        );
+      }
+
+      await testUtils.createTestPosition(market.id, maker, {
+        lockedCollateral: (1 - price) * restingQty * numOrders,
+      });
+
+      // Race a cancel and an aggressive full-size taker against every maker
+      // order at once — all interleaved on the same book/mutex.
+      const operations = makerOrders.flatMap((o) => {
+        const takerPayload = {
+          marketId: market.id,
+          userAddress: addresses[0],
+          side: "BUY" as const,
+          outcome: "YES" as const,
+          price,
+          quantity: restingQty,
+        };
+        return [
+          app.inject({
+            method: "DELETE",
+            url: `/v1/orders/${o.id}`,
+            payload: { userAddress: maker },
+          }),
+          app.inject({
+            method: "POST",
+            url: "/v1/orders",
+            headers: authHeaders(keypairs[0], takerPayload),
+            payload: takerPayload,
+          }),
+        ];
+      });
+
+      await Promise.all(operations);
+
+      const position = await prisma.userPosition.findUnique({
+        where: {
+          marketId_userAddress: { marketId: market.id, userAddress: maker },
+        },
+      });
+
+      expect(position).not.toBeNull();
+      // Invariant: locked collateral must never go negative, regardless of
+      // how the cancels and fills interleaved.
+      expect(Number(position!.lockedCollateral)).toBeGreaterThanOrEqual(0);
+
+      // Every maker order must be internally consistent: a CANCELLED order
+      // was never subsequently filled, and every trade recorded against a
+      // maker is reflected in that maker's own filledQuantity.
+      const finalOrders = await prisma.order.findMany({
+        where: { id: { in: makerOrders.map((o) => o.id) } },
+      });
+      for (const order of finalOrders) {
+        const trades = await prisma.trade.findMany({
+          where: { sellOrderId: order.id },
+        });
+        const tradedQty = trades.reduce((sum, t) => sum + t.quantity, 0);
+        expect(order.filledQuantity).toBe(tradedQty);
+        if (order.status === "CANCELLED") {
+          expect(tradedQty).toBe(0);
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #866

Makes cancel and match conflict-safe end-to-end: one winner per maker order version, no negative locked collateral, and no fills against a canceled maker order's remainder.

- **Optimistic versioning**: added a `version` column to `Order` (migration `20260729160000_add_order_version`). Every write that changes an order's status/filledQuantity conditions its UPDATE on the `(version, status)` it just read via `updateMany` + a `count` check — zero rows affected means a concurrent writer already won. This is the same conditional-update pattern already used in `apps/workers/src/finalization/job.ts`.
- **cancelOrder now runs under the same per-book mutex as `placeOrder`**: a same-instance optimization that prevents a cancel from interleaving in-memory with a match for the same book. The version-conditioned UPDATE is the authoritative safety net that also holds across processes (Postgres re-evaluates the `WHERE` clause against committed data once a blocked UPDATE's row lock is released — the second writer never overwrites with stale data).
- **placeOrder's maker-order update loop** re-reads each maker's status/version inside the transaction and rejects with `OrderConflictError` if the maker is no longer open, or if the conditional update affects zero rows. The whole transaction (including the taker order) rolls back — so a match can never partially commit against a maker that lost the race.
- **`OrderConflictError`** (409, code `order_conflict`) added to `src/api/middleware/errors.ts` — a documented, retryable error code for the conflict path. It falls through `errorHandler.ts`'s existing generic `AppError` branch, so no changes were needed there.
- Collateral release math is unchanged (remaining unfilled quantity only) but is now only applied once the conditional cancel actually succeeds; the existing `Math.max(0, ...)` clamp is preserved so `lockedCollateral` can never go negative.
- On a version conflict, the in-memory book is invalidated so the next operation for that book rehydrates fresh from the DB.

## Testing/validation performed

- `pnpm prisma:generate` / `pnpm prisma:deploy` against a local Postgres — new migration applies cleanly.
- Unit tests (`src/matching/matching-service.test.ts`): new coverage for the `cancelOrder` version-conflict path (`OrderConflictError`, book invalidation), the `placeOrder` maker-conflict path (maker no longer open, and `updateMany` count 0 — both roll back the whole transaction), and a non-negative-collateral regression case.
- Integration tests (`tests/integration/concurrent-orders.test.ts`): a real parallel `DELETE /orders/:id` + aggressive-taker `POST /orders` race against the same resting maker order (asserts no fill ever lands on a canceled maker — ran 5x locally, stable), and a property test firing many interleaved cancel/fill pairs across several maker orders for one user, asserting `lockedCollateral` never goes negative and every order's `filledQuantity` stays consistent with its recorded trades.
- `pnpm test:run` and `pnpm test:integration` — diffed against a clean `dev` checkout: identical set of 14 pre-existing, unrelated failures (indexer ingestion/eventFetcher, stellarAuth, finalization `maxRunMs` flake, `validation.test.ts` log-injection case, API-versioning/docker-compose contract tests) both before and after this change; zero new failures, all new tests pass.
- `pnpm tsc --noEmit` (root, apps, packages) — no new errors (two pre-existing, unrelated failures confirmed present on `dev` HEAD too: `apps/indexer/src/eventFetcher.ts`, `src/api/routes/positions.test.ts`).
- `pnpm format:check` — matches the pre-existing baseline exactly (no new formatting issues).
- Pre-commit hook (`lint-staged`: prettier + `tsc-files --noEmit` + `prisma validate`) passed.

## Link to issue

https://github.com/Vatix-Protocol/vatix-backend/issues/866

## Risks / follow-ups

- `pnpm prisma:validate`'s schema/migration diff already fails on `dev` HEAD independent of this PR, due to a pre-existing `trades.outcome` type mismatch between `schema.prisma` and its migration (confirmed on an unmodified checkout). This PR's migration introduces no additional drift — the `orders.version` column matches the schema exactly.
- The per-book mutex only protects a single process; the version-conditioned `updateMany` is what actually guarantees correctness across multiple instances/replicas. This was verified analytically (Postgres MVCC re-evaluates `UPDATE ... WHERE` against committed data after a blocked writer's lock releases) since a true multi-process race isn't practical to simulate in the existing single-process test harness.
- Outbox publishing and leader election are explicitly out of scope per the issue notes and were not touched.