### PR TITLE
Telemetry spans around indexer ingestion batch

### DIFF
--- a/apps/indexer/src/ingestion.ts
+++ b/apps/indexer/src/ingestion.ts
@@ -3,6 +3,8 @@ import type { CursorStorageClient } from "./storage.js";
 import type { InternalIndexerMetricsService } from "./metrics.js";
 import type { BatchWriter, BatchRecord } from "./batchWriter.js";
 import type { EventFetcher } from "./eventFetcher.js";
+import type { Telemetry } from "./telemetry.js";
+import { consoleTelemetry } from "./telemetry.js";
 import { parseTradeEvents } from "./tradeParser.js";
 import { parseResolutionEvents } from "./resolutionParser.js";
 import { parseCollateralDepositedEvents } from "./collateralDepositedParser.js";
@@ -37,6 +39,7 @@ export interface IngestionDependencies {
   gapPauseThreshold?: number;
   /** @see GapDetectorConfig.backfillMaxLedgers */
   backfillMaxLedgers?: number;
+  telemetry?: Telemetry;
 }
 
 interface IngestionBatchResult {
@@ -72,6 +75,9 @@ export class PollingIngestionLoop implements IngestionLoop {
   /** GapDetector wired in for all ingestion ticks. */
   private readonly gapDetector: GapDetector;
 
+  /** Emits spans for the fetch/parse/write stages of each ingestion batch. */
+  private readonly telemetry: Telemetry;
+
   constructor(
     private readonly logger: ILogger,
     private readonly storage: CursorStorageClient,
@@ -80,6 +86,7 @@ export class PollingIngestionLoop implements IngestionLoop {
     private readonly checkpointFlushEveryBatches: number,
     private readonly deps: IngestionDependencies
   ) {
+    this.telemetry = deps.telemetry ?? consoleTelemetry;
     this.gapDetector = new GapDetector(
       {
         gapPauseThreshold: deps.gapPauseThreshold ?? 1000,
@@ -328,11 +335,15 @@ export class PollingIngestionLoop implements IngestionLoop {
     const startLedger = safeCurrentSequence + 1;
     const provisionalEnd = startLedger + this.deps.ledgerWindowSize - 1;
 
+    const fetchSpan = this.telemetry.startSpan("indexer.ingestion.fetch", {
+      contractId: this.deps.contractId,
+    });
     const { events, latestLedger } =
       await this.deps.eventFetcher.fetchByLedgerWindow({
         startLedger,
         endLedger: provisionalEnd,
       });
+    fetchSpan.end({ eventCount: String(events.length) });
 
     // Track the latest network ledger for lag computation (Issue #713)
     if (latestLedger > 0) {
@@ -454,12 +465,21 @@ export class PollingIngestionLoop implements IngestionLoop {
       }
     }
 
+    const parseSpan = this.telemetry.startSpan("indexer.ingestion.parse", {
+      contractId: this.deps.contractId,
+    });
     const { trades, errors: tradeErrors } = parseTradeEvents(events);
     const { resolutions, errors: resolutionErrors } =
       parseResolutionEvents(events);
     const { deposits, errors: depositErrors } =
       parseCollateralDepositedEvents(events);
     const { markets, errors: marketErrors } = parseMarketCreatedEvents(events);
+    parseSpan.end({
+      trades: String(trades.length),
+      resolutions: String(resolutions.length),
+      deposits: String(deposits.length),
+      markets: String(markets.length),
+    });
 
     for (const error of tradeErrors) {
       this.logger.warn("Trade parse error — skipping event", {
@@ -533,7 +553,15 @@ export class PollingIngestionLoop implements IngestionLoop {
       })),
     ];
 
+    const writeSpan = this.telemetry.startSpan("indexer.ingestion.write", {
+      contractId: this.deps.contractId,
+    });
     const writeResult = await this.deps.batchWriter.write(records);
+    writeSpan.end({
+      written: String(writeResult.written),
+      skipped: String(writeResult.skipped),
+      errors: String(writeResult.errors.length),
+    });
 
     if (writeResult.errors.length > 0) {
       this.logger.warn("Indexer batch write completed with errors", {

--- a/apps/indexer/src/telemetry.ts
+++ b/apps/indexer/src/telemetry.ts
@@ -1,10 +1,29 @@
+export interface Span {
+  end(tags?: Record<string, string>): void;
+}
+
 export interface Telemetry {
   record(metric: string, value: number, tags?: Record<string, string>): void;
+  /** Starts a span for a named stage; call `.end()` when the stage completes. */
+  startSpan(name: string, tags?: Record<string, string>): Span;
 }
 
 export const consoleTelemetry: Telemetry = {
   record(metric, value, tags) {
     const tagStr = tags ? ` ${JSON.stringify(tags)}` : "";
     console.log(`[telemetry] ${metric}=${value}${tagStr}`);
+  },
+  startSpan(name, startTags) {
+    const startedAt = performance.now();
+    return {
+      end(endTags) {
+        const durationMs = performance.now() - startedAt;
+        const tags = { ...startTags, ...endTags };
+        const tagStr = Object.keys(tags).length ? ` ${JSON.stringify(tags)}` : "";
+        console.log(
+          `[telemetry] span ${name} duration_ms=${durationMs.toFixed(2)}${tagStr}`
+        );
+      },
+    };
   },
 };

--- a/docs/indexer-telemetry.md
+++ b/docs/indexer-telemetry.md
@@ -1,0 +1,21 @@
+# Indexer Telemetry: Metrics vs. Traces
+
+The indexer emits two distinct kinds of telemetry via `Telemetry` in
+[`apps/indexer/src/telemetry.ts`](../apps/indexer/src/telemetry.ts):
+
+- **Metrics** (`telemetry.record(name, value, tags)`): point-in-time counters
+  and gauges (e.g. `indexer.events.fetched`, `indexer.rpc.error`). Use these
+  for alerting thresholds and dashboards aggregated over time.
+- **Traces** (`telemetry.startSpan(name, tags)` / `span.end(tags)`): duration
+  spans around a unit of work. Each ingestion batch tick in
+  [`PollingIngestionLoop.ingestFromCursor`](../apps/indexer/src/ingestion.ts)
+  emits three spans:
+  - `indexer.ingestion.fetch` — time spent fetching the ledger window from RPC.
+  - `indexer.ingestion.parse` — time spent parsing fetched events into typed records.
+  - `indexer.ingestion.write` — time spent writing the batch via `BatchWriter`.
+
+  Use spans to answer "which stage is slow?" for a given batch; use metrics
+  to answer "how many/how often?" across batches over time.
+
+The default `consoleTelemetry` implementation logs both to stdout; swap in
+another `Telemetry` implementation to forward to an APM/tracing backend.


### PR DESCRIPTION
## Summary
Adds tracing spans around the indexer's ingestion batch stages so slow batches can be diagnosed stage-by-stage instead of only aggregate metrics.

- Extended `Telemetry` (`apps/indexer/src/telemetry.ts`) with `startSpan(name, tags)` / `span.end(tags)`, implemented in `consoleTelemetry` using `performance.now()` for duration.
- Instrumented `PollingIngestionLoop.ingestFromCursor` (`apps/indexer/src/ingestion.ts`) with three spans: `indexer.ingestion.fetch`, `indexer.ingestion.parse`, `indexer.ingestion.write`, each tagged with counts (events fetched, records per type, written/skipped/errors).
- `telemetry` is now an optional field on `IngestionDependencies`, defaulting to `consoleTelemetry`, so no existing call sites needed changes.

## Context / before-after
Before: only point-in-time metrics (e.g. `indexer.events.fetched`) existed — no way to see which stage of a batch (RPC fetch vs. parsing vs. DB write) is slow.
After: each batch tick emits duration spans for all three stages, logged via `consoleTelemetry` by default and swappable for a real tracing backend.

Added `docs/indexer-telemetry.md` documenting the metrics-vs-traces distinction and when to use each.

## Testing
No dependencies were installed in this environment, so the suite couldn't be run here — changes were reviewed manually for type/behavior correctness against the existing `Telemetry`/`ingestion.ts` call patterns. Please run `pnpm vitest apps/indexer/src/ingestion.test.ts` in CI/locally to confirm.

Closes #815