### PR TITLE
Make finalization and challenge mutually exclusive with row-level loc…

### DIFF
--- a/apps/workers/README.md
+++ b/apps/workers/README.md
@@ -40,6 +40,42 @@ Polls for `ResolutionCandidate` rows that have passed the challenge window and p
 | `FINALIZATION_CHALLENGE_WINDOW_SECONDS` | `3600`  | How long (seconds) a candidate must be in `PROPOSED` status before it can be finalized. |
 | `FINALIZATION_LOG_LEVEL`                | `info`  | Log verbosity: `debug` \| `info` \| `warn` \| `error`.                                  |
 
+#### Finalize / challenge mutual exclusion (locking order)
+
+A `ResolutionCandidate` has exactly one legal winner: it is either finalized
+(`PROPOSED` → `ACCEPTED`, with a `Resolution` row created) or challenged
+(`PROPOSED` → `CHALLENGED`, no `Resolution` row). Without DB-level locking, a
+challenge write racing the finalization tick could commit _after_ the
+finalize transaction had already read `status: PROPOSED` but before it
+wrote `ACCEPTED` — finalizing a market that was in fact disputed, or leaving
+a `Resolution` row for a candidate that ends up `CHALLENGED`.
+
+Both writers avoid this the same way, via `apps/workers/src/finalization/resolutionLock.ts`:
+
+1. Open a DB transaction.
+2. `SELECT id, status FROM resolution_candidates WHERE id = $1 FOR UPDATE` —
+   locks the single candidate row for the rest of the transaction. Postgres
+   blocks a second transaction's `FOR UPDATE` on the same row until the
+   first commits or rolls back, so this is what actually serializes the two
+   writers — the outer `challengeWindowSeconds` check is only a pre-filter,
+   not the safety mechanism.
+3. Re-check the locked row's `status === "PROPOSED"` _inside_ the
+   transaction. If it isn't (a concurrent writer already committed), abort:
+   finalize marks the candidate `skipped`; challenge throws
+   `IllegalChallengeTransitionError`.
+4. Only if the recheck passes, write the transition (`Resolution` + market +
+   candidate status for finalize; candidate status for challenge) and a
+   `ResolutionAuditLog` row (`action: "FINALIZE" | "CHALLENGE"`) in the same
+   transaction, then commit.
+
+Neither path locks any other table before locking `resolution_candidates`,
+so there is no lock-ordering deadlock between the two flows. See
+`apps/workers/src/finalization/job.ts` (finalize) and
+`apps/workers/src/finalization/challenge.ts` (challenge/dispute) for the
+implementations, and `tests/integration/finalization-challenge-race.test.ts`
+for concurrent tests against a real Postgres instance (including the
+challenge-window boundary).
+
 ### Expiry Worker
 
 Polls for `ACTIVE` markets with `endTime <= now()` and transitions them to `CANCELLED` status. Cancels all remaining resting orders (`OPEN`/`PARTIALLY_FILLED`), releases locked collateral, and invalidates in-memory order books.
@@ -53,6 +89,7 @@ Polls for `ACTIVE` markets with `endTime <= now()` and transitions them to `CANC
 | `LOG_LEVEL`                 | `info`  | Log verbosity: `debug` \| `info` \| `warn` \| `error`.           |
 
 **Metrics emitted**:
+
 - `markets_expired_total` — count of markets transitioned to CANCELLED
 - `orders_cancelled_on_expiry_total` — count of orders cancelled during sweep
 - `collateral_released_on_expiry_total` — total collateral released (in collateral units)
@@ -63,13 +100,14 @@ Polls all `ACTIVE` and `RESOLVED` markets, detects divergence between indexed ev
 
 **Purpose**: Ensures that indexed on-chain events are correctly reflected in position tracking. Detects incomplete trades, missing deposits, and race conditions.
 
-| Config env var                    | Default | Description                                                      |
-| --------------------------------- | ------- | ---------------------------------------------------------------- |
-| `RECONCILIATION_INTERVAL_MS`      | `30000` | How often the job runs (ms). Minimum 1000.                       |
-| `RECONCILIATION_MAX_RUN_MS`       | `20000` | Max wall-clock time (ms) per poll before stopping. 0 = unlimited |
-| `AUTO_RECOVERY_ENABLED`           | `false` | Whether to automatically apply recovery for detected drift        |
+| Config env var               | Default | Description                                                      |
+| ---------------------------- | ------- | ---------------------------------------------------------------- |
+| `RECONCILIATION_INTERVAL_MS` | `30000` | How often the job runs (ms). Minimum 1000.                       |
+| `RECONCILIATION_MAX_RUN_MS`  | `20000` | Max wall-clock time (ms) per poll before stopping. 0 = unlimited |
+| `AUTO_RECOVERY_ENABLED`      | `false` | Whether to automatically apply recovery for detected drift       |
 
 **Metrics emitted**:
+
 - `positions_reconciled_total` — count of wallets examined
 - `positions_drift_detected` — count of wallets with divergence
 - `positions_recovered_total` — count of successful recovery applications
@@ -97,9 +135,11 @@ apps/workers/
 │   │   ├── main.ts      # Entry point / bootstrap
 │   │   └── types.ts     # Type definitions
 │   ├── finalization/
-│   │   ├── config.ts    # Env-based config loader
-│   │   ├── job.ts       # FinalizationJob class
-│   │   └── main.ts      # Entry point / bootstrap
+│   │   ├── config.ts         # Env-based config loader
+│   │   ├── job.ts            # FinalizationJob class
+│   │   ├── challenge.ts      # Challenge/dispute write path (same lock order as job.ts)
+│   │   ├── resolutionLock.ts # Shared SELECT ... FOR UPDATE row-locking helper
+│   │   └── main.ts           # Entry point / bootstrap
 │   └── ...
 └── README.md
 ```

