### PR TITLE
Integration test helper seeds market and places order

### DIFF
--- a/tests/integration/helpers/market-order.ts
+++ b/tests/integration/helpers/market-order.ts
@@ -1,0 +1,47 @@
+import type { FastifyInstance } from "fastify";
+import { Keypair } from "@stellar/stellar-sdk";
+import { buildSignableMessage } from "../../../src/api/middleware/stellarAuth.js";
+import { issueChallenge } from "../../../src/api/middleware/nonceStore.js";
+import { testUtils, type TestMarketOverrides } from "../../setup.js";
+
+/** Seeds an ACTIVE test market unless overridden. Thin wrapper around testUtils.createTestMarket. */
+export async function seedMarket(overrides: TestMarketOverrides = {}) {
+  return testUtils.createTestMarket({ status: "ACTIVE", ...overrides });
+}
+
+export interface PlaceOrderInput {
+  marketId: string;
+  side: "BUY" | "SELL";
+  outcome: "YES" | "NO";
+  price: number;
+  quantity: number;
+}
+
+/**
+ * Places an order against a Fastify app that has ordersRoutes registered,
+ * signing the request with the given keypair. Returns the raw inject response.
+ */
+export async function placeOrder(
+  app: FastifyInstance,
+  keypair: Keypair,
+  input: PlaceOrderInput
+) {
+  const userAddress = keypair.publicKey();
+  const payload = { ...input, userAddress };
+  const timestamp = Date.now();
+  const { nonce } = await issueChallenge(userAddress);
+  const signature = keypair
+    .sign(buildSignableMessage({ ...payload, nonce, timestamp }))
+    .toString("base64");
+
+  return app.inject({
+    method: "POST",
+    url: "/v1/orders",
+    headers: {
+      "x-signature": signature,
+      "x-timestamp": String(timestamp),
+      "x-nonce": nonce,
+    },
+    payload,
+  });
+}

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -13,6 +13,7 @@ import { ordersRoutes } from "../../src/api/routes/orders.js";
 import { buildSignableMessage } from "../../src/api/middleware/stellarAuth.js";
 import { issueChallenge } from "../../src/api/middleware/nonceStore.js";
 import { buildTestApp, resetRateLimits } from "./helpers/build-test-app.js";
+import { seedMarket, placeOrder } from "./helpers/market-order.js";
 import { testUtils, getTestPrismaClient } from "../setup.js";
 import {
   acquireDatabaseLock,
@@ -78,21 +79,14 @@ describe("POST /v1/orders — creation, validation, DB persistence", () => {
   });
 
   it("returns 201 with order.id and status: OPEN for a valid payload on an ACTIVE market", async () => {
-    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+    const market = await seedMarket();
 
-    const payload = {
+    const res = await placeOrder(app, userKeypair, {
       marketId: market.id,
-      userAddress,
       side: "BUY",
       outcome: "YES",
       price: 0.5,
       quantity: 10,
-    };
-    const res = await app.inject({
-      method: "POST",
-      url: "/v1/orders",
-      headers: await authHeaders(userKeypair, payload),
-      payload,
     });
 
     expect(res.statusCode).toBe(201);


### PR DESCRIPTION
## Summary
Adds reusable integration-test helpers for the common "seed a market, place an order" setup, so tests stop re-deriving auth headers and market fixtures inline.

- New `tests/integration/helpers/market-order.ts`:
  - `seedMarket(overrides?)` — thin wrapper around `testUtils.createTestMarket` defaulting to `status: "ACTIVE"`.
  - `placeOrder(app, keypair, input)` — builds the `x-signature`/`x-timestamp`/`x-nonce` auth headers (nonce challenge + Ed25519 signature) and POSTs to `/v1/orders`, returning the raw inject response.
- Migrated the first case in `tests/integration/orders.test.ts` ("returns 201 with order.id and status: OPEN...") to use both helpers in place of the inline `testUtils.createTestMarket` + `authHeaders` + `app.inject` boilerplate.

## Context / before-after
Before: every integration test that needed an order built its own market fixture and manually assembled signed-request headers via a local `authHeaders` closure.
After: `seedMarket`/`placeOrder` centralize that logic for reuse across `tests/integration/*`. Behavior of the migrated test is unchanged — same assertions, same request shape.

## Testing
No dependencies were installed in this environment (kept minimal per task scope), so the suite couldn't be executed here. The helper mirrors the exact pattern already used and verified elsewhere in `orders.test.ts` (`authHeaders` + `buildSignableMessage` + `issueChallenge`), and the migrated test's assertions are untouched. Please run `pnpm vitest tests/integration/orders.test.ts` to confirm locally/in CI.

Closes #814