### PR TITLE
feat(auth): add durable single-use nonce challenge for Stellar auth

### DIFF
--- a/docs/adr/002-stellar-auth-challenge.md
+++ b/docs/adr/002-stellar-auth-challenge.md
@@ -1,0 +1,56 @@
+# ADR 002: Stellar auth challenge, nonce TTL and key layout
+
+## Status
+
+Accepted
+
+## Context
+
+Order routes proved wallet ownership with an Ed25519 signature over the request
+body plus an `x-timestamp` header inside a ±5 minute skew window. A skew window
+alone does not stop replay: a captured request can be resent to every API
+replica until the window closes, and any in-memory nonce map neither survives a
+restart nor federates across replicas.
+
+## Decision
+
+Auth is a challenge-response flow backed by Redis, which every API replica
+already shares.
+
+- `POST /v1/auth/challenge` takes `{ userAddress }` and returns a server-issued
+  nonce (24 random bytes, base64url) plus its expiry.
+- The nonce is stored under `auth:nonce:<userAddress>:<nonce>` with a TTL, on
+  top of the global `REDIS_KEY_PREFIX` namespace.
+- The nonce is part of the canonical signed message and is echoed in the
+  `x-nonce` header, so it cannot be swapped after signing.
+- `verifyStellarSignature` consumes the nonce with a single `DEL` **after** the
+  signature verifies. `DEL` returns the number of keys removed, so concurrent
+  double-submits — including ones landing on different replicas — produce
+  exactly one winner; a forged signature cannot burn a valid challenge.
+
+### Expiry policy
+
+| Setting                 | Default | Meaning                                     |
+| ----------------------- | ------- | ------------------------------------------- |
+| `CHALLENGE_TTL_SECONDS` | `120`   | Nonce lifetime; expired nonces fail closed. |
+| Timestamp skew          | 5 min   | Unchanged; applied before nonce lookup.     |
+
+The TTL is deliberately shorter than the skew window: expiry is enforced by
+Redis, so a missing key is indistinguishable from a used one and both are
+rejected.
+
+## Consequences
+
+- Failures return `401` with the standard auth error envelope
+  (`code: "UNAUTHORIZED"`): missing `x-nonce`, unknown/expired/used nonce, and
+  nonce store unavailable (fail closed).
+- Clients must fetch a challenge per mutating request; `scripts/load-test-orders.ts`
+  does this inline before each order.
+- Redis becomes a hard dependency of order placement, in line with the existing
+  readiness probe.
+
+## Alternatives considered
+
+- **Timestamp window only** — rejected; does not prevent replay.
+- **Postgres nonce table** — rejected; adds a write per request and needs a
+  sweeper, while Redis TTL expires keys for free.

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -4,22 +4,23 @@
 
 Routes are prefixed with `/v1/` to allow non-breaking additions in future versions. All public routes are already mounted under `/v1/`; legacy unprefixed aliases are kept temporarily for backwards compatibility and return `Deprecation`/`Sunset` headers (see below).
 
-| Method | Canonical path                            | Legacy alias                | Notes                                                    |
-| ------ | ----------------------------------------- | --------------------------- | -------------------------------------------------------- |
-| GET    | `/v1/health`                              | `/health`                   | Liveness and health summary                              |
-| GET    | `/v1/ready`                               | `/ready`, `/readiness`      | Readiness checks                                         |
-| GET    | `/v1/markets`                             | `/markets`                  | Market listing                                           |
-| GET    | `/v1/markets/:id`                         | `/markets/:id`              | Market details                                           |
-| GET    | `/v1/markets/:id/orderbook`               | `/markets/:id/orderbook`    | Market orderbook                                         |
-| POST   | `/v1/orders`                              | `/orders`                   | Create order                                             |
-| GET    | `/v1/orders/user/:address`                | `/orders/user/:address`     | Wallet order history                                     |
-| GET    | `/v1/trades`                              | none                        | Paginated trade listing (Postgres, optional Redis cache) |
-| GET    | `/v1/trades/user/:address`                | `/trades/user/:address`     | Wallet trade history                                     |
-| GET    | `/v1/wallets/:wallet/positions`           | `/positions/user/:address`  | Canonical wallet positions path                          |
-| GET    | `/v1/wallets/:wallet/positions/:marketId` | none                        | Single-market position read                              |
-| GET    | `/v1/admin/markets`                       | `/admin/markets`            | Requires API key and admin auth                          |
-| PATCH  | `/v1/admin/markets/:id/status`            | `/admin/markets/:id/status` | Requires API key and admin auth                          |
-| GET    | `/v1/openapi.json`                        | none                        | OpenAPI specification                                    |
+| Method | Canonical path                            | Legacy alias                | Notes                                                     |
+| ------ | ----------------------------------------- | --------------------------- | --------------------------------------------------------- |
+| GET    | `/v1/health`                              | `/health`                   | Liveness and health summary                               |
+| GET    | `/v1/ready`                               | `/ready`, `/readiness`      | Readiness checks                                          |
+| GET    | `/v1/markets`                             | `/markets`                  | Market listing                                            |
+| GET    | `/v1/markets/:id`                         | `/markets/:id`              | Market details                                            |
+| GET    | `/v1/markets/:id/orderbook`               | `/markets/:id/orderbook`    | Market orderbook                                          |
+| POST   | `/v1/orders`                              | `/orders`                   | Create order                                              |
+| GET    | `/v1/orders/user/:address`                | `/orders/user/:address`     | Wallet order history                                      |
+| GET    | `/v1/trades`                              | none                        | Paginated trade listing (Postgres, optional Redis cache)  |
+| GET    | `/v1/trades/user/:address`                | `/trades/user/:address`     | Wallet trade history                                      |
+| GET    | `/v1/wallets/:wallet/positions`           | `/positions/user/:address`  | Canonical wallet positions path                           |
+| GET    | `/v1/wallets/:wallet/positions/:marketId` | none                        | Single-market position read                               |
+| GET    | `/v1/admin/markets`                       | `/admin/markets`            | Requires API key and admin auth                           |
+| PATCH  | `/v1/admin/markets/:id/status`            | `/admin/markets/:id/status` | Requires API key and admin auth                           |
+| POST   | `/v1/auth/challenge`                      | none                        | Issues a single-use signing nonce for Stellar wallet auth |
+| GET    | `/v1/openapi.json`                        | none                        | OpenAPI specification                                     |
 
 Redis keys follow a namespaced pattern so a version bump can invalidate only affected entries without a full cache flush:
 

