### PR TITLE
Add k6 script stub for order placement soak test

### DIFF
--- a/scripts/load/README.md
+++ b/scripts/load/README.md
@@ -1,0 +1,26 @@
+# Load Scripts (k6)
+
+k6 stubs for load/soak testing. These are separate from `scripts/load-test-orders.ts`
+(the existing signed tsx load tool) — this directory holds k6-based stubs.
+
+## ⚠️ Local use only
+
+- Never point these at a staging or production URL.
+- `order-placement-soak.js` refuses to run unless `BASE_URL` contains
+  `localhost`, `127.0.0.1`, or `api` (the docker-compose service name).
+- Run only against your local `docker-compose` stack.
+
+## Prerequisites
+
+- [k6](https://k6.io/docs/get-started/installation/) installed locally (not bundled as a project dependency).
+- The API running locally: `docker compose --profile api up` or `pnpm dev`.
+- At least one `ACTIVE` market (`pnpm prisma:seed`), passed via `-e MARKET_ID=<id>`.
+
+## Run
+
+```bash
+k6 run scripts/load/order-placement-soak.js
+k6 run -e BASE_URL=http://localhost:3000 -e MARKET_ID=<id> scripts/load/order-placement-soak.js
+```
+
+Target: 100 rps order placement against `POST /v1/orders` for a 30s soak window.

--- a/scripts/load/order-placement-soak.js
+++ b/scripts/load/order-placement-soak.js
@@ -1,0 +1,63 @@
+// k6 stub — order placement soak test (#807, ties to #730)
+//
+// ⚠️  LOCAL USE ONLY. Do NOT point this at a staging/production URL — see
+// scripts/load/README.md. This is a stub: it exercises POST /v1/orders at a
+// steady rate against the local docker-compose stack. It does not yet sign
+// requests with a real Stellar keypair (see scripts/load-test-orders.ts for
+// that flow) — fill in AUTH_HEADER / MARKET_ID before running against an
+// environment that enforces auth.
+//
+// Run:
+//   k6 run scripts/load/order-placement-soak.js
+//   k6 run -e BASE_URL=http://localhost:3000 -e MARKET_ID=<id> scripts/load/order-placement-soak.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+const MARKET_ID = __ENV.MARKET_ID || "";
+const AUTH_HEADER = __ENV.AUTH_HEADER || "";
+
+// Guardrail: refuse anything that isn't clearly a local target.
+const ALLOWED_HOSTS = ["localhost", "127.0.0.1", "api"];
+if (!ALLOWED_HOSTS.some((h) => BASE_URL.includes(h))) {
+  throw new Error(
+    `Refusing to run against non-local BASE_URL="${BASE_URL}". ` +
+      `This script is for local soak testing only — see scripts/load/README.md.`
+  );
+}
+
+export const options = {
+  scenarios: {
+    order_placement_soak: {
+      executor: "constant-arrival-rate",
+      rate: 100, // target: 100 rps
+      timeUnit: "1s",
+      duration: "30s",
+      preAllocatedVUs: 50,
+      maxVUs: 200,
+    },
+  },
+};
+
+export default function () {
+  const side = Math.random() < 0.5 ? "BUY" : "SELL";
+  const payload = JSON.stringify({
+    marketId: MARKET_ID,
+    outcome: "YES",
+    side,
+    price: 0.5,
+    quantity: 10,
+  });
+
+  const headers = { "Content-Type": "application/json" };
+  if (AUTH_HEADER) headers["Authorization"] = AUTH_HEADER;
+
+  const res = http.post(`${BASE_URL}/v1/orders`, payload, { headers });
+
+  check(res, {
+    "status is not 5xx": (r) => r.status < 500,
+  });
+
+  sleep(0.01);
+}


### PR DESCRIPTION
## Summary
Adds a k6 script stub targeting ~100 rps order placement against `POST /v1/orders`, for local soak testing (ties to #730).

## Context
This complements the existing `scripts/load-test-orders.ts` (signed tsx load tool) with a k6-based option under `scripts/load/`. The script includes a hard local-only guardrail (refuses to run unless `BASE_URL` resolves to localhost/127.0.0.1/the compose `api` service) and a `constant-arrival-rate` executor set to 100 rps for a 30s soak window.

## Testing
- k6 is not bundled as a project dependency (per task constraints, no dependencies were installed); the script was reviewed for syntax correctness against k6's documented API (`k6/http`, `check`, `options.scenarios`) rather than executed locally.
- `scripts/load/README.md` documents prerequisites, the local-only guardrail, and exact run commands.

Closes #807