### PR TITLE
Document recommended Prisma pool sizes by environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,13 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5433/vatix
 # Falls back to DATABASE_URL when unset. Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE
 ANALYTICS_DATABASE_URL=
 
+# Optional: Max connections in the pg.Pool backing the Prisma adapter (#806).
+# Recommended defaults (tune based on DB max_connections and instance count):
+#   development / test : 5
+#   staging             : 10
+#   production          : 20-50 (must be < Postgres max_connections / number of API instances)
+DATABASE_POOL_SIZE=10
+
 # -----------------------------------------------------------------------------
 # Matching Engine
 # -----------------------------------------------------------------------------

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,12 @@ export const config = {
    */
   databaseUrl: env.DATABASE_URL,
   /**
+   * Max connections in the pg.Pool backing the Prisma adapter (#806).
+   * Configured via DATABASE_POOL_SIZE (default: 10). See .env.example for
+   * recommended values per environment.
+   */
+  databasePoolSize: env.DATABASE_POOL_SIZE,
+  /**
    * Read-only PostgreSQL connection string for analytics/reporting queries (#743).
    * Intended to point at a read replica so heavy analytical queries don't
    * compete with the primary's write/OLTP workload.

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -65,6 +65,30 @@ describe("parseApiEnv", () => {
   });
 });
 
+describe("parseApiEnv — DATABASE_POOL_SIZE (#806)", () => {
+  it("defaults to 10 when omitted", () => {
+    const env = parseApiEnv(VALID_ENV);
+    expect(env.DATABASE_POOL_SIZE).toBe(10);
+  });
+
+  it("parses a configured pool size", () => {
+    const env = parseApiEnv({ ...VALID_ENV, DATABASE_POOL_SIZE: "25" });
+    expect(env.DATABASE_POOL_SIZE).toBe(25);
+  });
+
+  it("throws on non-integer DATABASE_POOL_SIZE", () => {
+    expect(() =>
+      parseApiEnv({ ...VALID_ENV, DATABASE_POOL_SIZE: "abc" })
+    ).toThrow("DATABASE_POOL_SIZE");
+  });
+
+  it("throws on DATABASE_POOL_SIZE below minimum (1)", () => {
+    expect(() =>
+      parseApiEnv({ ...VALID_ENV, DATABASE_POOL_SIZE: "0" })
+    ).toThrow("DATABASE_POOL_SIZE");
+  });
+});
+
 describe("parseApiEnv — MATCHING_ENGINE_ENABLED (#744)", () => {
   it("defaults to true when omitted", () => {
     const env = parseApiEnv(VALID_ENV);

--- a/src/env.ts
+++ b/src/env.ts
@@ -92,6 +92,11 @@ export const apiEnvSchema = z.object({
       .default(3000)
   ),
   DATABASE_URL: postgresUrlSchema,
+  /**
+   * Max size of the pg.Pool used by the Prisma adapter (#806, ties to #742).
+   * Recommended defaults documented in .env.example — tune per environment.
+   */
+  DATABASE_POOL_SIZE: positiveInt("DATABASE_POOL_SIZE").default(10),
   ORACLE_CHALLENGE_WINDOW_SECONDS: positiveInt(
     "ORACLE_CHALLENGE_WINDOW_SECONDS"
   ).default(86400),

--- a/src/services/prisma.ts
+++ b/src/services/prisma.ts
@@ -21,7 +21,10 @@ export function getPrismaClient(): PrismaClient {
     const isProduction = config.nodeEnv === "production";
 
     // create postgres connection pool — URL already validated at startup via config
-    pgPool = new Pool({ connectionString: config.databaseUrl });
+    pgPool = new Pool({
+      connectionString: config.databaseUrl,
+      max: config.databasePoolSize,
+    });
     const adapter = new PrismaPg(pgPool);
 
     prismaInstance = new PrismaClient({


### PR DESCRIPTION
## Summary
Makes the pg.Pool size backing the Prisma adapter configurable via a new `DATABASE_POOL_SIZE` env var (default: 10), and documents recommended values per environment (ties to #742).

## Context
`src/services/prisma.ts` previously created the `pg.Pool` with no `max` set, relying on the driver's implicit default regardless of environment. Production needs a larger pool than dev/test, and CI-safety requires validated parsing.

**Before:** `new Pool({ connectionString: config.databaseUrl })` — pool size not configurable.
**After:** `new Pool({ connectionString: config.databaseUrl, max: config.databasePoolSize })`, sourced from `DATABASE_POOL_SIZE` (validated via the existing `positiveInt` Zod helper in `src/env.ts`, default 10).

`.env.example` documents recommended values:
- development/test: 5
- staging: 10
- production: 20-50 (must stay under Postgres `max_connections` / number of API instances)

## Testing
- Added parse tests in `src/env.test.ts` (`parseApiEnv — DATABASE_POOL_SIZE (#806)`): default value, valid override, non-integer rejection, below-minimum rejection.
- Dependencies were not installed locally per task constraints, so tests were reviewed for correctness against the existing `positiveInt`/PORT test pattern rather than executed; CI will run the full suite.

Closes #806