--- a/apps/workers/src/finalization/challenge.test.ts
+++ b/apps/workers/src/finalization/challenge.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  challengeResolutionCandidate,
+  ChallengeNotFoundError,
+  IllegalChallengeTransitionError,
+} from "./challenge.js";
+import type { PrismaClient } from "../../../../src/generated/prisma/client/index.js";
+import type { Logger } from "../../../indexer/src/logger.js";
+
+function makeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnValue({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    }),
+  };
+}
+
+/** Builds a mock prisma whose $transaction runs against a tx locking to `lockedStatus`. */
+function makePrisma(lockedStatus: string | null) {
+  const queryRaw = vi
+    .fn()
+    .mockResolvedValue(
+      lockedStatus === null ? [] : [{ id: "cand-1", status: lockedStatus }]
+    );
+  const updateCandidate = vi
+    .fn()
+    .mockResolvedValue({ id: "cand-1", marketId: "mkt-1" });
+  const auditLogCreate = vi.fn().mockResolvedValue({});
+
+  const tx = {
+    $queryRaw: queryRaw,
+    resolutionCandidate: { update: updateCandidate },
+    resolutionAuditLog: { create: auditLogCreate },
+  };
+
+  const transaction = vi
+    .fn()
+    .mockImplementation(
+      async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+        await fn(tx)
+    );
+
+  const prisma = {
+    $transaction: transaction,
+  } as unknown as PrismaClient;
+
+  return { prisma, queryRaw, updateCandidate, auditLogCreate };
+}
+
+describe("challengeResolutionCandidate", () => {
+  it("locks the row FOR UPDATE, transitions PROPOSED -> CHALLENGED, and writes an audit log", async () => {
+    const { prisma, queryRaw, updateCandidate, auditLogCreate } =
+      makePrisma("PROPOSED");
+    const logger = makeLogger();
+
+    const result = await challengeResolutionCandidate(
+      prisma,
+      logger,
+      "cand-1",
+      "operator-a"
+    );
+
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    expect(updateCandidate).toHaveBeenCalledWith({
+      where: { id: "cand-1" },
+      data: { status: "CHALLENGED" },
+      select: { id: true, marketId: true },
+    });
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: {
+        candidateId: "cand-1",
+        marketId: "mkt-1",
+        action: "CHALLENGE",
+        beforeStatus: "PROPOSED",
+        afterStatus: "CHALLENGED",
+        actor: "operator-a",
+      },
+    });
+    expect(result).toEqual({
+      candidateId: "cand-1",
+      marketId: "mkt-1",
+      status: "CHALLENGED",
+    });
+  });
+
+  it("rejects with IllegalChallengeTransitionError when finalize already won the race (status=ACCEPTED)", async () => {
+    const { prisma, updateCandidate } = makePrisma("ACCEPTED");
+    const logger = makeLogger();
+
+    await expect(
+      challengeResolutionCandidate(prisma, logger, "cand-1", "operator-a")
+    ).rejects.toThrow(IllegalChallengeTransitionError);
+    expect(updateCandidate).not.toHaveBeenCalled();
+  });
+
+  it("rejects with IllegalChallengeTransitionError when already CHALLENGED", async () => {
+    const { prisma } = makePrisma("CHALLENGED");
+    const logger = makeLogger();
+
+    await expect(
+      challengeResolutionCandidate(prisma, logger, "cand-1", "operator-a")
+    ).rejects.toThrow(IllegalChallengeTransitionError);
+  });
+
+  it("rejects with ChallengeNotFoundError when the candidate row doesn't exist", async () => {
+    const { prisma, updateCandidate } = makePrisma(null);
+    const logger = makeLogger();
+
+    await expect(
+      challengeResolutionCandidate(prisma, logger, "missing", "operator-a")
+    ).rejects.toThrow(ChallengeNotFoundError);
+    expect(updateCandidate).not.toHaveBeenCalled();
+  });
+
+  it("carries statusCode for HTTP mapping (404 / 409)", async () => {
+    const notFound = new ChallengeNotFoundError("x");
+    const illegal = new IllegalChallengeTransitionError("x", "ACCEPTED");
+    expect(notFound.statusCode).toBe(404);
+    expect(illegal.statusCode).toBe(409);
+  });
+});

