### PR TITLE
Hide internal admin routes from public Swagger in prod

### DIFF
--- a/src/api/openapi.test.ts
+++ b/src/api/openapi.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import type { FastifyInstance } from "fastify";
-import { openApiSpec } from "./openapi.js";
+import { openApiSpec, getOpenApiSpec } from "./openapi.js";
 
 vi.hoisted(() => {
   process.env.DATABASE_URL =
@@ -224,5 +224,41 @@ describe("OpenAPI contract", () => {
       totalDocumented,
       "OpenAPI spec should document all public API routes"
     ).toBeGreaterThan(0);
+  });
+});
+
+describe("getOpenApiSpec — Admin route visibility by environment (#805)", () => {
+  const adminPaths = Object.entries(openApiSpec.paths).filter(([, item]) =>
+    Object.values(item).some(
+      (op) =>
+        op &&
+        typeof op === "object" &&
+        "tags" in op &&
+        (op as { tags?: readonly string[] }).tags?.includes("Admin")
+    )
+  );
+
+  it("has at least one Admin-tagged path in the source spec", () => {
+    expect(adminPaths.length).toBeGreaterThan(0);
+  });
+
+  it("includes Admin routes for non-production environments", () => {
+    const spec = getOpenApiSpec("development");
+    for (const [path] of adminPaths) {
+      expect(spec.paths).toHaveProperty(path);
+    }
+  });
+
+  it("strips Admin routes in production", () => {
+    const spec = getOpenApiSpec("production");
+    for (const [path] of adminPaths) {
+      expect(spec.paths).not.toHaveProperty(path);
+    }
+  });
+
+  it("keeps non-Admin routes in production", () => {
+    const spec = getOpenApiSpec("production");
+    expect(spec.paths).toHaveProperty("/v1/markets");
+    expect(spec.paths).toHaveProperty("/v1/orders");
   });
 });

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -904,3 +904,31 @@ export const openApiSpec = {
     },
   },
 } as const;
+
+/**
+ * Returns the OpenAPI spec served to clients. In production, paths tagged
+ * "Admin" (internal-only endpoints) are stripped so they never appear in
+ * the public /docs Swagger UI or /v1/openapi.json response — reducing the
+ * discoverable surface area for internal admin routes (#805, ties to #741).
+ * Non-production environments continue to see the full spec, including
+ * Admin routes, for local/dev testing.
+ */
+export function getOpenApiSpec(nodeEnv: string): typeof openApiSpec {
+  if (nodeEnv !== "production") {
+    return openApiSpec;
+  }
+
+  const publicPaths = Object.fromEntries(
+    Object.entries(openApiSpec.paths).filter(([, pathItem]) => {
+      const operations = Object.values(pathItem) as Array<{
+        tags?: readonly string[];
+      }>;
+      return !operations.some((op) => op?.tags?.includes("Admin"));
+    })
+  );
+
+  return {
+    ...openApiSpec,
+    paths: publicPaths,
+  } as typeof openApiSpec;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { readyRoute } from "./api/routes/ready.js";
 import { metricsRoutes } from "./api/routes/metrics.js";
 import { createReadyDeps } from "./api/deps/ready-deps.js";
 import { registerDeprecatedAliases } from "./api/routes/legacy.js";
-import { openApiSpec } from "./api/openapi.js";
+import { getOpenApiSpec } from "./api/openapi.js";
 import { rateLimiter } from "./api/middleware/rateLimiter.js";
 import { requestLogger } from "./api/middleware/logger.js";
 import {
@@ -142,7 +142,8 @@ export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
       await v1.register(readyRoute(options.readyDeps ?? createReadyDeps()));
 
       v1.get("/openapi.json", async (_request, reply) => {
-        return reply.status(200).send(openApiSpec);
+        const nodeEnv = process.env.NODE_ENV || "development";
+        return reply.status(200).send(getOpenApiSpec(nodeEnv));
       });
     },
     { prefix: "/v1" }


### PR DESCRIPTION
## Summary
Strips `Admin`-tagged paths from the `/v1/openapi.json` response (and therefore the `/docs` Swagger UI, which loads its spec from that endpoint) when `NODE_ENV=production` (ties to #741).

## Context
Routes were already correctly tagged (`Admin` for `/v1/admin/markets`, `/v1/admin/markets/{id}/status`, `/v1/admin/analytics/summary`; specific public tags like `Markets`/`Orders`/`Trades`/`Positions`/`Wallet`/`Auth`/`Health` elsewhere) — the gap was that `/v1/openapi.json` always served the full spec regardless of environment, so internal admin routes were fully discoverable in production Swagger.

**Before:** `v1.get("/openapi.json", ...)` always returned the complete `openApiSpec`, including all 3 Admin paths, in every environment.
**After:** added `getOpenApiSpec(nodeEnv)` in `src/api/openapi.ts`, which returns the full spec unchanged for non-production, and a copy with any path containing an operation tagged `"Admin"` removed when `nodeEnv === "production"`. `src/index.ts` now calls this with `process.env.NODE_ENV` instead of serving the raw spec object.

Public/non-admin paths are unaffected in every environment; only production's public-facing spec changes shape (3 fewer paths).

## Testing
Added `describe("getOpenApiSpec — Admin route visibility by environment (#805)")` in `src/api/openapi.test.ts`:
- confirms the source spec still has Admin-tagged paths
- `getOpenApiSpec("development")` retains all Admin paths
- `getOpenApiSpec("production")` removes all Admin paths
- `getOpenApiSpec("production")` still includes non-admin paths (`/v1/markets`, `/v1/orders`)

Dependencies were not installed locally per task constraints, so this wasn't executed against a live `vitest` run; CI will run the full suite. Existing `openApiSpec` export and its consumers (`openapi.test.ts` contract tests, `/v1/openapi.json` structure) are unchanged/unaffected.

Closes #805