--- a/docs/orders-route.md
+++ b/docs/orders-route.md
@@ -65,16 +65,28 @@ then checking the market state, price, quantity, side, and outcome.
 
 ### Authentication
 
-Every `POST /v1/orders` request must carry two headers that prove the caller
+Every `POST /v1/orders` request must carry three headers that prove the caller
 controls the Stellar wallet identified by `userAddress`.
 
 | Header        | Type   | Description                                                            |
 | ------------- | ------ | ---------------------------------------------------------------------- |
 | `x-timestamp` | string | Current Unix time in **milliseconds** as a decimal string.             |
+| `x-nonce`     | string | Single-use nonce from `POST /v1/auth/challenge`.                       |
 | `x-signature` | string | Base64-encoded Ed25519 signature of the canonical message (see below). |
 
 The server rejects requests whose `x-timestamp` differs from server time by
-more than **5 minutes** to prevent replay attacks.
+more than **5 minutes**, and consumes `x-nonce` atomically from shared Redis so
+the same signed payload cannot be replayed against another API replica. See
+[adr/002-stellar-auth-challenge.md](adr/002-stellar-auth-challenge.md).
+
+#### Challenge issuance
+
+```http
+POST /v1/auth/challenge
+{ "userAddress": "G..." }
+
+201 { "nonce": "...", "expiresAt": "2026-01-01T00:02:00.000Z", "ttlSeconds": 120 }
+```
 
 #### Canonical message
 
