### PR TITLE
Trades traded_at index used by recent-trades query

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -154,7 +154,13 @@ CLOB-engine trade records. Written atomically with order fills; `trade_id` is th
 | `traded_at`      | `DateTime`      | When the trade occurred          |
 | `created_at`     | `DateTime`      | Auto-set on insert               |
 
-Indexes: `market_id`, `buyer_address`, `seller_address`, `(buyer_address, traded_at DESC)`, `(seller_address, traded_at DESC)`
+Indexes: `market_id`, `buyer_address`, `seller_address`, `(buyer_address, traded_at DESC)`, `(seller_address, traded_at DESC)`, `(traded_at DESC)`, `settlement_status`
+
+The unfiltered `(traded_at DESC)` index (`trades_traded_at_idx`) backs
+`AuditService.getTradeHistory`'s recent-trades query (`ORDER BY traded_at DESC`
+with no wallet filter). See
+[`tests/integration/trades-index.test.ts`](../tests/integration/trades-index.test.ts)
+for an `EXPLAIN`-based assertion that this index is used.
 
 ### `IndexedTrade`
 

--- a/tests/integration/trades-index.test.ts
+++ b/tests/integration/trades-index.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { getTestPrismaClient, testUtils } from "../setup.js";
+import {
+  acquireDatabaseLock,
+  releaseDatabaseLock,
+} from "../helpers/test-database.js";
+
+/**
+ * Verifies the assumption behind the recent-trades query (AuditService.getTradeHistory,
+ * `ORDER BY traded_at DESC` with no filter): that it can be served by the
+ * `@@index([tradedAt(sort: Desc)])` index on Trade (Postgres name: trades_traded_at_idx)
+ * rather than a full table scan. `enable_seqscan` is forced off so the assertion
+ * reflects index availability/usability rather than the planner's cost heuristic
+ * on a small fixture table.
+ */
+describe("recent-trades query uses the traded_at index", () => {
+  const prisma = getTestPrismaClient();
+
+  beforeAll(async () => {
+    await acquireDatabaseLock();
+  });
+
+  afterAll(async () => {
+    await releaseDatabaseLock();
+  });
+
+  it("plans an index scan on trades_traded_at_idx for unfiltered ORDER BY traded_at DESC", async () => {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+    const rows = Array.from({ length: 20 }, (_, i) => ({
+      tradeId: `idx-verify-${i}`,
+      marketId: market.id,
+      outcome: "YES",
+      buyerAddress: "G" + "B".repeat(55),
+      sellerAddress: "G" + "S".repeat(55),
+      buyOrderId: `idx-buy-${i}`,
+      sellOrderId: `idx-sell-${i}`,
+      price: 0.5,
+      quantity: 1,
+      tradedAt: new Date(Date.now() - i * 1000),
+    }));
+    await prisma.trade.createMany({ data: rows });
+
+    const plan = await prisma.$transaction(async (tx) => {
+      await tx.$executeRawUnsafe(`SET LOCAL enable_seqscan = off`);
+      return tx.$queryRawUnsafe<Array<Record<string, unknown>>>(
+        `EXPLAIN (FORMAT JSON) SELECT * FROM trades ORDER BY traded_at DESC LIMIT 20`
+      );
+    });
+
+    const planJson = JSON.stringify(plan);
+    expect(planJson).toContain("trades_traded_at_idx");
+  });
+});


### PR DESCRIPTION
## Summary
Verifies the assumption that the unfiltered recent-trades query (`AuditService.getTradeHistory` in `src/services/audit.ts:287`, `ORDER BY traded_at DESC` with no wallet/market filter) is actually served by the `@@index([tradedAt(sort: Desc)])` index on `Trade` (Postgres name `trades_traded_at_idx`), rather than a full table scan.

- Added `tests/integration/trades-index.test.ts`: seeds 20 trade rows, runs `EXPLAIN (FORMAT JSON) SELECT * FROM trades ORDER BY traded_at DESC LIMIT 20` inside a transaction with `SET LOCAL enable_seqscan = off`, and asserts the plan references `trades_traded_at_idx`. Forcing `enable_seqscan` off tests index *usability* for this query shape rather than the planner's cost heuristic on a small fixture table (which would otherwise happily pick a seq scan on 20 rows regardless of the index).
- Updated `docs/schema.md`'s `Trade` section, which was missing two indexes already present in `prisma/schema.prisma` (the plain `(traded_at DESC)` index and the `settlement_status` index), and added a pointer to the new test.

## Context
`Trade` has multiple `tradedAt`-related indexes: `(buyer_address, traded_at DESC)`, `(seller_address, traded_at DESC)`, and the plain `(traded_at DESC)`. Only the last one is relevant to the *unfiltered* recent-trades path; this PR confirms that specific index is the one actually usable for that query.

## Testing
No dependencies were installed in this environment (kept minimal per task scope), so this couldn't be run against a live Postgres here. The query and `EXPLAIN` approach were reviewed manually against `prisma/schema.prisma`'s index definitions and Prisma's default Postgres index-naming convention (`<table>_<column>_idx`). Please run `pnpm vitest tests/integration/trades-index.test.ts` against the CI Postgres service to confirm.

Closes #796