### PR TITLE
Add transactional outbox for durable settlement delivery

### DIFF
--- a/apps/workers/src/settlement/consumer.ts
+++ b/apps/workers/src/settlement/consumer.ts
@@ -29,6 +29,10 @@ import {
 } from "../shared/queue-config.js";
 import { createShutdown } from "../../../../packages/shared/src/shutdown.js";
 import { loadStellarEndpoints } from "../../../../packages/shared/src/stellarTransport.js";
+import {
+  startOutboxPublisher,
+  stopOutboxPublisher,
+} from "../../../../src/services/outbox-publisher.js";
 
 const MAX_ATTEMPTS = 3;
 const PROCESSING_TIMEOUT_MS = 30_000;
@@ -49,6 +53,11 @@ async function bootstrap(): Promise<void> {
   logger.info("Settlement worker started (BullMQ)", {
     queue: queueName,
   });
+
+  // Recovery path for the transactional outbox (#outbox): drains any
+  // SettlementOutboxEvent rows left PENDING/FAILED after a crash or Redis
+  // outage between MatchingService's DB commit and its fast-path enqueue.
+  startOutboxPublisher();
 
   const contractId = process.env.SETTLEMENT_CONTRACT_ID;
   const networkPassphrase = process.env.SOROBAN_NETWORK_PASSPHRASE;
@@ -130,6 +139,9 @@ async function bootstrap(): Promise<void> {
     timeoutMs: 30_000,
     component: "settlement-worker",
     teardown: [
+      async () => {
+        stopOutboxPublisher();
+      },
       async () => {
         await worker.close();
       },

--- a/docs/adr/003-settlement-outbox.md
+++ b/docs/adr/003-settlement-outbox.md
@@ -1,0 +1,153 @@
+# ADR 003 — Transactional Outbox for Settlement Delivery
+
+**Status:** Accepted
+**Date:** 2026-07-30
+
+---
+
+## Context
+
+`MatchingService.placeOrder` (`src/matching/matching-service.ts`) persists trades inside a
+Prisma transaction, then — after that transaction commits — calls
+`settlementQueue.enqueue()` (a Redis `XADD`, see `src/services/settlement-queue.ts`) once per
+trade to hand the fill off to the settlement worker.
+
+This is a classic **dual-write**: two independent systems (Postgres, Redis) are written to
+sequentially with no shared transaction. If the process crashes, Redis is unreachable, or the
+enqueue loop fails partway through a multi-trade match, the trade is durably committed to
+Postgres but the corresponding settlement job never reaches the queue. The prior code logged
+`settlement_enqueue_failed` and moved on — there was no automatic recovery path, so the trade
+silently never settles until an operator notices and manually reconciles it.
+
+## Decision
+
+Introduce a **transactional outbox**: every trade write is paired with an `OutboxEvent` row
+written in the **same** Prisma transaction as the `Trade` upsert. Delivery to the settlement
+queue is decoupled from that transaction into two paths:
+
+1. **Fast path** (`MatchingService.placeOrder`, post-commit): immediately attempts
+   `publishOutboxRow()` for low latency in the common case.
+2. **Recovery path** (`src/services/outbox-publisher.ts`, `startOutboxPublisher()`): a
+   background loop, started by the settlement worker process
+   (`apps/workers/src/settlement/consumer.ts`), that periodically drains any `OutboxEvent` row
+   still `PENDING` or `FAILED` and retries it with exponential backoff.
+
+Because the outbox row is committed atomically with the trade, **there is no window in which a
+trade exists without a corresponding durable settlement intent** — a crash or Redis outage
+between commit and enqueue just means the fast path fails and the row is picked up by the
+recovery loop instead.
+
+### Schema
+
+```prisma
+enum OutboxStatus {
+  PENDING
+  PUBLISHED
+  FAILED
+}
+
+model OutboxEvent {
+  id            String       @id @default(uuid())
+  tradeId       String       @unique @map("trade_id")
+  payload       Json
+  status        OutboxStatus @default(PENDING)
+  attempts      Int          @default(0)
+  lastError     String?      @map("last_error")
+  nextAttemptAt DateTime     @default(now()) @map("next_attempt_at")
+  publishedAt   DateTime?    @map("published_at")
+  createdAt     DateTime     @default(now()) @map("created_at")
+  updatedAt     DateTime     @updatedAt @map("updated_at")
+
+  @@map("outbox_events")
+}
+```
+
+`outbox_events` / `published_at IS NULL` was already the table+predicate the admission-control
+lag detector (`src/services/lag-detector.ts`, `getOutboxUnpublishedCount()`) expected and
+gracefully degraded around before this table existed — this migration is that table, so the
+existing lag-shedding admission control (`docs/ADMISSION_CONTROL_CONFIG.md`) now has real data
+instead of always reading 0.
+
+### Idempotency
+
+- **Trade persistence** was already idempotent on `tradeId` (`tx.trade.upsert`).
+- **Outbox row creation** is idempotent on `tradeId` (`tx.outboxEvent.upsert`), so retrying the
+  whole `placeOrder` transaction (should Prisma ever retry it) never creates a duplicate row.
+- **Publishing** (`publishOutboxRow`) is safe to call more than once for the same row: it
+  `updateMany`s on `{ tradeId, status: { not: "PUBLISHED" } }`, so a duplicate call after the
+  row is already `PUBLISHED` is a no-op on the DB side. It can still call
+  `settlementQueue.enqueue()` twice for the same trade (e.g. the fast path and a concurrent
+  drain both racing an unpublished row) — this is accepted as **at-least-once** delivery. The
+  settlement consumer (`apps/workers/src/settlement/settlement-worker.ts`, #870) already
+  idempotency-checks on `tradeId` before applying a position, so a duplicate enqueue never
+  double-applies a settlement.
+
+### Backoff and orphan detection
+
+`publishOutboxRow` uses capped exponential backoff (`1s * 2^attempts`, capped at 60s) on
+failure, tracked via `nextAttemptAt`. Rows are never abandoned — the drain loop keeps retrying
+indefinitely. Rows that have failed at least `OUTBOX_ORPHAN_ATTEMPTS_THRESHOLD` times (default 5) are surfaced via the `vatix_settlement_outbox_orphaned_trades` gauge for alerting; this is a
+visibility signal, not an automatic quarantine — see Operator Recovery below.
+
+## Metrics
+
+All registered on the shared Prometheus registry (`src/services/metrics.ts`), scraped via
+`GET /metrics`:
+
+| Metric                                           | Type    | Meaning                                                          |
+| ------------------------------------------------ | ------- | ---------------------------------------------------------------- |
+| `vatix_settlement_outbox_depth`                  | Gauge   | Rows currently `PENDING` or `FAILED` (not yet published)         |
+| `vatix_settlement_outbox_lag_seconds`            | Gauge   | Age of the oldest unpublished row                                |
+| `vatix_settlement_outbox_publish_failures_total` | Counter | Total failed publish attempts                                    |
+| `vatix_settlement_outbox_orphaned_trades`        | Gauge   | Rows that have failed ≥ `OUTBOX_ORPHAN_ATTEMPTS_THRESHOLD` times |
+
+Suggested alert: page when `vatix_settlement_outbox_lag_seconds` exceeds a few minutes, or when
+`vatix_settlement_outbox_orphaned_trades` is nonzero for an extended period — either indicates
+the recovery loop is running but the settlement queue (or the worker process itself) is
+unhealthy, not just a transient blip.
+
+## Operator Recovery
+
+If the settlement worker process is down entirely (so `startOutboxPublisher()` never runs), the
+outbox simply backs up — no trades are lost, they just wait. To manually verify or force a
+drain during an incident:
+
+```sql
+-- How many trades are waiting?
+SELECT status, count(*) FROM outbox_events WHERE status <> 'PUBLISHED' GROUP BY status;
+
+-- Oldest unpublished row (drives the lag metric)
+SELECT trade_id, status, attempts, created_at, last_error
+FROM outbox_events
+WHERE status <> 'PUBLISHED'
+ORDER BY created_at ASC
+LIMIT 20;
+```
+
+Restarting `apps/workers/src/settlement/consumer.ts` (`pnpm workers:settlement`) is sufficient
+to resume draining — `startOutboxPublisher()` runs on an interval
+(`OUTBOX_PUBLISHER_INTERVAL_MS`, default 2s) and requires no special flags. There is no
+separate "replay" command: any row not `PUBLISHED` is automatically eligible for the next drain
+cycle once `next_attempt_at` has passed.
+
+To force an immediate retry of rows currently in backoff (e.g. right after fixing a Redis
+outage, without waiting out the backoff window):
+
+```sql
+UPDATE outbox_events SET next_attempt_at = now() WHERE status IN ('PENDING', 'FAILED');
+```
+
+Rows never need to be manually deleted or reset to `PENDING` — the drain loop treats `FAILED`
+and `PENDING` identically as "still needs to be published."
+
+## Consequences
+
+- `settlementQueue.enqueue()` (`src/services/settlement-queue.ts`) is unchanged; both the fast
+  path and the recovery loop call it exactly as before. This ADR only changes how failures to
+  reach it are recovered from — it does not change the queue's own transport.
+- Every `placeOrder` transaction now does one extra upsert per trade; this is a small,
+  well-indexed write and negligible next to the existing order/position writes in the same
+  transaction.
+- The settlement worker process is now also responsible for outbox drain; if that process is
+  scaled to zero for an extended period, the outbox metric alerts (above) are the signal that
+  settlement is silently backing up.

--- a/docs/queue-consumer.md
+++ b/docs/queue-consumer.md
@@ -109,6 +109,10 @@ await processJob(logger, config, job, async (j) => {
 
 The settlement worker (`apps/workers/src/settlement/`) consumes the Redis settlement queue populated by `MatchingService` after each order match. It uses `processJob()` with dead-letter support and enforces idempotency on `tradeId`.
 
+### Durable Delivery via Transactional Outbox
+
+`MatchingService.placeOrder` does not enqueue settlement jobs directly. Every trade is written together with an `OutboxEvent` row in the same DB transaction, and delivery to this queue happens via a fast path (immediately after commit) plus a background recovery loop (`src/services/outbox-publisher.ts`, started by this worker's `bootstrap()`) that retries any row still unpublished. This guarantees a committed trade is never silently dropped, even if Redis is down or the process crashes between commit and enqueue. See [ADR 003 — Transactional Outbox for Settlement Delivery](adr/003-settlement-outbox.md) for the full design, metrics, and operator recovery commands.
+
 ### Environment Variables
 
 | Variable                | Default             | Description                           |

--- a/prisma/migrations/20260730120000_add_outbox_events/migration.sql
+++ b/prisma/migrations/20260730120000_add_outbox_events/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "OutboxStatus" AS ENUM ('PENDING', 'PUBLISHED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "outbox_events" (
+    "id" TEXT NOT NULL,
+    "trade_id" VARCHAR(256) NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status" "OutboxStatus" NOT NULL DEFAULT 'PENDING',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "last_error" TEXT,
+    "next_attempt_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "published_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "outbox_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "outbox_events_trade_id_key" ON "outbox_events"("trade_id");
+
+-- CreateIndex
+CREATE INDEX "outbox_events_status_next_attempt_at_idx" ON "outbox_events"("status", "next_attempt_at");
+
+-- CreateIndex
+CREATE INDEX "outbox_events_created_at_idx" ON "outbox_events"("created_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -290,27 +290,66 @@ model Trade {
   @@map("trades")
 }
 
+/// Lifecycle of an outbox row (transactional outbox pattern).
+/// PENDING: written in the same tx as the trade, not yet published to the
+/// settlement queue. PUBLISHED: publish confirmed. FAILED: a publish attempt
+/// errored; eligible for retry by the publisher loop until it succeeds.
+enum OutboxStatus {
+  PENDING
+  PUBLISHED
+  FAILED
+}
+
+/// Transactional outbox for settlement jobs (durable dual-write fix).
+///
+/// Written in the SAME Prisma transaction as the Trade upsert in
+/// MatchingService.placeOrder, so a committed trade and its outbox row are
+/// atomic — either both exist or neither does. A publisher loop
+/// (src/services/outbox-publisher.ts) drains PENDING/FAILED rows into the
+/// settlement queue and marks them PUBLISHED atomically. See
+/// docs/adr/003-settlement-outbox.md for the recovery flow.
+///
+/// `outbox_events` / `published_at IS NULL` is also the table+predicate the
+/// admission-control lag detector (src/services/lag-detector.ts) already
+/// queries for `outboxUnpublishedCount` — this model is that table.
+model OutboxEvent {
+  id            String       @id @default(uuid())
+  tradeId       String       @unique @map("trade_id") @db.VarChar(256)
+  payload       Json         @map("payload")
+  status        OutboxStatus @default(PENDING)
+  attempts      Int          @default(0)
+  lastError     String?      @map("last_error")
+  nextAttemptAt DateTime     @default(now()) @map("next_attempt_at")
+  publishedAt   DateTime?    @map("published_at")
+  createdAt     DateTime     @default(now()) @map("created_at")
+  updatedAt     DateTime     @default(now()) @updatedAt @map("updated_at")
+
+  @@index([status, nextAttemptAt])
+  @@index([createdAt])
+  @@map("outbox_events")
+}
+
 /// Durable, hash-chained audit trail for trade compliance and forensics.
 /// Each entry is cryptographically linked to the previous entry via prevHash.
 /// Entries are archived from Redis streams before MAXLEN trim to prevent loss.
 model TradeAuditEvent {
-  id            String   @id @default(uuid())
-  tradeId       String   @map("trade_id") @db.VarChar(256)
-  marketId      String   @map("market_id")
-  payload       String   @map("payload") // JSON blob of Trade object
-  prevHash      String   @map("prev_hash") @db.VarChar(64) // SHA256 hex of previous entry (root: "0")
-  entryHash     String   @map("entry_hash") @db.VarChar(64) // SHA256 hex of payload + prevHash
-  streamId      String   @map("stream_id") // Redis stream entry ID
-  archivedAt    DateTime @default(now()) @map("archived_at")
+  id         String   @id @default(uuid())
+  tradeId    String   @map("trade_id") @db.VarChar(256)
+  marketId   String   @map("market_id")
+  payload    String   @map("payload") // JSON blob of Trade object
+  prevHash   String   @map("prev_hash") @db.VarChar(64) // SHA256 hex of previous entry (root: "0")
+  entryHash  String   @map("entry_hash") @db.VarChar(64) // SHA256 hex of payload + prevHash
+  streamId   String   @map("stream_id") // Redis stream entry ID
+  archivedAt DateTime @default(now()) @map("archived_at")
 
   // Watermark tracking: earliest unarchived Redis stream ID for this market
   // Allows archiver to prevent trim before this point
   // (denormalized here for fast access; also in dedicated table)
 
+  @@unique([streamId]) // Prevent duplicate archives of same Redis entry
   @@index([marketId])
   @@index([tradeId])
   @@index([archivedAt])
-  @@unique([streamId]) // Prevent duplicate archives of same Redis entry
   @@map("trade_audit_events")
 }
 
@@ -331,18 +370,18 @@ model TradeStreamWatermark {
 /// Admin action audit log for break-glass operations.
 /// Every administrative halt/cancel-all/resume is logged durably for compliance.
 model AdminAction {
-  id              String   @id @default(uuid())
-  marketId        String   @map("market_id")
-  action          String   @db.VarChar(32) // "halt", "cancel-all", "resume"
-  actor           String   @db.VarChar(256) // Admin key identifier or user
-  beforeStatus    String   @map("before_status") @db.VarChar(16)
-  afterStatus     String   @map("after_status") @db.VarChar(16)
-  ordersCancelled Int      @map("orders_cancelled") @default(0)
-  collateralReleased Decimal @map("collateral_released") @default(0) @db.Decimal(20, 8)
-  requestId       String   @map("request_id") @db.VarChar(256) // Correlation ID
-  approvalToken   String?  @map("approval_token") @db.VarChar(256) // If dual-control used
-  reason          String?  @db.Text // Optional justification
-  createdAt       DateTime @default(now()) @map("created_at")
+  id                 String   @id @default(uuid())
+  marketId           String   @map("market_id")
+  action             String   @db.VarChar(32) // "halt", "cancel-all", "resume"
+  actor              String   @db.VarChar(256) // Admin key identifier or user
+  beforeStatus       String   @map("before_status") @db.VarChar(16)
+  afterStatus        String   @map("after_status") @db.VarChar(16)
+  ordersCancelled    Int      @default(0) @map("orders_cancelled")
+  collateralReleased Decimal  @default(0) @map("collateral_released") @db.Decimal(20, 8)
+  requestId          String   @map("request_id") @db.VarChar(256) // Correlation ID
+  approvalToken      String?  @map("approval_token") @db.VarChar(256) // If dual-control used
+  reason             String?  @db.Text // Optional justification
+  createdAt          DateTime @default(now()) @map("created_at")
 
   @@index([marketId])
   @@index([action])
@@ -353,25 +392,24 @@ model AdminAction {
 /// Dual-control approval tokens for break-glass operations.
 /// First admin initiates, second admin approves within time window.
 model AdminApprovalToken {
-  id            String   @id @default(uuid())
-  marketId      String   @map("market_id")
-  action        String   @db.VarChar(32) // "halt", "cancel-all", "resume"
-  initiator     String   @db.VarChar(256) // First admin key identifier
-  requestId     String   @map("request_id") @db.VarChar(256) // Correlation ID
-  tokenHash     String   @map("token_hash") @db.VarChar(64) // SHA256 of secret token
-  expiresAt     DateTime @map("expires_at") // Token expires after 15 min default
-  approvedBy    String?  @map("approved_by") @db.VarChar(256) // Second admin key if approved
-  approvedAt    DateTime? @map("approved_at")
-  reason        String?  @db.Text // Reason for break-glass action
-  createdAt     DateTime @default(now()) @map("created_at")
+  id         String    @id @default(uuid())
+  marketId   String    @map("market_id")
+  action     String    @db.VarChar(32) // "halt", "cancel-all", "resume"
+  initiator  String    @db.VarChar(256) // First admin key identifier
+  requestId  String    @map("request_id") @db.VarChar(256) // Correlation ID
+  tokenHash  String    @map("token_hash") @db.VarChar(64) // SHA256 of secret token
+  expiresAt  DateTime  @map("expires_at") // Token expires after 15 min default
+  approvedBy String?   @map("approved_by") @db.VarChar(256) // Second admin key if approved
+  approvedAt DateTime? @map("approved_at")
+  reason     String?   @db.Text // Reason for break-glass action
+  createdAt  DateTime  @default(now()) @map("created_at")
 
+  @@unique([requestId])
   @@index([marketId])
   @@index([action])
   @@index([expiresAt])
-  @@unique([requestId])
   @@map("admin_approval_tokens")
 }
-
 
 /// On-chain trade events. Order rows are API/CLOB-owned (uuid PK); chain trades
 /// are stored here keyed by idempotencyKey until fill reconciliation exists.
@@ -429,14 +467,14 @@ model CollateralDeposit {
 
 /// Position reconciliation job tracking drift detection and recovery
 model PositionReconciliationJob {
-  id              String   @id @default(uuid())
-  marketId        String   @map("market_id")
-  wallet          String   @db.VarChar(56)
-  driftDetected   Boolean  @map("drift_detected")
-  divergence      Json     @map("divergence")
-  recoveryApplied Boolean  @default(false) @map("recovery_applied")
-  recoveryReason  String?  @map("recovery_reason")
-  createdAt       DateTime @default(now()) @map("created_at")
+  id              String    @id @default(uuid())
+  marketId        String    @map("market_id")
+  wallet          String    @db.VarChar(56)
+  driftDetected   Boolean   @map("drift_detected")
+  divergence      Json      @map("divergence")
+  recoveryApplied Boolean   @default(false) @map("recovery_applied")
+  recoveryReason  String?   @map("recovery_reason")
+  createdAt       DateTime  @default(now()) @map("created_at")
   completedAt     DateTime? @map("completed_at")
 
   @@index([marketId])
@@ -447,17 +485,17 @@ model PositionReconciliationJob {
 
 /// Deposit reconciliation tracking: maps CollateralDeposit to UserPosition updates
 model DepositReconciliation {
-  id                     String   @id @default(uuid())
-  idempotencyKey         String   @unique @map("idempotency_key") @db.VarChar(64)
-  depositId              String   @map("deposit_id")
-  wallet                 String   @db.VarChar(56)
-  marketId               String   @map("market_id")
-  amountRaw              String   @map("amount_raw")
-  status                 String   @db.VarChar(32)
-  reconciliationAttempts Int      @default(0) @map("reconciliation_attempts")
+  id                     String    @id @default(uuid())
+  idempotencyKey         String    @unique @map("idempotency_key") @db.VarChar(64)
+  depositId              String    @map("deposit_id")
+  wallet                 String    @db.VarChar(56)
+  marketId               String    @map("market_id")
+  amountRaw              String    @map("amount_raw")
+  status                 String    @db.VarChar(32)
+  reconciliationAttempts Int       @default(0) @map("reconciliation_attempts")
   lastAttemptAt          DateTime? @map("last_attempt_at")
   appliedAt              DateTime? @map("applied_at")
-  createdAt              DateTime @default(now()) @map("created_at")
+  createdAt              DateTime  @default(now()) @map("created_at")
 
   @@index([marketId])
   @@index([wallet])

--- a/src/api/middleware/errors.ts
+++ b/src/api/middleware/errors.ts
@@ -82,3 +82,10 @@ export class MarketNotActiveError extends AppError {
     );
   }
 }
+
+/** Optimistic-concurrency conflict on an order (version/status raced). Retryable (409). */
+export class OrderConflictError extends AppError {
+  constructor(message = "Order was concurrently modified; please retry") {
+    super(message, 409, "order_conflict");
+  }
+}

--- a/src/matching/matching-service.test.ts
+++ b/src/matching/matching-service.test.ts
@@ -4,6 +4,7 @@ import {
   ServiceUnavailableError,
   MarketNotActiveError,
   MarketNotFoundError,
+  OrderConflictError,
 } from "../api/middleware/errors.js";
 
 // Mock dependencies
@@ -60,6 +61,9 @@ const mockTx = {
   trade: {
     upsert: vi.fn(),
   },
+  outboxEvent: {
+    upsert: vi.fn(),
+  },
   userPosition: {
     findUnique: vi.fn(),
     update: vi.fn(),
@@ -82,6 +86,9 @@ const mockPrismaClient = {
     findUnique: vi.fn(),
     upsert: vi.fn(),
     update: vi.fn(),
+  },
+  outboxEvent: {
+    updateMany: vi.fn().mockResolvedValue({ count: 1 }),
   },
   $transaction: vi.fn((cb: (tx: any) => Promise<any>) => cb(mockTx)),
 };

--- a/src/matching/matching-service.ts
+++ b/src/matching/matching-service.ts
@@ -10,14 +10,18 @@ import {
 } from "./engine.js";
 import { Mutex } from "./mutex.js";
 import { auditService } from "../services/audit.js";
-import { settlementQueue } from "../services/settlement-queue.js";
 import { redis } from "../services/redis.js";
 import { getPrismaClient } from "../services/prisma.js";
+import {
+  buildSettlementPayload,
+  publishOutboxRow,
+} from "../services/outbox-publisher.js";
 import {
   ValidationError,
   ServiceUnavailableError,
   MarketNotFoundError,
   MarketNotActiveError,
+  OrderConflictError,
 } from "../api/middleware/errors.js";
 import { orderbookHydratedMarketsGauge } from "../services/metrics.js";
 
@@ -507,7 +511,14 @@ class MatchingService {
             }
           }
 
-          // Persist trades as source of truth (idempotent on trade.id)
+          // Persist trades as source of truth (idempotent on trade.id), and
+          // write a settlement outbox row in the SAME transaction (#outbox).
+          // The trade and its outbox row are committed atomically — either
+          // both exist or neither does — so a crash or Redis outage between
+          // commit and the post-commit enqueue below can never permanently
+          // drop settlement for a trade: the outbox-publisher loop
+          // (src/services/outbox-publisher.ts) will pick up any row still
+          // PENDING/FAILED and retry it with backoff.
           for (const trade of matchResult.trades) {
             await tx.trade.upsert({
               where: { tradeId: trade.id },
@@ -522,6 +533,15 @@ class MatchingService {
                 price: trade.price.toString(),
                 quantity: trade.quantity,
                 tradedAt: new Date(trade.timestamp),
+              },
+              update: {},
+            });
+
+            await tx.outboxEvent.upsert({
+              where: { tradeId: trade.id },
+              create: {
+                tradeId: trade.id,
+                payload: buildSettlementPayload(trade) as any,
               },
               update: {},
             });
@@ -596,38 +616,18 @@ class MatchingService {
       // 2. Log trades to audit before returning control to the caller
       await Promise.all(auditWrites);
 
-      // 3. Enqueue settlement jobs with proper error handling
-      const settlementErrors: Array<{ tradeId: string; error: Error }> = [];
+      // 3. Best-effort fast-path publish straight to the settlement queue.
+      // The trade is already durably queued via the outbox row written in
+      // the transaction above, so a failure here (Redis down, process
+      // crash, etc.) is NOT a lost settlement — it just falls back to the
+      // outbox-publisher's background drain loop, which retries with
+      // backoff until the row is marked PUBLISHED.
       for (const trade of matchResult.trades) {
-        try {
-          await settlementQueue.enqueue({
-            tradeId: trade.id,
-            marketId: trade.marketId,
-            outcome: trade.outcome,
-            buyOrderId: trade.buyOrderId,
-            sellOrderId: trade.sellOrderId,
-            buyerAddress: trade.buyerAddress,
-            sellerAddress: trade.sellerAddress,
-            price: trade.price,
-            quantity: trade.quantity,
-            timestamp: trade.timestamp,
-          });
-        } catch (error) {
-          const err = error instanceof Error ? error : new Error(String(error));
-          settlementErrors.push({ tradeId: trade.id, error: err });
-          console.error(
-            JSON.stringify({
-              level: "error",
-              component: "matching-service",
-              action: "settlement_enqueue_failed",
-              tradeId: trade.id,
-              buyOrderId: trade.buyOrderId,
-              sellOrderId: trade.sellOrderId,
-              message: err.message,
-              stack: err.stack,
-            })
-          );
-        }
+        await publishOutboxRow(prisma, {
+          tradeId: trade.id,
+          payload: buildSettlementPayload(trade),
+          attempts: 0,
+        });
       }
 
       // 4. Refresh Redis cache with proper error handling

--- a/src/services/metrics.ts
+++ b/src/services/metrics.ts
@@ -38,3 +38,32 @@ export const oracleFailClosedTotal = new client.Counter({
   help: "Total number of times the oracle failed closed after all providers were unreachable",
   registers: [metricsRegistry],
 });
+
+/**
+ * Settlement outbox metrics (transactional outbox pattern for
+ * MatchingService.placeOrder -> settlement queue delivery).
+ * Updated by src/services/outbox-publisher.ts after each drain cycle.
+ */
+export const settlementOutboxDepthGauge = new client.Gauge({
+  name: "vatix_settlement_outbox_depth",
+  help: "Number of settlement outbox rows not yet PUBLISHED (PENDING + FAILED)",
+  registers: [metricsRegistry],
+});
+
+export const settlementOutboxLagSecondsGauge = new client.Gauge({
+  name: "vatix_settlement_outbox_lag_seconds",
+  help: "Age in seconds of the oldest unpublished settlement outbox row",
+  registers: [metricsRegistry],
+});
+
+export const settlementOutboxPublishFailuresTotal = new client.Counter({
+  name: "vatix_settlement_outbox_publish_failures_total",
+  help: "Total number of failed attempts to publish an outbox row to the settlement queue",
+  registers: [metricsRegistry],
+});
+
+export const settlementOutboxOrphanedTradesGauge = new client.Gauge({
+  name: "vatix_settlement_outbox_orphaned_trades",
+  help: "Number of outbox rows that have failed to publish at least OUTBOX_ORPHAN_ATTEMPTS_THRESHOLD times",
+  registers: [metricsRegistry],
+});

--- a/src/services/outbox-publisher.test.ts
+++ b/src/services/outbox-publisher.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Settlement Outbox Publisher Tests
+ *
+ * Verifies the transactional-outbox recovery path: a trade committed to
+ * Postgres with an OutboxEvent row must reach the settlement queue at
+ * least once, even if the enqueue call fails (simulated Redis outage /
+ * process crash) on the first attempt. Also verifies idempotency: draining
+ * the same row twice (two publisher instances racing, or a retry after a
+ * crash mid-publish) never errors and always converges on PUBLISHED.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./settlement-queue.js", () => ({
+  settlementQueue: {
+    enqueue: vi.fn(),
+  },
+}));
+
+vi.mock("./prisma.js", () => ({
+  getPrismaClient: vi.fn(),
+}));
+
+vi.mock("./metrics.js", () => ({
+  settlementOutboxDepthGauge: { set: vi.fn() },
+  settlementOutboxLagSecondsGauge: { set: vi.fn() },
+  settlementOutboxPublishFailuresTotal: { inc: vi.fn() },
+  settlementOutboxOrphanedTradesGauge: { set: vi.fn() },
+}));
+
+import { settlementQueue } from "./settlement-queue.js";
+import {
+  settlementOutboxDepthGauge,
+  settlementOutboxLagSecondsGauge,
+  settlementOutboxOrphanedTradesGauge,
+} from "./metrics.js";
+import {
+  buildSettlementPayload,
+  publishOutboxRow,
+  drainOutboxOnce,
+  refreshOutboxMetrics,
+  type OutboxRow,
+} from "./outbox-publisher.js";
+
+function makeTrade(
+  overrides?: Partial<Parameters<typeof buildSettlementPayload>[0]>
+) {
+  return {
+    id: "trade-1",
+    marketId: "market-1",
+    outcome: "YES",
+    buyOrderId: "buy-1",
+    sellOrderId: "sell-1",
+    buyerAddress: "GBUYER0000000000000000000000000000000000000000000000",
+    sellerAddress: "GSELLER000000000000000000000000000000000000000000000",
+    price: 0.5,
+    quantity: 10,
+    timestamp: 1700000000000,
+    ...overrides,
+  };
+}
+
+function makeMockPrisma() {
+  return {
+    outboxEvent: {
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+  };
+}
+
+describe("buildSettlementPayload", () => {
+  it("maps a Trade into the SettlementJob shape", () => {
+    const trade = makeTrade();
+    const payload = buildSettlementPayload(trade);
+
+    expect(payload).toEqual({
+      tradeId: "trade-1",
+      marketId: "market-1",
+      outcome: "YES",
+      buyOrderId: "buy-1",
+      sellOrderId: "sell-1",
+      buyerAddress: trade.buyerAddress,
+      sellerAddress: trade.sellerAddress,
+      price: 0.5,
+      quantity: 10,
+      timestamp: 1700000000000,
+    });
+  });
+});
+
+describe("publishOutboxRow", () => {
+  let mockPrisma: ReturnType<typeof makeMockPrisma>;
+  let row: OutboxRow;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = makeMockPrisma();
+    row = {
+      tradeId: "trade-1",
+      payload: buildSettlementPayload(makeTrade()),
+      attempts: 0,
+    };
+  });
+
+  it("marks the row PUBLISHED when enqueue succeeds", async () => {
+    vi.mocked(settlementQueue.enqueue).mockResolvedValue(undefined);
+
+    const outcome = await publishOutboxRow(mockPrisma as any, row);
+
+    expect(outcome).toBe("published");
+    expect(settlementQueue.enqueue).toHaveBeenCalledWith(row.payload);
+    expect(mockPrisma.outboxEvent.updateMany).toHaveBeenCalledWith({
+      where: { tradeId: "trade-1", status: { not: "PUBLISHED" } },
+      data: { status: "PUBLISHED", publishedAt: expect.any(Date) },
+    });
+  });
+
+  it("marks the row FAILED with incremented attempts and backoff when Redis is down", async () => {
+    vi.mocked(settlementQueue.enqueue).mockRejectedValue(
+      new Error("ECONNREFUSED: redis down")
+    );
+
+    const outcome = await publishOutboxRow(mockPrisma as any, row);
+
+    expect(outcome).toBe("failed");
+    expect(mockPrisma.outboxEvent.updateMany).toHaveBeenCalledWith({
+      where: { tradeId: "trade-1", status: { not: "PUBLISHED" } },
+      data: {
+        status: "FAILED",
+        attempts: 1,
+        lastError: expect.stringContaining("redis down"),
+        nextAttemptAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("crash mid-publish: enqueue succeeds but the row was never re-read — a retry of the SAME row is idempotent", async () => {
+    // Simulates: enqueue succeeded, then the process crashed before the
+    // updateMany landed. On restart, the publisher drains the row again
+    // (still PENDING/FAILED in the DB) and retries — this must not throw,
+    // must not double-apply anything, and must still converge on PUBLISHED.
+    vi.mocked(settlementQueue.enqueue).mockResolvedValue(undefined);
+
+    const first = await publishOutboxRow(mockPrisma as any, row);
+    const second = await publishOutboxRow(mockPrisma as any, row);
+
+    expect(first).toBe("published");
+    expect(second).toBe("published");
+    expect(settlementQueue.enqueue).toHaveBeenCalledTimes(2);
+    expect(settlementQueue.enqueue).toHaveBeenNthCalledWith(1, row.payload);
+    expect(settlementQueue.enqueue).toHaveBeenNthCalledWith(2, row.payload);
+  });
+
+  it("recovers after a transient failure: FAILED row retried later succeeds", async () => {
+    vi.mocked(settlementQueue.enqueue).mockRejectedValueOnce(
+      new Error("redis down")
+    );
+    vi.mocked(settlementQueue.enqueue).mockResolvedValueOnce(undefined);
+
+    const failedOutcome = await publishOutboxRow(mockPrisma as any, row);
+    expect(failedOutcome).toBe("failed");
+
+    const retryRow: OutboxRow = { ...row, attempts: 1 };
+    const publishedOutcome = await publishOutboxRow(
+      mockPrisma as any,
+      retryRow
+    );
+    expect(publishedOutcome).toBe("published");
+  });
+});
+
+describe("drainOutboxOnce", () => {
+  let mockPrisma: ReturnType<typeof makeMockPrisma>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = makeMockPrisma();
+  });
+
+  it("publishes every due row and reports counts", async () => {
+    const trades = [makeTrade({ id: "trade-1" }), makeTrade({ id: "trade-2" })];
+    mockPrisma.outboxEvent.findMany.mockResolvedValue(
+      trades.map((t) => ({
+        tradeId: t.id,
+        payload: buildSettlementPayload(t),
+        attempts: 0,
+        status: "PENDING",
+      }))
+    );
+    vi.mocked(settlementQueue.enqueue).mockResolvedValue(undefined);
+
+    const result = await drainOutboxOnce(mockPrisma as any, 10);
+
+    expect(result).toEqual({ published: 2, failed: 0 });
+    expect(settlementQueue.enqueue).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues draining remaining rows when one row fails to publish", async () => {
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([
+      {
+        tradeId: "trade-1",
+        payload: buildSettlementPayload(makeTrade({ id: "trade-1" })),
+        attempts: 0,
+        status: "PENDING",
+      },
+      {
+        tradeId: "trade-2",
+        payload: buildSettlementPayload(makeTrade({ id: "trade-2" })),
+        attempts: 0,
+        status: "PENDING",
+      },
+    ]);
+    vi.mocked(settlementQueue.enqueue)
+      .mockRejectedValueOnce(new Error("redis down"))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await drainOutboxOnce(mockPrisma as any, 10);
+
+    expect(result).toEqual({ published: 1, failed: 1 });
+  });
+
+  it("duplicate drain of the same batch (two publisher instances racing) is safe and idempotent", async () => {
+    const row = {
+      tradeId: "trade-1",
+      payload: buildSettlementPayload(makeTrade()),
+      attempts: 0,
+      status: "PENDING",
+    };
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([row]);
+    vi.mocked(settlementQueue.enqueue).mockResolvedValue(undefined);
+
+    const [first, second] = await Promise.all([
+      drainOutboxOnce(mockPrisma as any, 10),
+      drainOutboxOnce(mockPrisma as any, 10),
+    ]);
+
+    // Both drains see the same PENDING row (neither has claimed it yet) and
+    // both successfully publish — enqueue is called twice, which is
+    // acceptable because settlementQueue delivery is at-least-once and the
+    // downstream settlement consumer idempotency-checks on tradeId (#870).
+    expect(first.published).toBe(1);
+    expect(second.published).toBe(1);
+    expect(settlementQueue.enqueue).toHaveBeenCalledTimes(2);
+    // Never throws, never reports a hard failure for a duplicate.
+    expect(first.failed).toBe(0);
+    expect(second.failed).toBe(0);
+  });
+
+  it("only selects rows past their backoff window", async () => {
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+
+    await drainOutboxOnce(mockPrisma as any, 10);
+
+    expect(mockPrisma.outboxEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          status: { in: ["PENDING", "FAILED"] },
+          nextAttemptAt: { lte: expect.any(Date) },
+        },
+      })
+    );
+  });
+});
+
+describe("refreshOutboxMetrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets depth, lag, and orphaned gauges from current DB state", async () => {
+    const mockPrisma = makeMockPrisma();
+    mockPrisma.outboxEvent.count
+      .mockResolvedValueOnce(7) // depth
+      .mockResolvedValueOnce(2); // orphaned
+    const oldest = new Date(Date.now() - 5_000);
+    mockPrisma.outboxEvent.findFirst.mockResolvedValue({ createdAt: oldest });
+
+    await refreshOutboxMetrics(mockPrisma as any);
+
+    expect(settlementOutboxDepthGauge.set).toHaveBeenCalledWith(7);
+    expect(settlementOutboxOrphanedTradesGauge.set).toHaveBeenCalledWith(2);
+    const [lagValue] = vi.mocked(settlementOutboxLagSecondsGauge.set).mock
+      .calls[0];
+    expect(lagValue).toBeGreaterThanOrEqual(4);
+    expect(lagValue).toBeLessThan(10);
+  });
+
+  it("reports zero lag when there are no unpublished rows", async () => {
+    const mockPrisma = makeMockPrisma();
+
+    await refreshOutboxMetrics(mockPrisma as any);
+
+    expect(settlementOutboxLagSecondsGauge.set).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/services/outbox-publisher.ts
+++ b/src/services/outbox-publisher.ts
@@ -1,0 +1,284 @@
+/**
+ * Settlement Outbox Publisher — transactional outbox pattern.
+ *
+ * MatchingService.placeOrder writes an OutboxEvent row in the SAME
+ * Prisma transaction as the Trade upsert, so a committed trade and its
+ * outbox row are atomic. This module drains PENDING/FAILED outbox rows into
+ * the settlement queue (`settlementQueue.enqueue`) and marks them PUBLISHED,
+ * guaranteeing at-least-once delivery even if the process crashes or Redis
+ * is unreachable between commit and enqueue.
+ *
+ * See docs/adr/003-settlement-outbox.md for the full design and operator
+ * recovery flow.
+ *
+ * @module src/services/outbox-publisher
+ */
+import type { PrismaClient } from "../generated/prisma/client/index.js";
+import { getPrismaClient } from "./prisma.js";
+import { settlementQueue, type SettlementJob } from "./settlement-queue.js";
+import {
+  settlementOutboxDepthGauge,
+  settlementOutboxLagSecondsGauge,
+  settlementOutboxPublishFailuresTotal,
+  settlementOutboxOrphanedTradesGauge,
+} from "./metrics.js";
+
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_BASE_BACKOFF_MS = 1_000;
+const DEFAULT_MAX_BACKOFF_MS = 60_000;
+
+/**
+ * Attempts after which a still-failing row is surfaced via the
+ * orphaned-trade-count metric (for alerting). It is NOT abandoned — the
+ * publisher keeps retrying with capped exponential backoff indefinitely.
+ */
+const ORPHAN_ATTEMPTS_THRESHOLD =
+  Number(process.env.OUTBOX_ORPHAN_ATTEMPTS_THRESHOLD) || 5;
+
+/** Minimal shape needed to publish + mark a single outbox row. */
+export interface OutboxRow {
+  tradeId: string;
+  payload: SettlementJob;
+  attempts: number;
+}
+
+function backoffMs(attempts: number): number {
+  const delay = DEFAULT_BASE_BACKOFF_MS * 2 ** attempts;
+  return Math.min(delay, DEFAULT_MAX_BACKOFF_MS);
+}
+
+/**
+ * Builds the SettlementJob payload persisted in an outbox row from the
+ * fields available immediately after a Trade is upserted.
+ */
+export function buildSettlementPayload(trade: {
+  id: string;
+  marketId: string;
+  outcome: string;
+  buyOrderId: string;
+  sellOrderId: string;
+  buyerAddress: string;
+  sellerAddress: string;
+  price: number;
+  quantity: number;
+  timestamp: number;
+}): SettlementJob {
+  return {
+    tradeId: trade.id,
+    marketId: trade.marketId,
+    outcome: trade.outcome as SettlementJob["outcome"],
+    buyOrderId: trade.buyOrderId,
+    sellOrderId: trade.sellOrderId,
+    buyerAddress: trade.buyerAddress,
+    sellerAddress: trade.sellerAddress,
+    price: trade.price,
+    quantity: trade.quantity,
+    timestamp: trade.timestamp,
+  };
+}
+
+/**
+ * Publishes a single outbox row to the settlement queue and marks the
+ * outcome atomically, keyed on the unique `tradeId` rather than a
+ * previously-read row id — the caller (matching-service's post-commit fast
+ * path) never needs to round-trip the generated outbox row id.
+ *
+ * Idempotent on tradeId: safe to call more than once for the same trade
+ * (e.g. the fast path and the background drain racing the same row). A
+ * duplicate call can at worst enqueue the settlement job twice; the
+ * settlement consumer already idempotency-checks on tradeId (#870), so no
+ * position is ever applied twice.
+ */
+export async function publishOutboxRow(
+  prisma: PrismaClient,
+  row: OutboxRow
+): Promise<"published" | "failed"> {
+  const client = prisma as unknown as {
+    outboxEvent: {
+      updateMany: (args: unknown) => Promise<{ count: number }>;
+    };
+  };
+
+  try {
+    await settlementQueue.enqueue(row.payload);
+
+    await client.outboxEvent.updateMany({
+      where: { tradeId: row.tradeId, status: { not: "PUBLISHED" } },
+      data: { status: "PUBLISHED", publishedAt: new Date() },
+    });
+
+    return "published";
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    const nextAttempt = row.attempts + 1;
+
+    await client.outboxEvent.updateMany({
+      where: { tradeId: row.tradeId, status: { not: "PUBLISHED" } },
+      data: {
+        status: "FAILED",
+        attempts: nextAttempt,
+        lastError: err.message.slice(0, 2000),
+        nextAttemptAt: new Date(Date.now() + backoffMs(nextAttempt)),
+      },
+    });
+
+    settlementOutboxPublishFailuresTotal.inc();
+    console.error(
+      JSON.stringify({
+        level: "error",
+        component: "outbox-publisher",
+        action: "outbox_publish_failed",
+        tradeId: row.tradeId,
+        attempts: nextAttempt,
+        message: err.message,
+      })
+    );
+
+    return "failed";
+  }
+}
+
+/**
+ * Drains one batch of due (PENDING or FAILED-and-past-backoff) outbox rows.
+ * Safe to call concurrently from multiple processes: publishing is
+ * idempotent on tradeId (see publishOutboxRow), so at worst two instances
+ * both publish the same row in the same window — never a lost trade.
+ */
+export async function drainOutboxOnce(
+  prisma: PrismaClient,
+  batchSize: number = DEFAULT_BATCH_SIZE
+): Promise<{ published: number; failed: number }> {
+  const client = prisma as unknown as {
+    outboxEvent: {
+      findMany: (args: unknown) => Promise<
+        Array<{
+          tradeId: string;
+          payload: unknown;
+          attempts: number;
+          status: string;
+        }>
+      >;
+    };
+  };
+
+  const rows = await client.outboxEvent.findMany({
+    where: {
+      status: { in: ["PENDING", "FAILED"] },
+      nextAttemptAt: { lte: new Date() },
+    },
+    orderBy: { createdAt: "asc" },
+    take: batchSize,
+  });
+
+  let published = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    const outcome = await publishOutboxRow(prisma, {
+      tradeId: row.tradeId,
+      payload: row.payload as SettlementJob,
+      attempts: row.attempts,
+    });
+    if (outcome === "published") {
+      published++;
+    } else {
+      failed++;
+    }
+  }
+
+  await refreshOutboxMetrics(prisma);
+
+  return { published, failed };
+}
+
+/** Recomputes the outbox depth/lag/orphaned gauges from current DB state. */
+export async function refreshOutboxMetrics(
+  prisma: PrismaClient
+): Promise<void> {
+  const client = prisma as unknown as {
+    outboxEvent: {
+      count: (args: unknown) => Promise<number>;
+      findFirst: (args: unknown) => Promise<{ createdAt: Date } | null>;
+    };
+  };
+
+  const [depth, oldest, orphaned] = await Promise.all([
+    client.outboxEvent.count({
+      where: { status: { in: ["PENDING", "FAILED"] } },
+    }),
+    client.outboxEvent.findFirst({
+      where: { status: { in: ["PENDING", "FAILED"] } },
+      orderBy: { createdAt: "asc" },
+      select: { createdAt: true },
+    }),
+    client.outboxEvent.count({
+      where: {
+        status: "FAILED",
+        attempts: { gte: ORPHAN_ATTEMPTS_THRESHOLD },
+      },
+    }),
+  ]);
+
+  settlementOutboxDepthGauge.set(depth);
+  settlementOutboxLagSecondsGauge.set(
+    oldest ? (Date.now() - oldest.createdAt.getTime()) / 1000 : 0
+  );
+  settlementOutboxOrphanedTradesGauge.set(orphaned);
+}
+
+export interface OutboxPublisherOptions {
+  intervalMs?: number;
+  batchSize?: number;
+  prisma?: PrismaClient;
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let draining = false;
+
+/**
+ * Starts the background drain loop on a fixed interval. Safe to call once
+ * per process; a second call is a no-op while a loop is already running.
+ * Configurable via OUTBOX_PUBLISHER_INTERVAL_MS / OUTBOX_PUBLISHER_BATCH_SIZE.
+ */
+export function startOutboxPublisher(
+  options: OutboxPublisherOptions = {}
+): void {
+  if (timer) return;
+
+  const intervalMs =
+    options.intervalMs ??
+    (Number(process.env.OUTBOX_PUBLISHER_INTERVAL_MS) || 2_000);
+  const batchSize =
+    options.batchSize ??
+    (Number(process.env.OUTBOX_PUBLISHER_BATCH_SIZE) || DEFAULT_BATCH_SIZE);
+  const prisma = options.prisma ?? getPrismaClient();
+
+  timer = setInterval(() => {
+    if (draining) return;
+    draining = true;
+    drainOutboxOnce(prisma, batchSize)
+      .catch((error) => {
+        console.error(
+          JSON.stringify({
+            level: "error",
+            component: "outbox-publisher",
+            action: "drain_failed",
+            message: error instanceof Error ? error.message : String(error),
+          })
+        );
+      })
+      .finally(() => {
+        draining = false;
+      });
+  }, intervalMs);
+
+  timer.unref?.();
+}
+
+/** Stops the background drain loop. Used by graceful shutdown and tests. */
+export function stopOutboxPublisher(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/tests/integration/settlement-outbox.test.ts
+++ b/tests/integration/settlement-outbox.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Settlement Outbox Integration Tests
+ *
+ * Verifies the transactional outbox pattern end-to-end: a trade committed
+ * via POST /v1/orders must be durably queued for settlement even if the
+ * post-commit fast-path enqueue fails (Redis down / process crash between
+ * commit and enqueue) — the outbox row is written in the SAME DB
+ * transaction as the trade, so the recovery loop (drainOutboxOnce) can
+ * always find and republish it later.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from "vitest";
+import type { FastifyInstance } from "fastify";
+import { Keypair } from "@stellar/stellar-sdk";
+import { ordersRoutes } from "../../src/api/routes/orders.js";
+import { buildSignableMessage } from "../../src/api/middleware/stellarAuth.js";
+import { issueChallenge } from "../../src/api/middleware/nonceStore.js";
+import { buildTestApp, resetRateLimits } from "./helpers/build-test-app.js";
+import { testUtils, getTestPrismaClient } from "../setup.js";
+import {
+  acquireDatabaseLock,
+  releaseDatabaseLock,
+} from "../helpers/test-database.js";
+import { matchingService } from "../../src/matching/matching-service.js";
+import { settlementQueue } from "../../src/services/settlement-queue.js";
+import { drainOutboxOnce } from "../../src/services/outbox-publisher.js";
+
+const takerKeypair = Keypair.random();
+const makerKeypair = Keypair.random();
+const takerAddress = takerKeypair.publicKey();
+const makerAddress = makerKeypair.publicKey();
+
+async function authHeaders(
+  keypair: Keypair,
+  body: {
+    marketId: string;
+    userAddress: string;
+    side: string;
+    outcome: string;
+    price: number;
+    quantity: number;
+  }
+): Promise<Record<string, string>> {
+  const timestamp = Date.now();
+  const { nonce } = await issueChallenge(keypair.publicKey());
+  const sig = keypair
+    .sign(buildSignableMessage({ ...body, nonce, timestamp }))
+    .toString("base64");
+  return {
+    "x-signature": sig,
+    "x-timestamp": String(timestamp),
+    "x-nonce": nonce,
+  };
+}
+
+describe("Settlement Outbox — durable trade -> settlement queue delivery", () => {
+  let app: FastifyInstance;
+  const prisma = getTestPrismaClient();
+
+  beforeAll(async () => {
+    await acquireDatabaseLock();
+    app = await buildTestApp({ plugins: [ordersRoutes] });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await releaseDatabaseLock();
+  });
+
+  beforeEach(() => {
+    resetRateLimits();
+    (matchingService as any).books?.clear();
+    (matchingService as any).locks?.clear();
+    vi.clearAllMocks();
+  });
+
+  async function placeCrossingOrders(): Promise<{ marketId: string }> {
+    const market = await testUtils.createTestMarket({ status: "ACTIVE" });
+
+    await testUtils.createTestOrder(market.id, makerAddress, {
+      side: "SELL",
+      outcome: "YES",
+      price: 0.5,
+      quantity: 100,
+      filledQuantity: 0,
+      status: "OPEN",
+    });
+
+    const payload = {
+      marketId: market.id,
+      userAddress: takerAddress,
+      side: "BUY",
+      outcome: "YES",
+      price: 0.5,
+      quantity: 100,
+    };
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/orders",
+      headers: await authHeaders(takerKeypair, payload),
+      payload,
+    });
+
+    expect(res.statusCode).toBe(201);
+    return { marketId: market.id };
+  }
+
+  it("never permanently drops settlement when Redis is down between commit and enqueue", async () => {
+    // Simulate Redis being unreachable for the fast-path enqueue that runs
+    // immediately after the DB transaction commits.
+    vi.spyOn(settlementQueue, "enqueue").mockRejectedValue(
+      new Error("ECONNREFUSED: redis down")
+    );
+
+    await placeCrossingOrders();
+
+    // The trade is durably committed regardless of the enqueue failure.
+    const trades = await prisma.trade.findMany();
+    expect(trades).toHaveLength(1);
+    const tradeId = trades[0].tradeId;
+
+    // The outbox row for that trade exists and reflects the failed publish
+    // attempt — it is NOT lost, just not yet published.
+    const outboxRow = await (prisma as any).outboxEvent.findUnique({
+      where: { tradeId },
+    });
+    expect(outboxRow).not.toBeNull();
+    expect(outboxRow.status).toBe("FAILED");
+    expect(outboxRow.publishedAt).toBeNull();
+    expect(outboxRow.attempts).toBeGreaterThanOrEqual(1);
+
+    // Recovery: Redis comes back. The publisher's background drain loop
+    // (started by the settlement worker process) picks the row up and
+    // republishes it — simulated here via a single drain call.
+    vi.spyOn(settlementQueue, "enqueue").mockResolvedValue(undefined);
+    await (prisma as any).outboxEvent.update({
+      where: { tradeId },
+      data: { nextAttemptAt: new Date() },
+    });
+
+    const result = await drainOutboxOnce(prisma as any, 10);
+    expect(result.published).toBe(1);
+    expect(settlementQueue.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ tradeId })
+    );
+
+    const publishedRow = await (prisma as any).outboxEvent.findUnique({
+      where: { tradeId },
+    });
+    expect(publishedRow.status).toBe("PUBLISHED");
+    expect(publishedRow.publishedAt).not.toBeNull();
+  });
+
+  it("crash mid-publish: outbox row survives even if the fast path never runs at all", async () => {
+    // Simulate a hard process crash right after the DB transaction commits,
+    // before the fast-path enqueue loop executes at all. We approximate
+    // this by making enqueue throw synchronously for every fast-path call —
+    // from the DB's perspective this is indistinguishable from "the process
+    // died before publishing": the trade is committed, the outbox row is
+    // PENDING/FAILED, and nothing besides the background drain loop moves
+    // it forward.
+    vi.spyOn(settlementQueue, "enqueue").mockRejectedValue(
+      new Error("process crashed")
+    );
+
+    await placeCrossingOrders();
+
+    const trades = await prisma.trade.findMany();
+    const tradeId = trades[0].tradeId;
+
+    let row = await (prisma as any).outboxEvent.findUnique({
+      where: { tradeId },
+    });
+    expect(row.status).not.toBe("PUBLISHED");
+
+    // Two independent drain calls race for the same row (e.g. worker
+    // restarted mid-drain and a second instance also picks it up). Neither
+    // should error, and the row must converge on PUBLISHED exactly once in
+    // terms of final state — duplicate settlementQueue.enqueue calls are
+    // acceptable because settlement consumer idempotency-checks on tradeId.
+    vi.spyOn(settlementQueue, "enqueue").mockResolvedValue(undefined);
+    await (prisma as any).outboxEvent.update({
+      where: { tradeId },
+      data: { nextAttemptAt: new Date() },
+    });
+
+    await Promise.all([
+      drainOutboxOnce(prisma as any, 10),
+      drainOutboxOnce(prisma as any, 10),
+    ]);
+
+    row = await (prisma as any).outboxEvent.findUnique({ where: { tradeId } });
+    expect(row.status).toBe("PUBLISHED");
+
+    // No duplicate trade rows were ever created — trade persistence is
+    // upserted on tradeId independently of how many times settlement
+    // publish was retried.
+    const allTrades = await prisma.trade.findMany({ where: { tradeId } });
+    expect(allTrades).toHaveLength(1);
+  });
+
+  it("publishes successfully on the fast path when Redis is healthy (no outbox backlog)", async () => {
+    vi.spyOn(settlementQueue, "enqueue").mockResolvedValue(undefined);
+
+    await placeCrossingOrders();
+
+    const trades = await prisma.trade.findMany();
+    const tradeId = trades[0].tradeId;
+
+    const row = await (prisma as any).outboxEvent.findUnique({
+      where: { tradeId },
+    });
+    expect(row.status).toBe("PUBLISHED");
+    expect(row.publishedAt).not.toBeNull();
+  });
+});


### PR DESCRIPTION
closes #864 

Implemented a durable transactional outbox to guarantee reliable trade delivery to the settlement queue, eliminating the risk of lost messages caused by Postgres–Redis dual writes.

Changes
Added an OutboxEvent persisted within the same Prisma transaction as trade upserts.
Implemented a resilient outbox publisher with retry/backoff to publish events to the settlement queue.
Added atomic publish state updates (status and publishedAt) with safe crash recovery and republishing.
Introduced metrics for outbox lag, publish failures, and orphaned trades.
Added an integration test covering Redis failure after DB commit to verify automatic recovery.
Documented the outbox recovery workflow for operators.