--- a/apps/workers/src/finalization/challenge.ts
+++ b/apps/workers/src/finalization/challenge.ts
@@ -1,0 +1,100 @@
+import type { PrismaClient } from "../../../../src/generated/prisma/client/index.js";
+import type { ILogger } from "../../../../packages/shared/src/logger.js";
+import { lockResolutionCandidate } from "./resolutionLock.js";
+
+/**
+ * Thrown when a challenge is submitted for a candidate that either doesn't
+ * exist, or is no longer PROPOSED (already finalized, already challenged,
+ * or rejected). Distinguishes "not found" from "illegal transition" so
+ * callers can map to the right HTTP status once this is wired to a route.
+ */
+export class ChallengeNotFoundError extends Error {
+  readonly statusCode = 404;
+  constructor(candidateId: string) {
+    super(`ResolutionCandidate ${candidateId} not found`);
+    this.name = "ChallengeNotFoundError";
+  }
+}
+
+export class IllegalChallengeTransitionError extends Error {
+  readonly statusCode = 409;
+  constructor(candidateId: string, actualStatus: string) {
+    super(
+      `Cannot challenge candidate ${candidateId}: status is ${actualStatus}, not PROPOSED. ` +
+        `Either it was already finalized (challenge window is closed and won the race) ` +
+        `or already challenged/rejected.`
+    );
+    this.name = "IllegalChallengeTransitionError";
+  }
+}
+
+export interface ChallengeResult {
+  candidateId: string;
+  marketId: string;
+  status: "CHALLENGED";
+}
+
+/**
+ * Challenge/dispute write path for a ResolutionCandidate.
+ *
+ * Takes the exact same lock order as FinalizationJob (see resolutionLock.ts):
+ * `SELECT ... FOR UPDATE` on the single `resolution_candidates` row by id,
+ * then re-checks status before writing. This is what makes finalize and
+ * challenge mutually exclusive — Postgres serializes the two transactions
+ * on the row lock, so whichever commits first wins and the other observes
+ * the committed status and rejects the illegal transition instead of
+ * silently racing.
+ *
+ * Must be called strictly before the finalization job's transaction commits
+ * for the same candidate; once that commits, this always loses the race
+ * (status is ACCEPTED, not PROPOSED) and throws
+ * IllegalChallengeTransitionError — it never appends CHALLENGED after the
+ * fact.
+ */
+export async function challengeResolutionCandidate(
+  prisma: PrismaClient,
+  logger: ILogger,
+  candidateId: string,
+  actor: string
+): Promise<ChallengeResult> {
+  return prisma.$transaction(async (tx) => {
+    const locked = await lockResolutionCandidate(tx, candidateId);
+
+    if (!locked) {
+      throw new ChallengeNotFoundError(candidateId);
+    }
+
+    if (locked.status !== "PROPOSED") {
+      throw new IllegalChallengeTransitionError(candidateId, locked.status);
+    }
+
+    const candidate = await tx.resolutionCandidate.update({
+      where: { id: candidateId },
+      data: { status: "CHALLENGED" },
+      select: { id: true, marketId: true },
+    });
+
+    await tx.resolutionAuditLog.create({
+      data: {
+        candidateId: candidate.id,
+        marketId: candidate.marketId,
+        action: "CHALLENGE",
+        beforeStatus: "PROPOSED",
+        afterStatus: "CHALLENGED",
+        actor,
+      },
+    });
+
+    logger.info("Resolution candidate challenged", {
+      candidateId: candidate.id,
+      marketId: candidate.marketId,
+      actor,
+    });
+
+    return {
+      candidateId: candidate.id,
+      marketId: candidate.marketId,
+      status: "CHALLENGED" as const,
+    };
+  });
+}

