### PR TITLE
Verify non-root user in CI image smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,3 +231,50 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  docker-image-smoke:
+    name: Docker image non-root smoke test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build API image
+        run: docker build --target api -t vatix-backend-api:ci .
+
+      - name: Build indexer image
+        run: docker build --target indexer -t vatix-backend-indexer:ci .
+
+      - name: Verify API image runs as non-root
+        run: |
+          uid=$(docker run --rm vatix-backend-api:ci id -u)
+          echo "api container uid: $uid"
+          test "$uid" -ne 0
+
+      - name: Verify indexer image runs as non-root
+        run: |
+          uid=$(docker run --rm vatix-backend-indexer:ci id -u)
+          echo "indexer container uid: $uid"
+          test "$uid" -ne 0
+
+      - name: Start postgres/redis via compose
+        run: docker compose up -d postgres redis
+
+      - name: Wait for postgres/redis healthchecks
+        run: |
+          for i in $(seq 1 30); do
+            pg_status=$(docker inspect --format='{{.State.Health.Status}}' $(docker compose ps -q postgres))
+            redis_status=$(docker inspect --format='{{.State.Health.Status}}' $(docker compose ps -q redis))
+            echo "postgres=$pg_status redis=$redis_status"
+            if [ "$pg_status" = "healthy" ] && [ "$redis_status" = "healthy" ]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Timed out waiting for healthchecks"
+          exit 1
+
+      - name: Tear down compose stack
+        if: always()
+        run: docker compose down -v

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -30,6 +30,13 @@ commands like `docker logs vatix-indexer` work as documented there.
 default — this preserves the original host-run development workflow below.
 Every application process lives behind a profile so you opt in explicitly.
 
+All application images (`api`, `indexer`, `finalization-worker`,
+`oracle-worker`, `settlement-worker`) run as the non-root `vatix` user
+(uid/gid `1001`), set in the Dockerfile `runtime` stage. CI's
+`docker-image-smoke` job builds the `api` and `indexer` images and asserts
+`id -u` inside each container is non-zero, then confirms `postgres`/`redis`
+healthchecks still pass with the stack up.
+
 ## Option A — Data layer only (host-run development)
 
 This is the original workflow: run infra in containers, run the app processes


### PR DESCRIPTION
## Summary
The Dockerfile's `runtime` stage already creates and switches to a non-root `vatix` user (uid/gid 1001) for every application image (ties to #737), but nothing in CI verified this held for the built images. Adds a `docker-image-smoke` CI job that builds the `api` and `indexer` images and asserts each runs as non-root, and confirms `postgres`/`redis` healthchecks still pass with the stack up.

## Context / before-after
Before: non-root `USER vatix` was set in the Dockerfile but unverified by CI — a future change could silently reintroduce a root-running image without any check failing.
After: `.github/workflows/ci.yml` gets a new `docker-image-smoke` job:
- Builds `api` and `indexer` targets.
- Runs `id -u` inside each container and fails if uid is `0`.
- Brings up `postgres`/`redis` via `docker compose` and polls their healthchecks, failing after ~60s if either doesn't report `healthy`.
- Tears the stack down (`docker compose down -v`) even on failure.

Documented in `docs/docker-compose.md` under the Services section.

## Testing
Docker/CI runners weren't available in this environment (kept minimal per task scope — no dependency installs), so the job wasn't executed locally. It was modeled closely on the existing Dockerfile comments (build targets, non-root `vatix` user) and the compose file's existing `postgres`/`redis` healthcheck definitions. Please confirm the `docker-image-smoke` job passes on the actual CI runner.

Closes #813