@@ -84,6 +96,7 @@ and sign its raw bytes with the wallet's Ed25519 private key:
 ```json
 {
   "marketId": "<marketId from body>",
+  "nonce": "<x-nonce value>",
   "outcome": "<outcome from body>",
   "price": <price from body>,
   "quantity": <quantity from body>,
@@ -102,6 +115,12 @@ import { buildSignableMessage } from "src/api/middleware/stellarAuth";
 const keypair = Keypair.fromSecret("S...");
 const timestamp = Date.now();
 
+const challenge = await fetch("/v1/auth/challenge", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ userAddress: keypair.publicKey() }),
+}).then((res) => res.json());
+
 const body = {
   marketId: "market-1",
   userAddress: keypair.publicKey(),
@@ -111,7 +130,11 @@ const body = {
   quantity: 100,
 };
 
-const message = buildSignableMessage({ ...body, timestamp });
+const message = buildSignableMessage({
+  ...body,
+  nonce: challenge.nonce,
+  timestamp,
+});
 const signature = keypair.sign(message).toString("base64");
 
 fetch("/v1/orders", {
@@ -119,6 +142,7 @@ fetch("/v1/orders", {
   headers: {
     "Content-Type": "application/json",
     "x-timestamp": String(timestamp),
+    "x-nonce": challenge.nonce,
     "x-signature": signature,
   },
   body: JSON.stringify(body),
@@ -177,7 +201,7 @@ Common errors:
 | Status | Cause                                                                                                                                      |
 | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `400`  | Missing field, invalid Stellar address, invalid side/outcome, invalid price or quantity, unknown market, closed market, or expired market. |
-| `401`  | Missing or invalid `x-signature`/`x-timestamp` headers, expired timestamp, or signature mismatch.                                          |
+| `401`  | Missing or invalid `x-signature`/`x-timestamp`/`x-nonce` headers, expired timestamp, reused or expired nonce, or signature mismatch.       |
 | `500`  | Database write failed.                                                                                                                     |
 
 ## `GET /v1/trades/user/:address`

--- a/scripts/load-test-orders.ts
+++ b/scripts/load-test-orders.ts
@@ -256,17 +256,34 @@ async function placeOrder(
     quantity,
   };
   const timestamp = Date.now();
-  const message = buildSignableMessage({ ...body, timestamp });
-  const signature = trader.keypair.sign(message).toString("base64");
 
   const start = performance.now();
   try {
+    // Every order needs a fresh single-use nonce from the challenge endpoint.
+    const challengeRes = await fetch(`${baseUrl}/v1/auth/challenge`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ userAddress: trader.publicKey }),
+    });
+    if (!challengeRes.ok) {
+      await challengeRes.text();
+      return {
+        status: challengeRes.status,
+        latencyMs: performance.now() - start,
+      };
+    }
+    const { nonce } = (await challengeRes.json()) as { nonce: string };
+
+    const message = buildSignableMessage({ ...body, nonce, timestamp });
+    const signature = trader.keypair.sign(message).toString("base64");
+
     const res = await fetch(`${baseUrl}/v1/orders`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
         "x-signature": signature,
         "x-timestamp": String(timestamp),
+        "x-nonce": nonce,
       },
       body: JSON.stringify(body),
     });

--- a/src/api/middleware/nonceStore.test.ts
+++ b/src/api/middleware/nonceStore.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// In-memory stand-in for the shared Redis instance every API replica talks to.
+const { store } = vi.hoisted(() => ({ store: new Map<string, number>() }));
+
+vi.mock("../../services/redis.js", () => ({
+  redis: {
+    set: vi.fn(async (key: string, _value: string, ttl?: number) => {
+      store.set(key, Date.now() + (ttl ?? 0) * 1000);
+    }),
+    delIfExists: vi.fn(async (key: string) => {
+      const expiresAt = store.get(key);
+      if (expiresAt === undefined) return false;
+      store.delete(key);
+      return expiresAt > Date.now();
+    }),
+  },
+}));
+
+import { issueChallenge, consumeNonce } from "./nonceStore.js";
+
+const ADDRESS = "GADDRESS";
+
+describe("nonceStore", () => {
+  beforeEach(() => {
+    store.clear();
+    vi.useRealTimers();
+    delete process.env.CHALLENGE_TTL_SECONDS;
+  });
+
+  it("issues a unique nonce with the configured TTL", async () => {
+    process.env.CHALLENGE_TTL_SECONDS = "60";
+    const first = await issueChallenge(ADDRESS);
+    const second = await issueChallenge(ADDRESS);
+
+    expect(first.ttlSeconds).toBe(60);
+    expect(first.nonce).not.toBe(second.nonce);
+    expect(first.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("consumes a nonce exactly once — a replay against a second replica fails", async () => {
+    const { nonce } = await issueChallenge(ADDRESS);
+
+    await expect(consumeNonce(ADDRESS, nonce)).resolves.toBe(true);
+    await expect(consumeNonce(ADDRESS, nonce)).resolves.toBe(false);
+  });
+
+  it("rejects a nonce issued for a different address", async () => {
+    const { nonce } = await issueChallenge(ADDRESS);
+
+    await expect(consumeNonce("GOTHER", nonce)).resolves.toBe(false);
+  });
+
+  it("rejects an unknown nonce", async () => {
+    await expect(consumeNonce(ADDRESS, "never-issued")).resolves.toBe(false);
+  });
+
+  it("fails closed past the expiry boundary", async () => {
+    process.env.CHALLENGE_TTL_SECONDS = "1";
+    const { nonce } = await issueChallenge(ADDRESS);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 1_001);
+
+    await expect(consumeNonce(ADDRESS, nonce)).resolves.toBe(false);
+  });
+
+  it("yields a single winner for a concurrent double-submit", async () => {
+    const { nonce } = await issueChallenge(ADDRESS);
+
+    const results = await Promise.all([
+      consumeNonce(ADDRESS, nonce),
+      consumeNonce(ADDRESS, nonce),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+});

--- a/src/api/middleware/nonceStore.ts
+++ b/src/api/middleware/nonceStore.ts
@@ -1,0 +1,56 @@
+import { randomBytes } from "crypto";
+import { redis } from "../../services/redis.js";
+
+/**
+ * Challenge / nonce TTL in seconds.
+ * Override via CHALLENGE_TTL_SECONDS (default: 120).
+ */
+function loadTtlSeconds(): number {
+  const raw = process.env.CHALLENGE_TTL_SECONDS;
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : 120;
+}
+
+const NONCE_KEY_PREFIX = "auth:nonce:";
+
+function nonceKey(userAddress: string, nonce: string): string {
+  return `${NONCE_KEY_PREFIX}${userAddress}:${nonce}`;
+}
+
+export interface Challenge {
+  nonce: string;
+  expiresAt: number;
+  ttlSeconds: number;
+}
+
+/**
+ * Issue a single-use challenge for a wallet address.
+ *
+ * The nonce is stored in Redis (shared by every API replica) with a TTL, so a
+ * challenge issued by one replica can be consumed exactly once by any replica
+ * and disappears on expiry.
+ */
+export async function issueChallenge(userAddress: string): Promise<Challenge> {
+  const ttlSeconds = loadTtlSeconds();
+  const nonce = randomBytes(24).toString("base64url");
+  await redis.set(nonceKey(userAddress, nonce), "1", ttlSeconds);
+  return {
+    nonce,
+    ttlSeconds,
+    expiresAt: Date.now() + ttlSeconds * 1000,
+  };
+}
+
+/**
+ * Atomically consume a previously issued nonce.
+ *
+ * Returns true only for the first caller: the Redis DEL reply is the number of
+ * keys removed, so two concurrent replicas racing on the same nonce produce a
+ * single winner. Unknown or expired nonces return false (fail closed).
+ */
+export async function consumeNonce(
+  userAddress: string,
+  nonce: string
+): Promise<boolean> {
+  return redis.delIfExists(nonceKey(userAddress, nonce));
+}

--- a/src/api/middleware/stellarAuth.test.ts
+++ b/src/api/middleware/stellarAuth.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Fastify, { FastifyInstance } from "fastify";
 import { Keypair } from "@stellar/stellar-sdk";
 import { buildSignableMessage } from "./stellarAuth.js";
+
+// Nonce consumption is exercised in nonceStore.test.ts; here it always succeeds
+// so the signature checks stay the subject of these tests.
+const NONCE = "test-nonce";
+vi.mock("./nonceStore.js", () => ({
+  consumeNonce: vi.fn(async () => true),
+}));
 import type { PrismaClient } from "../../generated/prisma/client";
 
 // ---------------------------------------------------------------------------
@@ -67,11 +74,12 @@ function makeHeaders(
   ts = Date.now()
 ): Record<string, string> {
   const sig = keypair
-    .sign(buildSignableMessage({ ...body, timestamp: ts }))
+    .sign(buildSignableMessage({ ...body, nonce: NONCE, timestamp: ts }))
     .toString("base64");
   return {
     "x-signature": sig,
     "x-timestamp": String(ts),
+    "x-nonce": NONCE,
   };
 }
 
@@ -155,7 +163,7 @@ describe("POST /orders – Stellar wallet signature verification", () => {
   it("should return 401 when x-timestamp header is missing", async () => {
     const ts = Date.now();
     const sig = testKeypair
-      .sign(buildSignableMessage({ ...validBody, timestamp: ts }))
+      .sign(buildSignableMessage({ ...validBody, nonce: NONCE, timestamp: ts }))
       .toString("base64");
 
     const response = await app.inject({
@@ -174,7 +182,7 @@ describe("POST /orders – Stellar wallet signature verification", () => {
     const otherKeypair = Keypair.random();
     const ts = Date.now();
     const wrongSig = otherKeypair
-      .sign(buildSignableMessage({ ...validBody, timestamp: ts }))
+      .sign(buildSignableMessage({ ...validBody, nonce: NONCE, timestamp: ts }))
       .toString("base64");
 
     const response = await app.inject({
@@ -183,6 +191,7 @@ describe("POST /orders – Stellar wallet signature verification", () => {
       headers: {
         "x-signature": wrongSig,
         "x-timestamp": String(ts),
+        "x-nonce": NONCE,
       },
       payload: validBody,
     });
@@ -211,7 +220,9 @@ describe("POST /orders – Stellar wallet signature verification", () => {
     // Sign a body with a different price than what is actually sent
     const tamperedBody = { ...validBody, price: 0.1 };
     const sig = testKeypair
-      .sign(buildSignableMessage({ ...tamperedBody, timestamp: ts }))
+      .sign(
+        buildSignableMessage({ ...tamperedBody, nonce: NONCE, timestamp: ts })
+      )
       .toString("base64");
 
     const response = await app.inject({
@@ -220,6 +231,7 @@ describe("POST /orders – Stellar wallet signature verification", () => {
       headers: {
         "x-signature": sig,
         "x-timestamp": String(ts),
+        "x-nonce": NONCE,
       },
       payload: validBody, // original body – signature mismatch
     });
@@ -233,7 +245,9 @@ describe("POST /orders – Stellar wallet signature verification", () => {
     const ts = Date.now();
     const invalidBody = { ...validBody, userAddress: "not-a-stellar-address" };
     const sig = testKeypair
-      .sign(buildSignableMessage({ ...invalidBody, timestamp: ts }))
+      .sign(
+        buildSignableMessage({ ...invalidBody, nonce: NONCE, timestamp: ts })
+      )
       .toString("base64");
 
     const response = await app.inject({
@@ -242,6 +256,7 @@ describe("POST /orders – Stellar wallet signature verification", () => {
       headers: {
         "x-signature": sig,
         "x-timestamp": String(ts),
+        "x-nonce": NONCE,
       },
       payload: invalidBody,
     });
@@ -258,6 +273,7 @@ describe("POST /orders – Stellar wallet signature verification", () => {
       headers: {
         "x-signature": "!!!not-valid-base64!!!",
         "x-timestamp": String(Date.now()),
+        "x-nonce": NONCE,
       },
       payload: validBody,
     });

--- a/src/api/middleware/stellarAuth.ts
+++ b/src/api/middleware/stellarAuth.ts
@@ -1,6 +1,7 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
 import { Keypair } from "@stellar/stellar-sdk";
 import { unauthorized } from "./responses.js";
+import { consumeNonce } from "./nonceStore.js";
 
 const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -11,6 +12,7 @@ const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000; // 5 minutes
  */
 export function buildSignableMessage(fields: {
   marketId: string;
+  nonce: string;
   outcome: string;
   price: number;
   quantity: number;
@@ -20,6 +22,7 @@ export function buildSignableMessage(fields: {
 }): Buffer {
   const payload = JSON.stringify({
     marketId: fields.marketId,
+    nonce: fields.nonce,
     outcome: fields.outcome,
     price: fields.price,
     quantity: fields.quantity,
@@ -37,21 +40,24 @@ export function buildSignableMessage(fields: {
  * Required headers:
  *   x-signature  – base64-encoded Ed25519 signature of the canonical message
  *   x-timestamp  – milliseconds since Unix epoch (string); must be within ±5 min
+ *   x-nonce      – single-use nonce issued by POST /v1/auth/challenge
  *
  * The canonical message is built from the parsed request body fields combined
- * with the timestamp from the header, so a replay of an identical body with a
- * stale timestamp is rejected even if the signature itself was once valid.
+ * with the timestamp and nonce from the headers, so a replay of an identical
+ * body with a stale timestamp is rejected even if the signature itself was once
+ * valid.  The nonce lives in shared Redis and is consumed atomically, so the
+ * same signed payload cannot be replayed against another API replica.
  *
  * Returns HTTP 401 for any authentication failure; delegates all other
  * validation to the route handler.
  */
-export function verifyStellarSignature(
+export async function verifyStellarSignature(
   request: FastifyRequest,
-  reply: FastifyReply,
-  done: () => void
-): void {
+  reply: FastifyReply
+): Promise<void> {
   const rawSig = request.headers["x-signature"];
   const rawTs = request.headers["x-timestamp"];
+  const rawNonce = request.headers["x-nonce"];
 
   if (!rawSig || typeof rawSig !== "string") {
     unauthorized(reply, "Missing x-signature header");
@@ -60,6 +66,11 @@ export function verifyStellarSignature(
 
   if (!rawTs || typeof rawTs !== "string") {
     unauthorized(reply, "Missing x-timestamp header");
+    return;
+  }
+
+  if (!rawNonce || typeof rawNonce !== "string") {
+    unauthorized(reply, "Missing x-nonce header");
     return;
   }
 
@@ -94,6 +105,7 @@ export function verifyStellarSignature(
     const keypair = Keypair.fromPublicKey(userAddress);
     const message = buildSignableMessage({
       marketId: body?.marketId ?? "",
+      nonce: rawNonce,
       outcome: body?.outcome ?? "",
       price: body?.price ?? 0,
       quantity: body?.quantity ?? 0,
@@ -113,5 +125,18 @@ export function verifyStellarSignature(
     return;
   }
 
-  done();
+  // Consume the nonce only after the signature is proven valid, so an attacker
+  // cannot burn a legitimate challenge with a forged request.
+  let consumed = false;
+  try {
+    consumed = await consumeNonce(userAddress, rawNonce);
+  } catch {
+    unauthorized(reply, "Nonce store unavailable");
+    return;
+  }
+
+  if (!consumed) {
+    unauthorized(reply, "Nonce is unknown, expired or already used");
+    return;
+  }
 }

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -196,6 +196,50 @@ export const openApiSpec = {
         },
       },
     },
+    "/v1/auth/challenge": {
+      post: {
+        summary: "Issue a signing challenge",
+        description:
+          "Returns a single-use nonce that must be included in the signed message and sent as the x-nonce header on the next mutating request. The nonce is stored in shared Redis with a TTL, so it is valid across API replicas exactly once.",
+        tags: ["Auth"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["userAddress"],
+                properties: {
+                  userAddress: {
+                    type: "string",
+                    description:
+                      "Stellar public key (G...) requesting the challenge",
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Challenge issued",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    nonce: { type: "string" },
+                    expiresAt: { type: "string", format: "date-time" },
+                    ttlSeconds: { type: "integer" },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "Invalid userAddress" },
+        },
+      },
+    },
     "/v1/orders": {
       post: {
         summary: "Create an order",
@@ -217,6 +261,14 @@ export const openApiSpec = {
             required: true,
             description:
               "Unix timestamp in milliseconds (string). Must be within ±5 minutes of server time to prevent replay attacks.",
+            schema: { type: "string" },
+          },
+          {
+            name: "x-nonce",
+            in: "header",
+            required: true,
+            description:
+              "Single-use nonce obtained from POST /v1/auth/challenge and included in the signed message. Consumed atomically in shared Redis, so a captured request cannot be replayed against another API replica.",
             schema: { type: "string" },
           },
         ],

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -1,0 +1,56 @@
+import type { FastifyInstance } from "fastify";
+import { Keypair } from "@stellar/stellar-sdk";
+import { issueChallenge } from "../middleware/nonceStore.js";
+import { unauthorized } from "../middleware/responses.js";
+
+interface ChallengeBody {
+  userAddress: string;
+}
+
+interface ChallengeResponse {
+  nonce: string;
+  expiresAt: string;
+  ttlSeconds: number;
+}
+
+/**
+ * Challenge issuance for Stellar wallet auth.
+ *
+ * The returned nonce must be echoed in the `x-nonce` header and included in the
+ * signed payload of the next mutating request; it is single-use and expires
+ * after `ttlSeconds`.
+ */
+export async function authRoutes(fastify: FastifyInstance) {
+  fastify.post<{ Body: ChallengeBody; Reply: ChallengeResponse }>(
+    "/auth/challenge",
+    {
+      schema: {
+        body: {
+          type: "object",
+          required: ["userAddress"],
+          properties: {
+            userAddress: { type: "string" },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { userAddress } = request.body;
+
+      try {
+        Keypair.fromPublicKey(userAddress);
+      } catch {
+        unauthorized(reply, "Invalid userAddress");
+        return;
+      }
+
+      const challenge = await issueChallenge(userAddress);
+
+      reply.status(201).send({
+        nonce: challenge.nonce,
+        expiresAt: new Date(challenge.expiresAt).toISOString(),
+        ttlSeconds: challenge.ttlSeconds,
+      });
+    }
+  );
+}

--- a/src/api/routes/registry.ts
+++ b/src/api/routes/registry.ts
@@ -69,6 +69,11 @@ export const CANONICAL_V1_ROUTES: CanonicalRoute[] = [
     notes: "Requires API key and admin auth",
   },
   {
+    method: "POST",
+    path: "/v1/auth/challenge",
+    notes: "Issues a single-use signing nonce for Stellar wallet auth",
+  },
+  {
     method: "GET",
     path: "/v1/openapi.json",
     notes: "OpenAPI specification",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { marketsRoutes } from "./api/routes/markets.js";
 import { ordersRoutes } from "./api/routes/orders.js";
 import { fillsRoutes } from "./api/routes/fills.js";
 import { adminRoutes } from "./api/routes/admin.js";
+import { authRoutes } from "./api/routes/auth.js";
 import { healthRoutes } from "./api/routes/health.js";
 import { readyRoute } from "./api/routes/ready.js";
 import { metricsRoutes } from "./api/routes/metrics.js";
@@ -123,6 +124,7 @@ export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
       await v1.register(positionsRouter);
       await v1.register(fillsRoutes);
       await v1.register(adminRoutes);
+      await v1.register(authRoutes);
       await v1.register(healthRoutes);
       await v1.register(readyRoute(options.readyDeps ?? createReadyDeps()));
 

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -262,6 +262,22 @@ class RedisService {
   }
 
   /**
+   * Atomically delete a key, reporting whether it existed.
+   * DEL returns the number of keys removed, so concurrent callers racing on the
+   * same key yield exactly one `true`.
+   */
+  async delIfExists(key: string): Promise<boolean> {
+    try {
+      const client = await this.ensureConnected();
+      const removed = await client.del(key);
+      return removed === 1;
+    } catch (error) {
+      console.error({ service: "redis", key, err: error }, "Redis DEL failed");
+      throw error;
+    }
+  }
+
+  /**
    * Check if a key exists
    */
   async exists(key: string): Promise<boolean> {

--- a/tests/integration/concurrent-orders.test.ts
+++ b/tests/integration/concurrent-orders.test.ts
@@ -24,6 +24,7 @@ import type { FastifyInstance } from "fastify";
 import { Keypair } from "@stellar/stellar-sdk";
 import { ordersRoutes } from "../../src/api/routes/orders.js";
 import { buildSignableMessage } from "../../src/api/middleware/stellarAuth.js";
+import { issueChallenge } from "../../src/api/middleware/nonceStore.js";
 import { buildTestApp, resetRateLimits } from "./helpers/build-test-app.js";
 import { testUtils, getTestPrismaClient } from "../setup.js";
 import {
@@ -41,7 +42,7 @@ const keypairs = Array.from({ length: 5 }, () => Keypair.random());
 const addresses = keypairs.map((kp) => kp.publicKey());
 
 /** Build auth headers for a POST /v1/orders request. */
-function authHeaders(
+async function authHeaders(
   keypair: Keypair,
   body: {
     marketId: string;
@@ -51,12 +52,17 @@ function authHeaders(
     price: number;
     quantity: number;
   }
-): Record<string, string> {
+): Promise<Record<string, string>> {
   const timestamp = Date.now();
+  const { nonce } = await issueChallenge(keypair.publicKey());
   const sig = keypair
-    .sign(buildSignableMessage({ ...body, timestamp }))
+    .sign(buildSignableMessage({ ...body, nonce, timestamp }))
     .toString("base64");
-  return { "x-signature": sig, "x-timestamp": String(timestamp) };
+  return {
+    "x-signature": sig,
+    "x-timestamp": String(timestamp),
+    "x-nonce": nonce,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -113,13 +119,13 @@ describe("Concurrent order placement — same order book", () => {
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[0], payload1),
+        headers: await authHeaders(keypairs[0], payload1),
         payload: payload1,
       }),
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[1], payload2),
+        headers: await authHeaders(keypairs[1], payload2),
         payload: payload2,
       }),
     ]);
@@ -160,13 +166,13 @@ describe("Concurrent order placement — same order book", () => {
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[0], payload1),
+        headers: await authHeaders(keypairs[0], payload1),
         payload: payload1,
       }),
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[1], payload2),
+        headers: await authHeaders(keypairs[1], payload2),
         payload: payload2,
       }),
     ]);
@@ -220,13 +226,13 @@ describe("Concurrent order placement — same order book", () => {
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[0], payload1),
+        headers: await authHeaders(keypairs[0], payload1),
         payload: payload1,
       }),
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[1], payload2),
+        headers: await authHeaders(keypairs[1], payload2),
         payload: payload2,
       }),
     ]);
@@ -267,7 +273,7 @@ describe("Concurrent order placement — same order book", () => {
       return app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(kp, payload),
+        headers: await authHeaders(kp, payload),
         payload,
       });
     });
@@ -311,13 +317,13 @@ describe("Concurrent order placement — same order book", () => {
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[0], payloadA),
+        headers: await authHeaders(keypairs[0], payloadA),
         payload: payloadA,
       }),
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[1], payloadB),
+        headers: await authHeaders(keypairs[1], payloadB),
         payload: payloadB,
       }),
     ]);
@@ -370,13 +376,13 @@ describe("Concurrent order placement — same order book", () => {
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[0], selfPayload),
+        headers: await authHeaders(keypairs[0], selfPayload),
         payload: selfPayload,
       }),
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(keypairs[1], legitimatePayload),
+        headers: await authHeaders(keypairs[1], legitimatePayload),
         payload: legitimatePayload,
       }),
     ]);
@@ -427,7 +433,7 @@ describe("Concurrent order placement — same order book", () => {
         return app.inject({
           method: "POST",
           url: "/v1/orders",
-          headers: authHeaders(kp, payload),
+          headers: await authHeaders(kp, payload),
           payload,
         });
       })

--- a/tests/integration/orders-matching.test.ts
+++ b/tests/integration/orders-matching.test.ts
@@ -29,6 +29,7 @@ import type { FastifyInstance } from "fastify";
 import { Keypair } from "@stellar/stellar-sdk";
 import { ordersRoutes } from "../../src/api/routes/orders.js";
 import { buildSignableMessage } from "../../src/api/middleware/stellarAuth.js";
+import { issueChallenge } from "../../src/api/middleware/nonceStore.js";
 import { buildTestApp, resetRateLimits } from "./helpers/build-test-app.js";
 import { testUtils, getTestPrismaClient } from "../setup.js";
 import {
@@ -49,7 +50,7 @@ const takerAddress = takerKeypair.publicKey();
 const makerAddress = makerKeypair.publicKey();
 const maker2Address = maker2Keypair.publicKey();
 
-function authHeaders(
+async function authHeaders(
   keypair: Keypair,
   body: {
     marketId: string;
@@ -59,12 +60,17 @@ function authHeaders(
     price: number;
     quantity: number;
   }
-): Record<string, string> {
+): Promise<Record<string, string>> {
   const timestamp = Date.now();
+  const { nonce } = await issueChallenge(keypair.publicKey());
   const sig = keypair
-    .sign(buildSignableMessage({ ...body, timestamp }))
+    .sign(buildSignableMessage({ ...body, nonce, timestamp }))
     .toString("base64");
-  return { "x-signature": sig, "x-timestamp": String(timestamp) };
+  return {
+    "x-signature": sig,
+    "x-timestamp": String(timestamp),
+    "x-nonce": nonce,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -120,7 +126,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -161,7 +167,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -199,7 +205,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -235,7 +241,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -264,7 +270,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -298,7 +304,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -342,7 +348,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -395,7 +401,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -433,7 +439,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -473,7 +479,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -512,7 +518,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, p1),
+      headers: await authHeaders(takerKeypair, p1),
       payload: p1,
     });
 
@@ -536,7 +542,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, p2),
+      headers: await authHeaders(takerKeypair, p2),
       payload: p2,
     });
 
@@ -578,7 +584,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -608,7 +614,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -654,7 +660,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -692,7 +698,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -740,7 +746,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -779,7 +785,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 
@@ -812,7 +818,7 @@ describe("Orders Matching Integration — CLOB engine via POST /v1/orders", () =
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(takerKeypair, payload),
+      headers: await authHeaders(takerKeypair, payload),
       payload,
     });
 

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -11,6 +11,7 @@ import type { FastifyInstance } from "fastify";
 import { Keypair } from "@stellar/stellar-sdk";
 import { ordersRoutes } from "../../src/api/routes/orders.js";
 import { buildSignableMessage } from "../../src/api/middleware/stellarAuth.js";
+import { issueChallenge } from "../../src/api/middleware/nonceStore.js";
 import { buildTestApp, resetRateLimits } from "./helpers/build-test-app.js";
 import { testUtils, getTestPrismaClient } from "../setup.js";
 import {
@@ -27,7 +28,7 @@ const userAddress = userKeypair.publicKey();
 const makerAddress = makerKeypair.publicKey();
 
 /** Returns the two auth headers required by POST /v1/orders. */
-function authHeaders(
+async function authHeaders(
   keypair: Keypair,
   body: {
     marketId: string;
@@ -37,12 +38,17 @@ function authHeaders(
     price: number;
     quantity: number;
   }
-): Record<string, string> {
+): Promise<Record<string, string>> {
   const timestamp = Date.now();
+  const { nonce } = await issueChallenge(keypair.publicKey());
   const sig = keypair
-    .sign(buildSignableMessage({ ...body, timestamp }))
+    .sign(buildSignableMessage({ ...body, nonce, timestamp }))
     .toString("base64");
-  return { "x-signature": sig, "x-timestamp": String(timestamp) };
+  return {
+    "x-signature": sig,
+    "x-timestamp": String(timestamp),
+    "x-nonce": nonce,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -85,7 +91,7 @@ describe("POST /v1/orders — creation, validation, DB persistence", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, payload),
+      headers: await authHeaders(userKeypair, payload),
       payload,
     });
 
@@ -116,7 +122,7 @@ describe("POST /v1/orders — creation, validation, DB persistence", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, payload),
+      headers: await authHeaders(userKeypair, payload),
       payload,
     });
 
@@ -149,7 +155,7 @@ describe("POST /v1/orders — creation, validation, DB persistence", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, payload),
+      headers: await authHeaders(userKeypair, payload),
       payload,
     });
 
@@ -172,7 +178,7 @@ describe("POST /v1/orders — creation, validation, DB persistence", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, payload),
+      headers: await authHeaders(userKeypair, payload),
       payload,
     });
     expect(res.statusCode).toBe(400);
@@ -192,7 +198,7 @@ describe("POST /v1/orders — creation, validation, DB persistence", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, payload),
+      headers: await authHeaders(userKeypair, payload),
       payload,
     });
     expect(res.statusCode).toBe(400);
@@ -334,7 +340,7 @@ describe("GET /v1/orders/user/:address — listing and status filter", () => {
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, createPayload),
+      headers: await authHeaders(userKeypair, createPayload),
       payload: createPayload,
     });
 
@@ -438,7 +444,7 @@ describe("Integration Tests: POST /v1/orders with Matching", () => {
     const response = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, filledPayload),
+      headers: await authHeaders(userKeypair, filledPayload),
       payload: filledPayload,
     });
 
@@ -488,7 +494,7 @@ describe("Integration Tests: POST /v1/orders with Matching", () => {
     const response = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, partialPayload),
+      headers: await authHeaders(userKeypair, partialPayload),
       payload: partialPayload,
     });
 
@@ -526,7 +532,7 @@ describe("Integration Tests: POST /v1/orders with Matching", () => {
     const response = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, openPayload),
+      headers: await authHeaders(userKeypair, openPayload),
       payload: openPayload,
     });
 
@@ -570,7 +576,7 @@ describe("Integration Tests: POST /v1/orders with Matching", () => {
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, posPayload),
+      headers: await authHeaders(userKeypair, posPayload),
       payload: posPayload,
     });
 
@@ -615,7 +621,7 @@ describe("Integration Tests: POST /v1/orders with Matching", () => {
     const response = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, selfTradePayload),
+      headers: await authHeaders(userKeypair, selfTradePayload),
       payload: selfTradePayload,
     });
 
@@ -647,7 +653,7 @@ describe("Integration Tests: POST /v1/orders with Matching", () => {
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, settlementPayload),
+      headers: await authHeaders(userKeypair, settlementPayload),
       payload: settlementPayload,
     });
 
@@ -682,13 +688,13 @@ describe("Integration Tests: POST /v1/orders with Matching", () => {
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(userKeypair, concPayload1),
+        headers: await authHeaders(userKeypair, concPayload1),
         payload: concPayload1,
       }),
       app.inject({
         method: "POST",
         url: "/v1/orders",
-        headers: authHeaders(makerKeypair, concPayload2),
+        headers: await authHeaders(makerKeypair, concPayload2),
         payload: concPayload2,
       }),
     ]);
@@ -729,7 +735,7 @@ describe("Integration Tests: POST /v1/orders with Matching", () => {
     const response = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(userKeypair, rebuildPayload),
+      headers: await authHeaders(userKeypair, rebuildPayload),
       payload: rebuildPayload,
     });
 

--- a/tests/integration/settlement-queue.test.ts
+++ b/tests/integration/settlement-queue.test.ts
@@ -20,6 +20,7 @@ import { Keypair } from "@stellar/stellar-sdk";
 import Redis from "ioredis";
 import { ordersRoutes } from "../../src/api/routes/orders.js";
 import { buildSignableMessage } from "../../src/api/middleware/stellarAuth.js";
+import { issueChallenge } from "../../src/api/middleware/nonceStore.js";
 import { buildTestApp, resetRateLimits } from "./helpers/build-test-app.js";
 import { testUtils } from "../setup.js";
 import {
@@ -37,7 +38,7 @@ const sellerKeypair = Keypair.random();
 const buyerAddress = buyerKeypair.publicKey();
 const sellerAddress = sellerKeypair.publicKey();
 
-function authHeaders(
+async function authHeaders(
   keypair: Keypair,
   body: {
     marketId: string;
@@ -47,12 +48,17 @@ function authHeaders(
     price: number;
     quantity: number;
   }
-): Record<string, string> {
+): Promise<Record<string, string>> {
   const timestamp = Date.now();
+  const { nonce } = await issueChallenge(keypair.publicKey());
   const sig = keypair
-    .sign(buildSignableMessage({ ...body, timestamp }))
+    .sign(buildSignableMessage({ ...body, nonce, timestamp }))
     .toString("base64");
-  return { "x-signature": sig, "x-timestamp": String(timestamp) };
+  return {
+    "x-signature": sig,
+    "x-timestamp": String(timestamp),
+    "x-nonce": nonce,
+  };
 }
 
 describe("Settlement queue: producer writes to Redis stream on trade match", () => {
@@ -98,7 +104,7 @@ describe("Settlement queue: producer writes to Redis stream on trade match", () 
     await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(sellerKeypair, sellPayload),
+      headers: await authHeaders(sellerKeypair, sellPayload),
       payload: sellPayload,
     });
 
@@ -114,7 +120,7 @@ describe("Settlement queue: producer writes to Redis stream on trade match", () 
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(buyerKeypair, buyPayload),
+      headers: await authHeaders(buyerKeypair, buyPayload),
       payload: buyPayload,
     });
 
@@ -161,7 +167,7 @@ describe("Settlement queue: producer writes to Redis stream on trade match", () 
     const res = await app.inject({
       method: "POST",
       url: "/v1/orders",
-      headers: authHeaders(buyerKeypair, buyPayload),
+      headers: await authHeaders(buyerKeypair, buyPayload),
       payload: buyPayload,
     });
 


### PR DESCRIPTION
## Summary

- Add `POST /v1/auth/challenge` issuing a server nonce with TTL, stored in shared Redis (`auth:nonce:<address>:<nonce>`)
- Bind the nonce into the canonical signed message and require the `x-nonce` header; `verifyStellarSignature` consumes it atomically (single `DEL`) after the signature verifies, so replays across API replicas, expired challenges and concurrent double-submits fail closed with the existing 401 auth envelope
- Add `RedisService.delIfExists` for the atomic consume
- Update OpenAPI, route registry, api-versioning table, orders-route docs and `scripts/load-test-orders.ts` for the challenge flow; add ADR 002 covering challenge expiry, nonce TTL and key layout
- Table-driven unit tests for issue/consume/replay/expiry-boundary/concurrency; integration signing helpers updated to fetch a challenge

## Validation

- `vitest run src/api/middleware` — new nonce tests pass; two suites in that dir fail on a pre-existing `Cannot find module 'zod'` resolution error unrelated to this change
- `tsc --noEmit` — no new errors from the touched files (repo has pre-existing errors from a stale generated Prisma client and missing `zod`/`bullmq` deps)

Closes #871