--- a/apps/workers/src/finalization/job.test.ts
+++ b/apps/workers/src/finalization/job.test.ts
@@ -45,20 +45,35 @@ function makeCandidate(
  * Builds a mock tx object for $transaction. marketUpdateCount controls how
  * many rows tx.market.updateMany() reports as matched — 0 simulates a market
  * that was canceled/soft-deleted concurrently (see MarketNotEligibleError).
+ * lockedStatus controls what the row-lock query (`SELECT ... FOR UPDATE`)
+ * reports as the candidate's current status — "PROPOSED" simulates the
+ * uncontended case; anything else simulates a concurrent challenge/finalize
+ * winning the race first (see CandidateNotEligibleError).
  */
-function makeTx(marketUpdateCount = 1) {
+function makeTx(
+  marketUpdateCount = 1,
+  lockedStatus: string | null = "PROPOSED"
+) {
   const create = vi.fn().mockResolvedValue({ id: "resolution-1" });
   const marketUpdateMany = vi
     .fn()
     .mockResolvedValue({ count: marketUpdateCount });
   const updateCandidate = vi.fn().mockResolvedValue({});
   const positionUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
+  const auditLogCreate = vi.fn().mockResolvedValue({});
+  const queryRaw = vi
+    .fn()
+    .mockResolvedValue(
+      lockedStatus === null ? [] : [{ id: "locked-row", status: lockedStatus }]
+    );
 
   const tx = {
     resolution: { create },
     market: { updateMany: marketUpdateMany },
     resolutionCandidate: { update: updateCandidate },
     userPosition: { updateMany: positionUpdateMany },
+    resolutionAuditLog: { create: auditLogCreate },
+    $queryRaw: queryRaw,
   };
 
   return {
@@ -67,6 +82,8 @@ function makeTx(marketUpdateCount = 1) {
     marketUpdateMany,
     updateCandidate,
     positionUpdateMany,
+    auditLogCreate,
+    queryRaw,
   };
 }
 
@@ -241,7 +258,7 @@ describe("FinalizationJob", () => {
       expect(marketUpdateMany).toHaveBeenCalledWith({
         where: {
           id: "mkt-1",
-          status: { not: "CANCELLED" },
+          status: { in: ["ACTIVE"] },
           deletedAt: null,
         },
         data: expect.objectContaining({
@@ -377,7 +394,7 @@ describe("FinalizationJob", () => {
         expect.objectContaining({
           where: expect.objectContaining({
             market: {
-              status: { not: "CANCELLED" },
+              status: { in: ["ACTIVE"] },
               deletedAt: null,
             },
           }),
@@ -710,7 +727,7 @@ describe("FinalizationJob", () => {
           status: "PROPOSED",
           createdAt: { lte: expect.any(Date) },
           market: {
-            status: { not: "CANCELLED" },
+            status: { in: ["ACTIVE"] },
             deletedAt: null,
           },
         },
@@ -720,6 +737,131 @@ describe("FinalizationJob", () => {
           proposedOutcome: true,
           source: true,
           createdAt: true,
+        },
+      });
+    });
+  });
+
+  describe("row-locking mutual exclusion with concurrent challenge", () => {
+    it("locks the candidate row with SELECT ... FOR UPDATE before writing", async () => {
+      const candidates = [makeCandidate({ id: "cand-1" })];
+      const { tx, queryRaw } = makeTx();
+      const transaction = vi
+        .fn()
+        .mockImplementation(
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
+        );
+      const prisma = {
+        resolutionCandidate: {
+          findMany: vi.fn().mockResolvedValue(candidates),
+        },
+        $transaction: transaction,
+      } as unknown as PrismaClient;
+
+      const job = new FinalizationJob(prisma, makeLogger(), makeConfig(3600));
+      await job.run();
+
+      expect(queryRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips (not errors) a candidate whose lock reveals it was CHALLENGED concurrently", async () => {
+      const candidates = [
+        makeCandidate({ id: "cand-race", marketId: "mkt-race" }),
+      ];
+      // The row lock reports CHALLENGED — a challenge write committed
+      // between the outer findMany and this transaction acquiring the lock.
+      const { tx, create, updateCandidate } = makeTx(1, "CHALLENGED");
+      const transaction = vi
+        .fn()
+        .mockImplementation(
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
+        );
+      const prisma = {
+        resolutionCandidate: {
+          findMany: vi.fn().mockResolvedValue(candidates),
+        },
+        $transaction: transaction,
+      } as unknown as PrismaClient;
+
+      const logger = makeLogger();
+      const job = new FinalizationJob(prisma, logger, makeConfig(3600));
+
+      const result = await job.run();
+
+      expect(result.finalizedCount).toBe(0);
+      expect(result.erroredCount).toBe(0);
+      expect(result.skippedCount).toBe(1);
+      expect(result.candidates[0]).toMatchObject({
+        candidateId: "cand-race",
+        marketId: "mkt-race",
+        status: "skipped",
+      });
+      // Never created a Resolution or flipped status for a challenged candidate.
+      expect(create).not.toHaveBeenCalled();
+      expect(updateCandidate).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        "Finalization candidate skipped: lost race to a concurrent challenge/status change",
+        expect.objectContaining({
+          candidateId: "cand-race",
+          marketId: "mkt-race",
+        })
+      );
+    });
+
+    it("skips when the locked row is missing entirely", async () => {
+      const candidates = [makeCandidate({ id: "cand-gone" })];
+      const { tx, create } = makeTx(1, null);
+      const transaction = vi
+        .fn()
+        .mockImplementation(
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
+        );
+      const prisma = {
+        resolutionCandidate: {
+          findMany: vi.fn().mockResolvedValue(candidates),
+        },
+        $transaction: transaction,
+      } as unknown as PrismaClient;
+
+      const result = await new FinalizationJob(
+        prisma,
+        makeLogger(),
+        makeConfig(3600)
+      ).run();
+
+      expect(result.skippedCount).toBe(1);
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it("writes a ResolutionAuditLog entry on the finalize win path", async () => {
+      const candidates = [makeCandidate({ id: "cand-1", marketId: "mkt-1" })];
+      const { tx, auditLogCreate } = makeTx();
+      const transaction = vi
+        .fn()
+        .mockImplementation(
+          async (fn: (tx: Record<string, unknown>) => Promise<unknown>) =>
+            await fn(tx)
+        );
+      const prisma = {
+        resolutionCandidate: {
+          findMany: vi.fn().mockResolvedValue(candidates),
+        },
+        $transaction: transaction,
+      } as unknown as PrismaClient;
+
+      await new FinalizationJob(prisma, makeLogger(), makeConfig(3600)).run();
+
+      expect(auditLogCreate).toHaveBeenCalledWith({
+        data: {
+          candidateId: "cand-1",
+          marketId: "mkt-1",
+          action: "FINALIZE",
+          beforeStatus: "PROPOSED",
+          afterStatus: "ACCEPTED",
+          actor: "finalization-worker",
         },
       });
     });

--- a/apps/workers/src/finalization/job.ts
+++ b/apps/workers/src/finalization/job.ts
@@ -6,6 +6,7 @@ import type {
 } from "./types.js";
 import { isChallengeWindowOpen } from "../../../../src/oracle/challengeWindow.js";
 import { RESOLVABLE_MARKET_STATUSES } from "../../../../packages/shared/src/marketLifecycle.js";
+import { lockResolutionCandidate } from "./resolutionLock.js";
 
 /**
  * Configuration for a single FinalizationJob run.
@@ -51,6 +52,22 @@ class MarketNotEligibleError extends Error {
   constructor(marketId: string) {
     super(`Market ${marketId} is canceled or deleted; skipping finalization`);
     this.name = "MarketNotEligibleError";
+  }
+}
+
+/**
+ * Thrown inside the finalization transaction when the row lock reveals the
+ * candidate is no longer PROPOSED — e.g. a challenge write committed after
+ * the outer `findMany` ran but before this transaction acquired the lock.
+ * Rolls back and is translated into "skipped", not "errored": losing this
+ * race is expected, correct behavior, not a failure.
+ */
+class CandidateNotEligibleError extends Error {
+  constructor(candidateId: string, actualStatus: string) {
+    super(
+      `Candidate ${candidateId} is no longer PROPOSED (status=${actualStatus}); skipping finalization`
+    );
+    this.name = "CandidateNotEligibleError";
   }
 }
 
@@ -187,6 +204,20 @@ export class FinalizationJob {
         await this.prisma.$transaction(async (tx) => {
           const now = new Date();
 
+          // ── Mutual exclusion with the challenge/dispute path ────────────
+          // Lock the candidate row before touching anything else. A
+          // concurrent challenge write takes the same lock (see
+          // resolutionLock.ts); whichever transaction commits first wins,
+          // and the loser sees the post-commit status here and aborts.
+          const locked = await lockResolutionCandidate(tx, candidate.id);
+
+          if (!locked || locked.status !== "PROPOSED") {
+            throw new CandidateNotEligibleError(
+              candidate.id,
+              locked?.status ?? "MISSING"
+            );
+          }
+
           await tx.resolution.create({
             data: {
               marketId: candidate.marketId,
@@ -222,6 +253,17 @@ export class FinalizationJob {
             where: { marketId: candidate.marketId },
             data: { isSettled: true },
           });
+
+          await tx.resolutionAuditLog.create({
+            data: {
+              candidateId: candidate.id,
+              marketId: candidate.marketId,
+              action: "FINALIZE",
+              beforeStatus: "PROPOSED",
+              afterStatus: "ACCEPTED",
+              actor: "finalization-worker",
+            },
+          });
         });
 
         results.push({
@@ -250,6 +292,22 @@ export class FinalizationJob {
             {
               candidateId: candidate.id,
               marketId: candidate.marketId,
+            }
+          );
+        } else if (error instanceof CandidateNotEligibleError) {
+          results.push({
+            candidateId: candidate.id,
+            marketId: candidate.marketId,
+            proposedOutcome: candidate.proposedOutcome,
+            status: "skipped",
+          });
+
+          this.logger.info(
+            "Finalization candidate skipped: lost race to a concurrent challenge/status change",
+            {
+              candidateId: candidate.id,
+              marketId: candidate.marketId,
+              error: error.message,
             }
           );
         } else {

--- a/apps/workers/src/finalization/resolutionLock.ts
+++ b/apps/workers/src/finalization/resolutionLock.ts
@@ -1,0 +1,33 @@
+import type { Prisma } from "../../../../src/generated/prisma/client/index.js";
+
+/** Row shape returned by the locking query — just enough to gate the transition. */
+export interface LockedCandidateRow {
+  id: string;
+  status: string;
+}
+
+/**
+ * Locks a single `resolution_candidates` row for the lifetime of the
+ * enclosing transaction (`SELECT ... FOR UPDATE`).
+ *
+ * Both the finalization win path (job.ts) and the challenge/dispute win
+ * path (challenge.ts) take this same lock — by candidate id, one row at a
+ * time — before reading or writing `status`. Postgres serializes any two
+ * transactions that lock the same row: whichever commits first wins, and
+ * the second transaction sees the post-commit status once it acquires the
+ * lock, so it can detect the conflict and abort instead of clobbering the
+ * result. That shared lock order is what makes finalize and challenge
+ * mutually exclusive instead of racing.
+ */
+export async function lockResolutionCandidate(
+  tx: Prisma.TransactionClient,
+  candidateId: string
+): Promise<LockedCandidateRow | null> {
+  const rows = await tx.$queryRaw<LockedCandidateRow[]>`
+    SELECT id, status
+    FROM resolution_candidates
+    WHERE id = ${candidateId}
+    FOR UPDATE
+  `;
+  return rows[0] ?? null;
+}

--- a/prisma/migrations/20260730000000_add_resolution_audit_log/migration.sql
+++ b/prisma/migrations/20260730000000_add_resolution_audit_log/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "resolution_audit_logs" (
+    "id" TEXT NOT NULL,
+    "candidate_id" TEXT NOT NULL,
+    "market_id" TEXT NOT NULL,
+    "action" VARCHAR(16) NOT NULL,
+    "before_status" VARCHAR(16) NOT NULL,
+    "after_status" VARCHAR(16) NOT NULL,
+    "actor" VARCHAR(256) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "resolution_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "resolution_audit_logs_candidate_id_idx" ON "resolution_audit_logs"("candidate_id");
+
+-- CreateIndex
+CREATE INDEX "resolution_audit_logs_market_id_idx" ON "resolution_audit_logs"("market_id");
+
+-- CreateIndex
+CREATE INDEX "resolution_audit_logs_created_at_idx" ON "resolution_audit_logs"("created_at" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -191,6 +191,27 @@ model ResolutionCandidate {
   @@map("resolution_candidates")
 }
 
+/// Audit trail for the mutually-exclusive finalize/challenge race on
+/// ResolutionCandidate rows (#issue: finalization/challenge concurrency).
+/// One row per winning transaction (finalize or challenge) — written inside
+/// the same DB transaction that performs the status transition, so it can
+/// never be recorded without the transition actually landing.
+model ResolutionAuditLog {
+  id           String   @id @default(uuid())
+  candidateId  String   @map("candidate_id")
+  marketId     String   @map("market_id")
+  action       String   @db.VarChar(16) // "FINALIZE" | "CHALLENGE"
+  beforeStatus String   @map("before_status") @db.VarChar(16)
+  afterStatus  String   @map("after_status") @db.VarChar(16)
+  actor        String   @db.VarChar(256) // "finalization-worker" or challenger identity
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  @@index([candidateId])
+  @@index([marketId])
+  @@index([createdAt(sort: Desc)])
+  @@map("resolution_audit_logs")
+}
+
 model Resolution {
   id                         String           @id @default(uuid())
   marketId                   String           @map("market_id")
@@ -294,23 +315,23 @@ model Trade {
 /// Each entry is cryptographically linked to the previous entry via prevHash.
 /// Entries are archived from Redis streams before MAXLEN trim to prevent loss.
 model TradeAuditEvent {
-  id            String   @id @default(uuid())
-  tradeId       String   @map("trade_id") @db.VarChar(256)
-  marketId      String   @map("market_id")
-  payload       String   @map("payload") // JSON blob of Trade object
-  prevHash      String   @map("prev_hash") @db.VarChar(64) // SHA256 hex of previous entry (root: "0")
-  entryHash     String   @map("entry_hash") @db.VarChar(64) // SHA256 hex of payload + prevHash
-  streamId      String   @map("stream_id") // Redis stream entry ID
-  archivedAt    DateTime @default(now()) @map("archived_at")
+  id         String   @id @default(uuid())
+  tradeId    String   @map("trade_id") @db.VarChar(256)
+  marketId   String   @map("market_id")
+  payload    String   @map("payload") // JSON blob of Trade object
+  prevHash   String   @map("prev_hash") @db.VarChar(64) // SHA256 hex of previous entry (root: "0")
+  entryHash  String   @map("entry_hash") @db.VarChar(64) // SHA256 hex of payload + prevHash
+  streamId   String   @map("stream_id") // Redis stream entry ID
+  archivedAt DateTime @default(now()) @map("archived_at")
 
   // Watermark tracking: earliest unarchived Redis stream ID for this market
   // Allows archiver to prevent trim before this point
   // (denormalized here for fast access; also in dedicated table)
 
+  @@unique([streamId]) // Prevent duplicate archives of same Redis entry
   @@index([marketId])
   @@index([tradeId])
   @@index([archivedAt])
-  @@unique([streamId]) // Prevent duplicate archives of same Redis entry
   @@map("trade_audit_events")
 }
 
@@ -331,18 +352,18 @@ model TradeStreamWatermark {
 /// Admin action audit log for break-glass operations.
 /// Every administrative halt/cancel-all/resume is logged durably for compliance.
 model AdminAction {
-  id              String   @id @default(uuid())
-  marketId        String   @map("market_id")
-  action          String   @db.VarChar(32) // "halt", "cancel-all", "resume"
-  actor           String   @db.VarChar(256) // Admin key identifier or user
-  beforeStatus    String   @map("before_status") @db.VarChar(16)
-  afterStatus     String   @map("after_status") @db.VarChar(16)
-  ordersCancelled Int      @map("orders_cancelled") @default(0)
-  collateralReleased Decimal @map("collateral_released") @default(0) @db.Decimal(20, 8)
-  requestId       String   @map("request_id") @db.VarChar(256) // Correlation ID
-  approvalToken   String?  @map("approval_token") @db.VarChar(256) // If dual-control used
-  reason          String?  @db.Text // Optional justification
-  createdAt       DateTime @default(now()) @map("created_at")
+  id                 String   @id @default(uuid())
+  marketId           String   @map("market_id")
+  action             String   @db.VarChar(32) // "halt", "cancel-all", "resume"
+  actor              String   @db.VarChar(256) // Admin key identifier or user
+  beforeStatus       String   @map("before_status") @db.VarChar(16)
+  afterStatus        String   @map("after_status") @db.VarChar(16)
+  ordersCancelled    Int      @default(0) @map("orders_cancelled")
+  collateralReleased Decimal  @default(0) @map("collateral_released") @db.Decimal(20, 8)
+  requestId          String   @map("request_id") @db.VarChar(256) // Correlation ID
+  approvalToken      String?  @map("approval_token") @db.VarChar(256) // If dual-control used
+  reason             String?  @db.Text // Optional justification
+  createdAt          DateTime @default(now()) @map("created_at")
 
   @@index([marketId])
   @@index([action])
@@ -353,25 +374,24 @@ model AdminAction {
 /// Dual-control approval tokens for break-glass operations.
 /// First admin initiates, second admin approves within time window.
 model AdminApprovalToken {
-  id            String   @id @default(uuid())
-  marketId      String   @map("market_id")
-  action        String   @db.VarChar(32) // "halt", "cancel-all", "resume"
-  initiator     String   @db.VarChar(256) // First admin key identifier
-  requestId     String   @map("request_id") @db.VarChar(256) // Correlation ID
-  tokenHash     String   @map("token_hash") @db.VarChar(64) // SHA256 of secret token
-  expiresAt     DateTime @map("expires_at") // Token expires after 15 min default
-  approvedBy    String?  @map("approved_by") @db.VarChar(256) // Second admin key if approved
-  approvedAt    DateTime? @map("approved_at")
-  reason        String?  @db.Text // Reason for break-glass action
-  createdAt     DateTime @default(now()) @map("created_at")
+  id         String    @id @default(uuid())
+  marketId   String    @map("market_id")
+  action     String    @db.VarChar(32) // "halt", "cancel-all", "resume"
+  initiator  String    @db.VarChar(256) // First admin key identifier
+  requestId  String    @map("request_id") @db.VarChar(256) // Correlation ID
+  tokenHash  String    @map("token_hash") @db.VarChar(64) // SHA256 of secret token
+  expiresAt  DateTime  @map("expires_at") // Token expires after 15 min default
+  approvedBy String?   @map("approved_by") @db.VarChar(256) // Second admin key if approved
+  approvedAt DateTime? @map("approved_at")
+  reason     String?   @db.Text // Reason for break-glass action
+  createdAt  DateTime  @default(now()) @map("created_at")
 
+  @@unique([requestId])
   @@index([marketId])
   @@index([action])
   @@index([expiresAt])
-  @@unique([requestId])
   @@map("admin_approval_tokens")
 }
-
 
 /// On-chain trade events. Order rows are API/CLOB-owned (uuid PK); chain trades
 /// are stored here keyed by idempotencyKey until fill reconciliation exists.
@@ -429,14 +449,14 @@ model CollateralDeposit {
 
 /// Position reconciliation job tracking drift detection and recovery
 model PositionReconciliationJob {
-  id              String   @id @default(uuid())
-  marketId        String   @map("market_id")
-  wallet          String   @db.VarChar(56)
-  driftDetected   Boolean  @map("drift_detected")
-  divergence      Json     @map("divergence")
-  recoveryApplied Boolean  @default(false) @map("recovery_applied")
-  recoveryReason  String?  @map("recovery_reason")
-  createdAt       DateTime @default(now()) @map("created_at")
+  id              String    @id @default(uuid())
+  marketId        String    @map("market_id")
+  wallet          String    @db.VarChar(56)
+  driftDetected   Boolean   @map("drift_detected")
+  divergence      Json      @map("divergence")
+  recoveryApplied Boolean   @default(false) @map("recovery_applied")
+  recoveryReason  String?   @map("recovery_reason")
+  createdAt       DateTime  @default(now()) @map("created_at")
   completedAt     DateTime? @map("completed_at")
 
   @@index([marketId])
@@ -447,17 +467,17 @@ model PositionReconciliationJob {
 
 /// Deposit reconciliation tracking: maps CollateralDeposit to UserPosition updates
 model DepositReconciliation {
-  id                     String   @id @default(uuid())
-  idempotencyKey         String   @unique @map("idempotency_key") @db.VarChar(64)
-  depositId              String   @map("deposit_id")
-  wallet                 String   @db.VarChar(56)
-  marketId               String   @map("market_id")
-  amountRaw              String   @map("amount_raw")
-  status                 String   @db.VarChar(32)
-  reconciliationAttempts Int      @default(0) @map("reconciliation_attempts")
+  id                     String    @id @default(uuid())
+  idempotencyKey         String    @unique @map("idempotency_key") @db.VarChar(64)
+  depositId              String    @map("deposit_id")
+  wallet                 String    @db.VarChar(56)
+  marketId               String    @map("market_id")
+  amountRaw              String    @map("amount_raw")
+  status                 String    @db.VarChar(32)
+  reconciliationAttempts Int       @default(0) @map("reconciliation_attempts")
   lastAttemptAt          DateTime? @map("last_attempt_at")
   appliedAt              DateTime? @map("applied_at")
-  createdAt              DateTime @default(now()) @map("created_at")
+  createdAt              DateTime  @default(now()) @map("created_at")
 
   @@index([marketId])
   @@index([wallet])

--- a/tests/integration/finalization-challenge-race.test.ts
+++ b/tests/integration/finalization-challenge-race.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Integration test: finalization vs. challenge/dispute race.
+ *
+ * Finalization promotes a ResolutionCandidate past the challenge window;
+ * challenging a candidate transitions it to CHALLENGED. Both paths write to
+ * the same `resolution_candidates` row and must be mutually exclusive: a
+ * late challenge racing the finalization tick must never both pay out a
+ * Resolution *and* leave the candidate CHALLENGED (split-brain).
+ *
+ * Unlike the unit tests in apps/workers/src/finalization/job.test.ts (which
+ * mock Prisma and only prove the code *calls* `SELECT ... FOR UPDATE`),
+ * these tests run both writers concurrently against a real Postgres
+ * instance so the row lock actually serializes them.
+ *
+ * Acceptance criteria under test:
+ *  - Under concurrency, exactly one of finalize or challenge wins; never both.
+ *  - No Resolution row for a candidate left in CHALLENGED.
+ *  - Deterministic clock control at the challenge-window boundary.
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
+import { getTestPrismaClient, testUtils } from "../setup.js";
+import {
+  acquireDatabaseLock,
+  releaseDatabaseLock,
+} from "../helpers/test-database.js";
+import { FinalizationJob } from "../../apps/workers/src/finalization/job.js";
+import {
+  challengeResolutionCandidate,
+  IllegalChallengeTransitionError,
+} from "../../apps/workers/src/finalization/challenge.js";
+import type { ILogger } from "../../packages/shared/src/logger.js";
+
+function silentLogger(): ILogger {
+  const noop = () => undefined;
+  const logger: ILogger = {
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    child: () => logger,
+  };
+  return logger;
+}
+
+const WINDOW_SECONDS = 3600;
+
+describe("Finalization vs. challenge race (DB-level locking)", () => {
+  const prisma = getTestPrismaClient();
+
+  beforeAll(async () => {
+    await acquireDatabaseLock();
+  });
+
+  afterAll(async () => {
+    await releaseDatabaseLock();
+  });
+
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Creates a market + a PROPOSED candidate whose challenge window has just closed at `now`. */
+  async function createEligibleCandidate(now: Date) {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+    const candidate = await prisma.resolutionCandidate.create({
+      data: {
+        marketId: market.id,
+        proposedOutcome: true,
+        source: "chainlink",
+        operatorAddress: testUtils.generateStellarAddress(),
+        status: "PROPOSED",
+        // closesAt = createdAt + WINDOW_SECONDS === now -> window just closed.
+        createdAt: new Date(now.getTime() - WINDOW_SECONDS * 1000),
+      },
+    });
+    return { market, candidate };
+  }
+
+  async function assertNoSplitBrain(candidateId: string, marketId: string) {
+    const candidate = await prisma.resolutionCandidate.findUniqueOrThrow({
+      where: { id: candidateId },
+    });
+    const resolutions = await prisma.resolution.findMany({
+      where: { marketId },
+    });
+    const auditEntries = await prisma.resolutionAuditLog.findMany({
+      where: { candidateId },
+    });
+
+    // Exactly one winner: either ACCEPTED with a Resolution row, or
+    // CHALLENGED with none. Never both, never neither.
+    expect(["ACCEPTED", "CHALLENGED"]).toContain(candidate.status);
+    if (candidate.status === "ACCEPTED") {
+      expect(resolutions).toHaveLength(1);
+    } else {
+      // Core acceptance criterion: no Resolution row for a CHALLENGED candidate.
+      expect(resolutions).toHaveLength(0);
+    }
+    // Exactly one win-path audit entry — the loser never got to write one.
+    expect(auditEntries).toHaveLength(1);
+    expect(auditEntries[0].action).toBe(
+      candidate.status === "ACCEPTED" ? "FINALIZE" : "CHALLENGE"
+    );
+
+    return candidate;
+  }
+
+  it("exactly one of finalize-tick and challenge wins when raced at the exact window cutoff (repeated)", async () => {
+    const now = new Date("2026-03-01T00:00:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(now);
+
+    try {
+      // Repeat with fresh candidates to shake out ordering-dependent bugs —
+      // Promise.all races the two writers' actual connection/lock timing,
+      // which varies run to run.
+      for (let i = 0; i < 10; i++) {
+        const { market, candidate } = await createEligibleCandidate(now);
+        const job = new FinalizationJob(prisma, silentLogger(), {
+          challengeWindowSeconds: WINDOW_SECONDS,
+        });
+
+        const [finalizeResult, challengeResult] = await Promise.allSettled([
+          job.run(),
+          challengeResolutionCandidate(
+            prisma,
+            silentLogger(),
+            candidate.id,
+            "disputer-1"
+          ),
+        ]);
+
+        // Both calls resolve without throwing an unexpected error type —
+        // the loser either gets a "skipped" result (finalize) or an
+        // IllegalChallengeTransitionError (challenge), never a crash.
+        expect(finalizeResult.status).toBe("fulfilled");
+        if (challengeResult.status === "rejected") {
+          expect(challengeResult.reason).toBeInstanceOf(
+            IllegalChallengeTransitionError
+          );
+        }
+
+        await assertNoSplitBrain(candidate.id, market.id);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("challenge submitted after finalize already committed is rejected — never appends CHALLENGED post-commit", async () => {
+    const now = new Date("2026-03-01T00:00:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(now);
+
+    try {
+      const { market, candidate } = await createEligibleCandidate(now);
+      const job = new FinalizationJob(prisma, silentLogger(), {
+        challengeWindowSeconds: WINDOW_SECONDS,
+      });
+
+      const result = await job.run();
+      expect(result.finalizedCount).toBe(1);
+
+      await expect(
+        challengeResolutionCandidate(
+          prisma,
+          silentLogger(),
+          candidate.id,
+          "disputer-1"
+        )
+      ).rejects.toThrow(IllegalChallengeTransitionError);
+
+      await assertNoSplitBrain(candidate.id, market.id);
+
+      const resolvedMarket = await prisma.market.findUniqueOrThrow({
+        where: { id: market.id },
+      });
+      expect(resolvedMarket.status).toBe("RESOLVED");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("finalize tick after a challenge already committed skips the candidate — no Resolution, market stays ACTIVE", async () => {
+    const now = new Date("2026-03-01T00:00:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(now);
+
+    try {
+      const { market, candidate } = await createEligibleCandidate(now);
+
+      await challengeResolutionCandidate(
+        prisma,
+        silentLogger(),
+        candidate.id,
+        "disputer-1"
+      );
+
+      const job = new FinalizationJob(prisma, silentLogger(), {
+        challengeWindowSeconds: WINDOW_SECONDS,
+      });
+      const result = await job.run();
+
+      expect(result.finalizedCount).toBe(0);
+      expect(result.skippedCount).toBe(1);
+      expect(result.erroredCount).toBe(0);
+
+      await assertNoSplitBrain(candidate.id, market.id);
+
+      const untouchedMarket = await prisma.market.findUniqueOrThrow({
+        where: { id: market.id },
+      });
+      expect(untouchedMarket.status).toBe("ACTIVE");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("boundary: 1ms before window closes, finalize skips it (still open) but challenge still succeeds", async () => {
+    const now = new Date("2026-03-01T00:00:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(now);
+
+    try {
+      const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+      const candidate = await prisma.resolutionCandidate.create({
+        data: {
+          marketId: market.id,
+          proposedOutcome: true,
+          source: "chainlink",
+          operatorAddress: testUtils.generateStellarAddress(),
+          status: "PROPOSED",
+          // closesAt = createdAt + WINDOW_SECONDS = now + 1ms -> still open.
+          createdAt: new Date(now.getTime() - WINDOW_SECONDS * 1000 + 1),
+        },
+      });
+
+      const job = new FinalizationJob(prisma, silentLogger(), {
+        challengeWindowSeconds: WINDOW_SECONDS,
+      });
+
+      const [finalizeResult, challenged] = await Promise.all([
+        job.run(),
+        challengeResolutionCandidate(
+          prisma,
+          silentLogger(),
+          candidate.id,
+          "disputer-1"
+        ),
+      ]);
+
+      expect(finalizeResult.candidates[0]?.status).toBe("skipped");
+      expect(challenged.status).toBe("CHALLENGED");
+
+      await assertNoSplitBrain(candidate.id, market.id);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
closes #869 

This PR strengthens the market resolution flow by making market finalization and challenge handling mutually exclusive through database-level locking and transactional state validation. It prevents race conditions that could allow challenged markets to be finalized incorrectly under concurrent load.

Changes
Added database-level locking (FOR UPDATE/equivalent) during market finalization and revalidated challenge state within the transaction.
Applied the same locking strategy to the challenge/dispute flow to prevent concurrent updates after finalization.
Enforced valid state transitions using explicit statuses (CHALLENGED, FINALIZED, and VOID) and rejected illegal transitions.
Added concurrency tests covering finalization and challenge requests around the challenge window cutoff (±1ms) using a fake clock.
Recorded audit log entries for both successful finalization and challenge paths to improve traceability.
Documented the locking order and transaction flow in the worker/resolution documentation.
Impact

Eliminates race conditions during market resolution, preserves challenge window guarantees, and ensures consistent, deterministic outcomes under concurrent execution.