### PR TITLE
Make oracle report submission crash-safe with durable state machine

### DIFF
--- a/apps/workers/src/oracle/main.ts
+++ b/apps/workers/src/oracle/main.ts
@@ -4,6 +4,13 @@
  * Replaces the RedisSubmissionQueue polling loop with a BullMQ Worker.
  * Retry/backoff/DLQ are now handled by BullMQ via DEFAULT_JOB_OPTIONS.
  *
+ * Crash safety (#996): submissions are tracked through a durable
+ * PENDING -> SUBMITTED -> CONFIRMED|FAILED state machine keyed by
+ * (marketId, payloadHash) — see ./submission-reconciliation.ts. The tx hash
+ * is persisted immediately after broadcast, before confirmation is polled,
+ * and any submission left SUBMITTED from a prior process (crash/restart) is
+ * reconciled against the chain on startup before new jobs are processed.
+ *
  * @module apps/workers/src/oracle/main
  */
 
@@ -36,23 +43,59 @@ import {
   rpc as StellarRpc,
   xdr,
 } from "@stellar/stellar-sdk";
-import { createHash } from "crypto";
 import type { ShutdownSignal } from "../../../../packages/shared/src/shutdown.js";
 import { createShutdown } from "../../../../packages/shared/src/shutdown.js";
+import { withRetry } from "../../../oracle/retry-utils.js";
+import {
+  checkOnChainStatus,
+  claimSubmissionIntent,
+  computePayloadHash,
+  recordBroadcast,
+  recordConfirmed,
+  reconcileInFlightSubmissions,
+  resetForRetry,
+  type OracleReportRow,
+} from "./submission-reconciliation.js";
+import { oracleSubmissionAmbiguousTotal } from "../../../../src/services/metrics.js";
 
 type OracleStellarConfig = ResolvedOracleStellarConfig;
 
-async function submitOnChain(
+/** Thrown when a broadcast tx's on-chain status cannot yet be determined.
+ *  BullMQ will retry the job, which re-checks chain status rather than
+ *  building and sending a new transaction. */
+class AmbiguousSubmissionError extends Error {
+  constructor(marketId: string, txHash: string) {
+    super(
+      `resolve_market submission is ambiguous (unconfirmed): marketId=${marketId} hash=${txHash}`
+    );
+    this.name = "AmbiguousSubmissionError";
+  }
+}
+
+const STELLAR_RPC_RETRY_CONFIG = {
+  maxRetries: 3,
+  initialDelayMs: 500,
+  maxDelayMs: 5_000,
+};
+
+/**
+ * Broadcasts the signed resolution on-chain, persisting the tx hash the
+ * instant it's known (before polling for confirmation), then polls until
+ * confirmed or definitively failed.
+ */
+async function broadcastAndConfirm(
   report: SignedResolutionReport,
-  oracleAddress: string,
+  payloadHash: string,
+  attempts: number,
   stellar: OracleStellarConfig,
+  prisma: ReturnType<typeof getPrismaClient>,
   logger: ReturnType<typeof createLogger>
 ): Promise<string> {
   const { rpcUrl, contractId, networkPassphrase, signerSecret } = stellar;
+  const marketId = report.payload.marketId;
 
   logger.debug("Invoking resolve_market on-chain", {
-    marketId: report.payload.marketId,
-    oracleAddress,
+    marketId,
     outcome: report.payload.outcome,
     contractId,
   });
@@ -60,7 +103,21 @@ async function submitOnChain(
   const keypair = Keypair.fromSecret(signerSecret);
   const server = new StellarRpc.Server(rpcUrl);
   const contract = new Contract(contractId);
-  const sourceAccount = await server.getAccount(keypair.publicKey());
+
+  const onRpcRetry = (error: Error, attempt: number, delayMs: number) => {
+    logger.warn("Retrying Stellar RPC call for resolve_market", {
+      marketId,
+      attempt,
+      delayMs,
+      error: error.message,
+    });
+  };
+
+  const sourceAccount = await withRetry(
+    () => server.getAccount(keypair.publicKey()),
+    STELLAR_RPC_RETRY_CONFIG,
+    onRpcRetry
+  );
 
   const args: xdr.ScVal[] = [
     nativeToScVal(report.payload.marketId, { type: "string" }),
@@ -77,9 +134,18 @@ async function submitOnChain(
     .setTimeout(30)
     .build();
 
-  const preparedTx = await server.prepareTransaction(tx);
+  const preparedTx = await withRetry(
+    () => server.prepareTransaction(tx),
+    STELLAR_RPC_RETRY_CONFIG,
+    onRpcRetry
+  );
   preparedTx.sign(keypair);
-  const sendResult = await server.sendTransaction(preparedTx);
+
+  const sendResult = await withRetry(
+    () => server.sendTransaction(preparedTx),
+    STELLAR_RPC_RETRY_CONFIG,
+    onRpcRetry
+  );
 
   if (sendResult.status === "ERROR") {
     throw new Error(
@@ -88,8 +154,18 @@ async function submitOnChain(
   }
 
   logger.info("resolve_market submitted, awaiting confirmation", {
-    marketId: report.payload.marketId,
+    marketId,
     hash: sendResult.hash,
+  });
+
+  // Persist the tx hash immediately — before polling for confirmation. This
+  // is the durable record a restart reconciles against if the process
+  // crashes anywhere between here and observing confirmation.
+  await recordBroadcast(prisma, {
+    marketId,
+    payloadHash,
+    txHash: sendResult.hash,
+    attempts,
   });
 
   const MAX_POLL = 30;
@@ -98,22 +174,77 @@ async function submitOnChain(
     const txStatus = await server.getTransaction(sendResult.hash);
     if (txStatus.status === StellarRpc.Api.GetTransactionStatus.SUCCESS) {
       logger.info("resolve_market confirmed on-chain", {
-        marketId: report.payload.marketId,
+        marketId,
         hash: sendResult.hash,
         ledger: txStatus.ledger,
+      });
+      await recordConfirmed(prisma, {
+        marketId,
+        payloadHash,
+        txHash: sendResult.hash,
       });
       return sendResult.hash;
     }
     if (txStatus.status === StellarRpc.Api.GetTransactionStatus.FAILED) {
+      await resetForRetry(prisma, { marketId, payloadHash, attempts });
       throw new Error(
         `resolve_market transaction failed on-chain: hash=${sendResult.hash}`
       );
     }
   }
 
-  throw new Error(
-    `resolve_market not confirmed after ${MAX_POLL}s: hash=${sendResult.hash}`
-  );
+  // Timed out waiting for confirmation. The tx hash is already durably
+  // persisted (recordBroadcast above), so this is ambiguous, not failed —
+  // leave the row SUBMITTED and let the next attempt (or startup
+  // reconciliation) re-check the chain rather than resubmitting.
+  oracleSubmissionAmbiguousTotal.inc();
+  throw new AmbiguousSubmissionError(marketId, sendResult.hash);
+}
+
+/**
+ * Checks a previously-broadcast, unconfirmed tx against the chain instead of
+ * blindly resubmitting. Only definite (timebound-expired) non-inclusion
+ * clears the row for a fresh broadcast.
+ */
+async function reconcileBeforeResubmit(
+  marketId: string,
+  payloadHash: string,
+  intent: OracleReportRow,
+  stellar: OracleStellarConfig,
+  prisma: ReturnType<typeof getPrismaClient>,
+  logger: ReturnType<typeof createLogger>
+): Promise<void> {
+  const txHash = intent.txHash!;
+  const server = new StellarRpc.Server(stellar.rpcUrl);
+
+  const result = await checkOnChainStatus(server, txHash, intent.broadcastAt);
+
+  if (result === "CONFIRMED") {
+    await recordConfirmed(prisma, { marketId, payloadHash, txHash });
+    logger.info("Prior oracle submission confirmed on recheck", {
+      marketId,
+      txHash,
+    });
+    return;
+  }
+
+  if (result === "FAILED") {
+    await resetForRetry(prisma, {
+      marketId,
+      payloadHash,
+      attempts: intent.attempts,
+    });
+    logger.warn(
+      "Prior oracle submission definitely not included, resubmitting",
+      { marketId, txHash }
+    );
+    throw new Error(
+      `previous resolve_market tx ${txHash} not included, cleared for resubmission`
+    );
+  }
+
+  oracleSubmissionAmbiguousTotal.inc();
+  throw new AmbiguousSubmissionError(marketId, txHash);
 }
 
 async function bootstrap(): Promise<void> {
@@ -132,6 +263,14 @@ async function bootstrap(): Promise<void> {
     );
   }
 
+  // Reconcile any submission left broadcast-but-unconfirmed by a prior
+  // process (crash, deploy, OOM-kill) before accepting new work, so a
+  // stale in-flight tx isn't shadowed by a fresh resubmission.
+  const reconciliationServer = stellarConfig
+    ? new StellarRpc.Server(stellarConfig.rpcUrl)
+    : undefined;
+  await reconcileInFlightSubmissions(prisma, reconciliationServer, logger);
+
   logger.info("Oracle submission worker starting (BullMQ)", {
     component: "oracle-worker",
   });
@@ -140,15 +279,40 @@ async function bootstrap(): Promise<void> {
     async (item: SubmissionQueueItem, attemptsMade: number) => {
       const { request, result } = item;
 
+      // Use the result's own timestamp (set once, at enqueue time) rather
+      // than minting a fresh one per attempt — a stable payload is required
+      // both for signature verification (signed with this exact timestamp)
+      // and for the payload hash to stay constant across retries (#996).
       const report: SignedResolutionReport = {
         payload: {
           marketId: request.marketId,
           outcome: result.outcome,
-          timestamp: new Date().toISOString(),
+          timestamp: result.timestamp,
         },
         signature: result.signature || "",
         publicKey: result.publicKey || "",
       };
+
+      const payloadHash = computePayloadHash(report.payload);
+
+      // Durable intent: claim (or fetch) the state-machine row *before* doing
+      // anything else, so a redelivery that fails signature verification
+      // still has a row to record the failure against.
+      const intent = await claimSubmissionIntent(prisma, {
+        marketId: request.marketId,
+        payloadHash,
+        source: request.oracleAddress,
+        candidateResolution: result.outcome,
+        createdAt: new Date(report.payload.timestamp),
+      });
+
+      if (intent.status === "CONFIRMED") {
+        logger.info(
+          "Oracle submission already confirmed, skipping resubmission",
+          { marketId: request.marketId, txHash: intent.txHash }
+        );
+        return;
+      }
 
       if (!verifyResolutionReport(report)) {
         throw new Error(
@@ -156,12 +320,22 @@ async function bootstrap(): Promise<void> {
         );
       }
 
-      let txHash: string | undefined;
-      if (stellarConfig) {
-        await submitOnChain(
-          report,
-          request.oracleAddress,
+      if (intent.status === "SUBMITTED" && intent.txHash && stellarConfig) {
+        await reconcileBeforeResubmit(
+          request.marketId,
+          payloadHash,
+          intent,
           stellarConfig,
+          prisma,
+          logger
+        );
+      } else if (stellarConfig) {
+        await broadcastAndConfirm(
+          report,
+          payloadHash,
+          attemptsMade + 1,
+          stellarConfig,
+          prisma,
           logger
         );
       } else {
@@ -169,25 +343,16 @@ async function bootstrap(): Promise<void> {
           "No Stellar config — resolve_market call skipped (off-chain only)",
           { marketId: request.marketId, oracleAddress: request.oracleAddress }
         );
+        await prisma.oracleReport.update({
+          where: {
+            marketId_payloadHash: {
+              marketId: request.marketId,
+              payloadHash,
+            },
+          },
+          data: { status: "CONFIRMED", txHash: null, confidence: 1.0 },
+        });
       }
-
-      const payloadHash = createHash("sha256")
-        .update(JSON.stringify(report.payload))
-        .digest("hex");
-
-      await prisma.oracleReport.create({
-        data: {
-          payloadHash,
-          source: request.oracleAddress,
-          confidence: 1.0,
-          marketId: request.marketId,
-          candidateResolution: result.outcome,
-          status: txHash ? "CONFIRMED" : "PENDING",
-          attempts: attemptsMade + 1,
-          txHash,
-          createdAt: new Date(report.payload.timestamp),
-        },
-      });
 
       await prisma.resolutionCandidate.upsert({
         where: {

--- a/apps/workers/src/oracle/submission-reconciliation.test.ts
+++ b/apps/workers/src/oracle/submission-reconciliation.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  rpc: {
+    Api: {
+      GetTransactionStatus: {
+        SUCCESS: "SUCCESS",
+        FAILED: "FAILED",
+        NOT_FOUND: "NOT_FOUND",
+      },
+    },
+  },
+}));
+
+import {
+  checkOnChainStatus,
+  computePayloadHash,
+  reconcileInFlightSubmissions,
+} from "./submission-reconciliation.js";
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn(),
+};
+
+describe("computePayloadHash", () => {
+  it("is stable for the same payload and differs for different payloads", () => {
+    const a = computePayloadHash({
+      marketId: "m1",
+      outcome: true,
+      timestamp: "t1",
+    });
+    const b = computePayloadHash({
+      marketId: "m1",
+      outcome: true,
+      timestamp: "t1",
+    });
+    const c = computePayloadHash({
+      marketId: "m1",
+      outcome: false,
+      timestamp: "t1",
+    });
+
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+});
+
+describe("checkOnChainStatus", () => {
+  it("returns CONFIRMED on SUCCESS", async () => {
+    const server = {
+      getTransaction: vi.fn().mockResolvedValue({ status: "SUCCESS" }),
+    };
+    await expect(
+      checkOnChainStatus(server as any, "hash1", new Date())
+    ).resolves.toBe("CONFIRMED");
+  });
+
+  it("returns FAILED on an on-chain FAILED status", async () => {
+    const server = {
+      getTransaction: vi.fn().mockResolvedValue({ status: "FAILED" }),
+    };
+    await expect(
+      checkOnChainStatus(server as any, "hash1", new Date())
+    ).resolves.toBe("FAILED");
+  });
+
+  it("returns AMBIGUOUS for NOT_FOUND within the tx's timebound", async () => {
+    const server = {
+      getTransaction: vi.fn().mockResolvedValue({ status: "NOT_FOUND" }),
+    };
+    const broadcastAt = new Date(); // just broadcast — well within the 30s timebound
+    await expect(
+      checkOnChainStatus(server as any, "hash1", broadcastAt)
+    ).resolves.toBe("AMBIGUOUS");
+  });
+
+  it("returns FAILED for NOT_FOUND once the timebound has definitely expired", async () => {
+    const server = {
+      getTransaction: vi.fn().mockResolvedValue({ status: "NOT_FOUND" }),
+    };
+    const broadcastAt = new Date(Date.now() - 5 * 60 * 1000); // 5 minutes ago
+    await expect(
+      checkOnChainStatus(server as any, "hash1", broadcastAt)
+    ).resolves.toBe("FAILED");
+  });
+
+  it("returns AMBIGUOUS for NOT_FOUND when broadcastAt is unknown", async () => {
+    const server = {
+      getTransaction: vi.fn().mockResolvedValue({ status: "NOT_FOUND" }),
+    };
+    await expect(
+      checkOnChainStatus(server as any, "hash1", null)
+    ).resolves.toBe("AMBIGUOUS");
+  });
+});
+
+describe("reconcileInFlightSubmissions", () => {
+  let prisma: {
+    oracleReport: {
+      findMany: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma = {
+      oracleReport: {
+        findMany: vi.fn(),
+        update: vi.fn().mockResolvedValue({ broadcastAt: null }),
+      },
+    };
+  });
+
+  it("is a no-op without a Stellar server (off-chain deployments)", async () => {
+    const summary = await reconcileInFlightSubmissions(
+      prisma as any,
+      undefined,
+      mockLogger
+    );
+
+    expect(summary).toEqual({ confirmed: 0, failed: 0, ambiguous: 0 });
+    expect(prisma.oracleReport.findMany).not.toHaveBeenCalled();
+  });
+
+  it("confirms rows whose broadcast tx succeeded on-chain", async () => {
+    prisma.oracleReport.findMany.mockResolvedValue([
+      {
+        marketId: "market-1",
+        payloadHash: "hash1",
+        txHash: "tx1",
+        attempts: 1,
+        broadcastAt: new Date(),
+      },
+    ]);
+    const server = {
+      getTransaction: vi.fn().mockResolvedValue({ status: "SUCCESS" }),
+    };
+
+    const summary = await reconcileInFlightSubmissions(
+      prisma as any,
+      server as any,
+      mockLogger
+    );
+
+    expect(summary.confirmed).toBe(1);
+    expect(prisma.oracleReport.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          marketId_payloadHash: { marketId: "market-1", payloadHash: "hash1" },
+        },
+        data: expect.objectContaining({ status: "CONFIRMED", txHash: "tx1" }),
+      })
+    );
+  });
+
+  it("clears rows for retry once non-inclusion is definite", async () => {
+    prisma.oracleReport.findMany.mockResolvedValue([
+      {
+        marketId: "market-1",
+        payloadHash: "hash1",
+        txHash: "tx1",
+        attempts: 1,
+        broadcastAt: new Date(Date.now() - 5 * 60 * 1000),
+      },
+    ]);
+    const server = {
+      getTransaction: vi.fn().mockResolvedValue({ status: "NOT_FOUND" }),
+    };
+
+    const summary = await reconcileInFlightSubmissions(
+      prisma as any,
+      server as any,
+      mockLogger
+    );
+
+    expect(summary.failed).toBe(1);
+    expect(prisma.oracleReport.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "PENDING", txHash: null }),
+      })
+    );
+  });
+
+  it("leaves recently-broadcast rows ambiguous rather than clearing them", async () => {
+    prisma.oracleReport.findMany.mockResolvedValue([
+      {
+        marketId: "market-1",
+        payloadHash: "hash1",
+        txHash: "tx1",
+        attempts: 1,
+        broadcastAt: new Date(),
+      },
+    ]);
+    const server = {
+      getTransaction: vi.fn().mockResolvedValue({ status: "NOT_FOUND" }),
+    };
+
+    const summary = await reconcileInFlightSubmissions(
+      prisma as any,
+      server as any,
+      mockLogger
+    );
+
+    expect(summary.ambiguous).toBe(1);
+    expect(prisma.oracleReport.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/workers/src/oracle/submission-reconciliation.ts
+++ b/apps/workers/src/oracle/submission-reconciliation.ts
@@ -1,0 +1,307 @@
+/**
+ * Oracle Submission State Machine & Reconciliation (#996)
+ *
+ * Makes oracle report submission crash-safe by persisting a durable
+ * intent -> broadcast -> confirmed/failed state machine for every
+ * (marketId, payloadHash) pair, and by reconciling any submission left
+ * "in flight" (broadcast but not yet confirmed) against the chain — on
+ * worker startup, and inline before a retry would otherwise resubmit.
+ *
+ * Without this, a crash between broadcasting a resolve_market tx and
+ * persisting its txHash/status is ambiguous: the retry loop cannot tell
+ * whether the tx landed on-chain, so it either double-submits (a fresh tx
+ * calling resolve_market again) or wrongly reports failure for a
+ * resolution that actually succeeded.
+ *
+ * @module apps/workers/src/oracle/submission-reconciliation
+ */
+import { rpc as StellarRpc } from "@stellar/stellar-sdk";
+import { createHash } from "crypto";
+import type { ILogger } from "../../../../packages/shared/src/logger.js";
+import type { PrismaClient } from "../../../../src/generated/prisma/client/index.js";
+import {
+  oracleSubmissionAmbiguousTotal,
+  oracleSubmissionConfirmationLatency,
+} from "../../../../src/services/metrics.js";
+
+/** Matches the `.setTimeout(30)` used when building the resolve_market tx.
+ *  Once this many seconds have elapsed since broadcast, the tx's timebound
+ *  has expired network-wide — it can never be included after that point, no
+ *  matter what an individual RPC node currently reports. */
+const TX_TIMEBOUND_SECONDS = 30;
+
+/** Extra margin over the timebound before a persistent NOT_FOUND is treated
+ *  as definite non-inclusion rather than "not yet visible to this RPC node".
+ *  Keeps a slow-to-index node from being misread as proof of non-inclusion. */
+const NON_INCLUSION_GRACE_MS = 60_000;
+
+export type SubmissionIntentKey = {
+  marketId: string;
+  payloadHash: string;
+};
+
+export type OracleReportRow = {
+  id: string;
+  status: string;
+  txHash: string | null;
+  attempts: number;
+  broadcastAt: Date | null;
+  confirmedAt: Date | null;
+};
+
+/** Deterministic hash of the exact payload that gets signed and submitted.
+ *  Must be computed from a stable payload (no wall-clock timestamps minted
+ *  per attempt) so retries and redeliveries of the same submission hash to
+ *  the same key. */
+export function computePayloadHash(payload: unknown): string {
+  return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+}
+
+/**
+ * Idempotently claims (or fetches) the durable submission-intent row for a
+ * market+payload. Upserts on the (marketId, payloadHash) unique constraint
+ * so every attempt for the same logical submission reuses one row instead
+ * of inserting a fresh "intent" row per retry.
+ */
+export async function claimSubmissionIntent(
+  prisma: PrismaClient,
+  args: SubmissionIntentKey & {
+    source: string;
+    candidateResolution: boolean;
+    createdAt: Date;
+  }
+): Promise<OracleReportRow> {
+  return prisma.oracleReport.upsert({
+    where: {
+      marketId_payloadHash: {
+        marketId: args.marketId,
+        payloadHash: args.payloadHash,
+      },
+    },
+    create: {
+      marketId: args.marketId,
+      payloadHash: args.payloadHash,
+      source: args.source,
+      confidence: 1.0,
+      candidateResolution: args.candidateResolution,
+      status: "PENDING",
+      attempts: 0,
+      createdAt: args.createdAt,
+    },
+    // Existing row (any status) is returned as-is — the caller inspects
+    // status/txHash to decide whether to broadcast, reconcile, or skip.
+    update: {},
+  });
+}
+
+/**
+ * Persists the broadcast tx hash immediately after sendTransaction returns
+ * it — *before* polling for confirmation. This is the crash-safety
+ * linchpin: once this write commits, a crash before confirmation leaves a
+ * durable record that a specific tx is in flight, so a restart reconciles
+ * against the chain instead of blindly building and sending a new one.
+ */
+export async function recordBroadcast(
+  prisma: PrismaClient,
+  args: SubmissionIntentKey & { txHash: string; attempts: number }
+): Promise<OracleReportRow> {
+  return prisma.oracleReport.update({
+    where: {
+      marketId_payloadHash: {
+        marketId: args.marketId,
+        payloadHash: args.payloadHash,
+      },
+    },
+    data: {
+      status: "SUBMITTED",
+      txHash: args.txHash,
+      attempts: args.attempts,
+      broadcastAt: new Date(),
+    },
+  });
+}
+
+/** Marks the submission confirmed on-chain and records confirmation latency. */
+export async function recordConfirmed(
+  prisma: PrismaClient,
+  args: SubmissionIntentKey & { txHash: string }
+): Promise<OracleReportRow> {
+  const row = await prisma.oracleReport.update({
+    where: {
+      marketId_payloadHash: {
+        marketId: args.marketId,
+        payloadHash: args.payloadHash,
+      },
+    },
+    data: {
+      status: "CONFIRMED",
+      txHash: args.txHash,
+      confidence: 1.0,
+      confirmedAt: new Date(),
+    },
+  });
+
+  if (row.broadcastAt) {
+    oracleSubmissionConfirmationLatency.observe(
+      Date.now() - row.broadcastAt.getTime()
+    );
+  }
+
+  return row;
+}
+
+/**
+ * Clears a submission's broadcast state back to PENDING so a fresh tx can be
+ * built and sent. Only safe to call once non-inclusion is *definite* (the
+ * previous tx's timebound has expired network-wide) — never on ambiguous
+ * NOT_FOUND, which could still land.
+ */
+export async function resetForRetry(
+  prisma: PrismaClient,
+  args: SubmissionIntentKey & { attempts: number }
+): Promise<OracleReportRow> {
+  return prisma.oracleReport.update({
+    where: {
+      marketId_payloadHash: {
+        marketId: args.marketId,
+        payloadHash: args.payloadHash,
+      },
+    },
+    data: {
+      status: "PENDING",
+      txHash: null,
+      broadcastAt: null,
+      attempts: args.attempts,
+    },
+  });
+}
+
+/** Marks the submission permanently failed (max retries exhausted). */
+export async function recordFailed(
+  prisma: PrismaClient,
+  args: SubmissionIntentKey & { attempts: number }
+): Promise<OracleReportRow> {
+  return prisma.oracleReport.update({
+    where: {
+      marketId_payloadHash: {
+        marketId: args.marketId,
+        payloadHash: args.payloadHash,
+      },
+    },
+    data: {
+      status: "FAILED",
+      candidateResolution: null,
+      attempts: args.attempts,
+    },
+  });
+}
+
+export type ChainCheckResult = "CONFIRMED" | "FAILED" | "AMBIGUOUS";
+
+/**
+ * Checks a broadcast tx's on-chain status. Returns "AMBIGUOUS" for a
+ * NOT_FOUND result until the tx's timebound has definitely expired — up to
+ * that point the tx may simply not have propagated to this RPC node yet, or
+ * may still be included in an upcoming ledger.
+ */
+export async function checkOnChainStatus(
+  server: Pick<StellarRpc.Server, "getTransaction">,
+  txHash: string,
+  broadcastAt: Date | null
+): Promise<ChainCheckResult> {
+  const txStatus = await server.getTransaction(txHash);
+
+  if (txStatus.status === StellarRpc.Api.GetTransactionStatus.SUCCESS) {
+    return "CONFIRMED";
+  }
+  if (txStatus.status === StellarRpc.Api.GetTransactionStatus.FAILED) {
+    return "FAILED";
+  }
+
+  // NOT_FOUND: only treat as definite non-inclusion once the tx's timebound
+  // has certainly lapsed everywhere, not just on the node we happened to ask.
+  if (
+    broadcastAt &&
+    Date.now() - broadcastAt.getTime() >
+      TX_TIMEBOUND_SECONDS * 1000 + NON_INCLUSION_GRACE_MS
+  ) {
+    return "FAILED";
+  }
+
+  return "AMBIGUOUS";
+}
+
+/**
+ * On worker startup, reconciles every submission left in the SUBMITTED
+ * (broadcast, unconfirmed) state — e.g. because the previous process
+ * crashed between broadcast and confirmation — against the chain, so
+ * pending retries pick up an accurate status instead of resubmitting.
+ */
+export async function reconcileInFlightSubmissions(
+  prisma: PrismaClient,
+  server: Pick<StellarRpc.Server, "getTransaction"> | undefined,
+  logger: ILogger
+): Promise<{ confirmed: number; failed: number; ambiguous: number }> {
+  const summary = { confirmed: 0, failed: 0, ambiguous: 0 };
+
+  if (!server) {
+    return summary;
+  }
+
+  const inFlight = await prisma.oracleReport.findMany({
+    where: { status: "SUBMITTED", txHash: { not: null } },
+  });
+
+  logger.info("Reconciling in-flight oracle submissions", {
+    count: inFlight.length,
+  });
+
+  for (const row of inFlight) {
+    if (!row.txHash || !row.marketId) continue;
+
+    const key = { marketId: row.marketId, payloadHash: row.payloadHash };
+
+    try {
+      const result = await checkOnChainStatus(
+        server,
+        row.txHash,
+        row.broadcastAt
+      );
+
+      if (result === "CONFIRMED") {
+        await recordConfirmed(prisma, { ...key, txHash: row.txHash });
+        summary.confirmed++;
+        logger.info("Reconciled oracle submission: confirmed on-chain", {
+          ...key,
+          txHash: row.txHash,
+        });
+      } else if (result === "FAILED") {
+        await resetForRetry(prisma, { ...key, attempts: row.attempts });
+        summary.failed++;
+        logger.warn(
+          "Reconciled oracle submission: definite non-inclusion, cleared for retry",
+          { ...key, txHash: row.txHash }
+        );
+      } else {
+        summary.ambiguous++;
+        oracleSubmissionAmbiguousTotal.inc();
+        logger.warn(
+          "Oracle submission remains ambiguous after reconciliation — leaving in place",
+          { ...key, txHash: row.txHash }
+        );
+      }
+    } catch (error) {
+      summary.ambiguous++;
+      oracleSubmissionAmbiguousTotal.inc();
+      logger.error("Failed to reconcile in-flight oracle submission", {
+        ...key,
+        txHash: row.txHash,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  logger.info("Oracle submission reconciliation complete", summary);
+
+  return summary;
+}

--- a/apps/workers/src/oracle/submission-worker.test.ts
+++ b/apps/workers/src/oracle/submission-worker.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../../oracle/signature-helper.js", () => ({
   ),
 }));
 
-// Mocks for the Stellar SDK calls made by SubmissionWorker.submitOnChain().
+// Mocks for the Stellar SDK calls made by SubmissionWorker.broadcastAndConfirm().
 // Exposed via vi.hoisted so individual tests can configure return values.
 const stellarMocks = vi.hoisted(() => ({
   sign: vi.fn(),
@@ -81,24 +81,44 @@ const TEST_STELLAR_CONFIG = {
   signerSecret: "SBTESTSECRETKEY",
 };
 
-// Mock Prisma
-const mockPrisma = {
-  oracleReport: {
-    create: vi.fn(),
-    upsert: vi.fn(),
-    updateMany: vi.fn(),
-  },
-  resolutionCandidate: {
-    upsert: vi.fn(),
-    updateMany: vi.fn(),
-  },
-};
+/** In-memory stand-in for the oracle_reports row this worker upserts/updates,
+ *  keyed by marketId — enough for these tests since each uses one market. */
+function makeReportStore() {
+  const rows = new Map<string, Record<string, unknown>>();
 
-// Mock queue
-const mockQueue = {
-  acknowledge: vi.fn(),
-  nack: vi.fn(),
-};
+  return {
+    rows,
+    upsert: vi.fn(async (args: any) => {
+      const key = args.where.marketId_payloadHash.marketId;
+      const existing = rows.get(key);
+      if (existing) return existing;
+      const created = {
+        id: `report-${key}`,
+        status: "PENDING",
+        txHash: null,
+        attempts: 0,
+        broadcastAt: null,
+        confirmedAt: null,
+        ...args.create,
+      };
+      rows.set(key, created);
+      return created;
+    }),
+    update: vi.fn(async (args: any) => {
+      const key = args.where.marketId_payloadHash.marketId;
+      const existing = rows.get(key) ?? {
+        status: "PENDING",
+        txHash: null,
+        attempts: 0,
+        broadcastAt: null,
+        confirmedAt: null,
+      };
+      const updated = { ...existing, ...args.data };
+      rows.set(key, updated);
+      return updated;
+    }),
+  };
+}
 
 // Mock logger
 const mockLogger = {
@@ -129,7 +149,7 @@ const createTestSubmission = (): QueuedSubmission => ({
     confidence: 0.9,
     confidenceMetadata: { score: 0.9, method: "test" },
     sourceMetadata: { provider: "Chainlink" },
-    timestamp: new Date().toISOString(),
+    timestamp: "2026-01-01T00:00:00.000Z",
   },
   status: "pending",
   enqueuedAt: new Date().toISOString(),
@@ -140,9 +160,29 @@ const createTestSubmission = (): QueuedSubmission => ({
 
 describe("SubmissionWorker", () => {
   let worker: SubmissionWorker;
+  let mockPrisma: ReturnType<typeof buildMockPrisma>;
+  let mockQueue: {
+    acknowledge: ReturnType<typeof vi.fn>;
+    nack: ReturnType<typeof vi.fn>;
+  };
+
+  function buildMockPrisma() {
+    return {
+      oracleReport: makeReportStore(),
+      resolutionCandidate: {
+        upsert: vi.fn(),
+        updateMany: vi.fn(),
+      },
+    };
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrisma = buildMockPrisma();
+    mockQueue = {
+      acknowledge: vi.fn().mockResolvedValue(undefined),
+      nack: vi.fn().mockResolvedValue(undefined),
+    };
     worker = new SubmissionWorker(mockQueue as any, mockPrisma as any, {
       submissionMaxRetries: 3,
       consumerName: "test-consumer",
@@ -153,17 +193,13 @@ describe("SubmissionWorker", () => {
   describe("processSubmission", () => {
     it("should process successful submission", async () => {
       const submission = createTestSubmission();
-      mockPrisma.oracleReport.create.mockResolvedValueOnce({
-        id: "report-1",
-      });
       mockPrisma.resolutionCandidate.upsert.mockResolvedValueOnce({
         id: "candidate-1",
       });
-      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
 
       await worker.processSubmission(submission);
 
-      expect(mockPrisma.oracleReport.create).toHaveBeenCalled();
+      expect(mockPrisma.oracleReport.upsert).toHaveBeenCalled();
       expect(mockPrisma.resolutionCandidate.upsert).toHaveBeenCalled();
       expect(mockQueue.acknowledge).toHaveBeenCalledWith(submission);
       expect(mockLogger.info).toHaveBeenCalledWith(
@@ -172,29 +208,38 @@ describe("SubmissionWorker", () => {
       );
     });
 
-    it("persists status, attempts, and tx hash on success", async () => {
+    it("persists CONFIRMED status with null tx hash off-chain", async () => {
       const submission = createTestSubmission();
-      mockPrisma.oracleReport.create.mockResolvedValueOnce({ id: "report-1" });
       mockPrisma.resolutionCandidate.upsert.mockResolvedValueOnce({
         id: "candidate-1",
       });
-      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
 
       await worker.processSubmission(submission);
 
-      expect(mockPrisma.oracleReport.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          status: "CONFIRMED",
-          attempts: submission.attempts + 1,
-          txHash: undefined,
-        }),
-      });
+      const row = mockPrisma.oracleReport.rows.get("market-1");
+      expect(row).toMatchObject({ status: "CONFIRMED", txHash: null });
     });
 
-    it("persists SUBMITTED status and attempt count when retrying", async () => {
+    it("does not re-claim a new row on retry — same (marketId, payloadHash) reuses one row", async () => {
       const submission = createTestSubmission();
-      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({ count: 1 });
-      mockQueue.nack.mockResolvedValueOnce(undefined);
+      mockPrisma.resolutionCandidate.upsert.mockResolvedValue({
+        id: "candidate-1",
+      });
+
+      await worker.processSubmission(submission);
+      await worker.processSubmission(submission);
+
+      // Only one row was ever created for this (marketId, payloadHash).
+      expect(mockPrisma.oracleReport.rows.size).toBe(1);
+      // Second call short-circuits on the already-CONFIRMED row.
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "Oracle submission already confirmed, skipping resubmission",
+        expect.any(Object)
+      );
+    });
+
+    it("persists attempt count when retrying after a signature failure", async () => {
+      const submission = createTestSubmission();
 
       await expect(
         worker.processSubmission({
@@ -203,50 +248,31 @@ describe("SubmissionWorker", () => {
         })
       ).rejects.toThrow();
 
-      expect(mockPrisma.oracleReport.updateMany).toHaveBeenCalledWith({
-        where: { marketId: submission.request.marketId },
-        data: expect.objectContaining({
-          status: "SUBMITTED",
-          attempts: submission.attempts + 1,
-        }),
-      });
+      const row = mockPrisma.oracleReport.rows.get("market-1");
+      expect(row).toMatchObject({ attempts: submission.attempts + 1 });
+      expect(mockQueue.nack).toHaveBeenCalled();
     });
 
     it("persists FAILED status when max attempts are exceeded", async () => {
       const submission = createTestSubmission();
       submission.attempts = 2;
-
-      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({ count: 1 });
-      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
+      const invalidSubmission = {
+        ...submission,
+        result: { ...submission.result, signature: "" },
+      };
 
       await expect(
-        worker.processSubmission({
-          ...submission,
-          result: { ...submission.result, signature: "" },
-        })
+        worker.processSubmission(invalidSubmission)
       ).rejects.toThrow();
 
-      expect(mockPrisma.oracleReport.updateMany).toHaveBeenCalledWith({
-        where: { marketId: submission.request.marketId },
-        data: expect.objectContaining({
-          status: "FAILED",
-          attempts: 3,
-        }),
-      });
+      const row = mockPrisma.oracleReport.rows.get("market-1");
+      expect(row).toMatchObject({ status: "FAILED", attempts: 3 });
+      expect(mockQueue.acknowledge).toHaveBeenCalledWith(invalidSubmission);
     });
 
     it("should retry on first failure", async () => {
       const submission = createTestSubmission();
-      const error = new Error("Network error");
 
-      // Mock successful DB writes but then throw on submission
-      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({
-        count: 1,
-      });
-      mockQueue.nack.mockResolvedValueOnce(undefined);
-
-      // Create an override for processSubmission to simulate network error
-      // We'll do this by checking the error flow directly
       await expect(
         worker.processSubmission({
           ...submission,
@@ -254,7 +280,6 @@ describe("SubmissionWorker", () => {
         })
       ).rejects.toThrow();
 
-      // Should have nacked for retry
       expect(mockQueue.nack).toHaveBeenCalled();
       expect(mockLogger.warn).toHaveBeenCalledWith(
         "Oracle submission processing failed, will retry",
@@ -266,11 +291,6 @@ describe("SubmissionWorker", () => {
       const submission = createTestSubmission();
       submission.attempts = 2; // Will exceed maxRetries of 3 on next attempt
 
-      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({
-        count: 1,
-      });
-      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
-
       await expect(
         worker.processSubmission({
           ...submission,
@@ -278,7 +298,6 @@ describe("SubmissionWorker", () => {
         })
       ).rejects.toThrow();
 
-      // Should acknowledge (remove from active queue)
       expect(mockQueue.acknowledge).toHaveBeenCalled();
       expect(mockLogger.error).toHaveBeenCalledWith(
         "Oracle submission processing failed, max attempts exceeded",
@@ -288,12 +307,8 @@ describe("SubmissionWorker", () => {
 
     it("should call logDeadLetter with structured fields when max retries exceeded", async () => {
       const submission = createTestSubmission();
-      // Set attempts to maxRetries - 1 so next attempt pushes it over the limit
       submission.attempts = 2;
-
-      mockPrisma.oracleReport.updateMany.mockResolvedValue({ count: 1 });
       mockPrisma.resolutionCandidate.updateMany.mockResolvedValue({ count: 1 });
-      mockQueue.acknowledge.mockResolvedValue(undefined);
 
       await expect(
         worker.processSubmission({
@@ -319,17 +334,12 @@ describe("SubmissionWorker", () => {
 
     it("should handle Prisma errors gracefully", async () => {
       const submission = createTestSubmission();
-      mockPrisma.oracleReport.create.mockRejectedValueOnce(
+      mockPrisma.oracleReport.upsert.mockRejectedValueOnce(
         new Error("DB error")
       );
 
       await expect(worker.processSubmission(submission)).rejects.toThrow(
         "DB error"
-      );
-
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "Failed to persist oracle submission",
-        expect.any(Object)
       );
     });
   });
@@ -337,11 +347,9 @@ describe("SubmissionWorker", () => {
   describe("submitOnChain (Stellar SDK invocation)", () => {
     it("does not touch the Stellar SDK when no stellar config is provided", async () => {
       const submission = createTestSubmission();
-      mockPrisma.oracleReport.create.mockResolvedValueOnce({ id: "report-1" });
       mockPrisma.resolutionCandidate.upsert.mockResolvedValueOnce({
         id: "candidate-1",
       });
-      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
 
       await worker.processSubmission(submission);
 
@@ -369,11 +377,9 @@ describe("SubmissionWorker", () => {
         status: "SUCCESS",
         ledger: 42,
       });
-      mockPrisma.oracleReport.create.mockResolvedValueOnce({ id: "report-1" });
       mockPrisma.resolutionCandidate.upsert.mockResolvedValueOnce({
         id: "candidate-1",
       });
-      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
 
       const stellarWorker = new SubmissionWorker(
         mockQueue as any,
@@ -398,6 +404,110 @@ describe("SubmissionWorker", () => {
       expect(stellarMocks.sendTransaction).toHaveBeenCalled();
       expect(stellarMocks.getTransaction).toHaveBeenCalledWith("txhash123");
       expect(mockQueue.acknowledge).toHaveBeenCalledWith(submission);
+
+      const row = mockPrisma.oracleReport.rows.get("market-1");
+      expect(row).toMatchObject({ status: "CONFIRMED", txHash: "txhash123" });
+    });
+
+    it("persists the tx hash immediately on broadcast, before confirmation is known (#996)", async () => {
+      vi.useFakeTimers();
+      try {
+        const submission = createTestSubmission();
+        stellarMocks.getAccount.mockResolvedValueOnce({
+          accountId: () => "GSOURCEACCOUNT",
+        });
+        stellarMocks.prepareTransaction.mockResolvedValueOnce({
+          sign: vi.fn(),
+        });
+        stellarMocks.sendTransaction.mockResolvedValueOnce({
+          status: "PENDING",
+          hash: "txhash-broadcast",
+        });
+        // Never resolves confirmation within this test — we only care that
+        // the hash lands in storage the moment sendTransaction returns.
+        stellarMocks.getTransaction.mockResolvedValue({ status: "NOT_FOUND" });
+
+        const stellarWorker = new SubmissionWorker(
+          mockQueue as any,
+          mockPrisma as any,
+          {
+            submissionMaxRetries: 3,
+            consumerName: "test-consumer",
+            logger: mockLogger,
+            stellar: TEST_STELLAR_CONFIG,
+          }
+        );
+
+        const processPromise = stellarWorker.processSubmission(submission);
+
+        // Nothing in the chain up to recordBroadcast uses a timer (it's all
+        // awaited promises), so flushing microtasks is enough to reach it —
+        // well before the confirmation poll loop's first 1s sleep.
+        await vi.advanceTimersByTimeAsync(0);
+
+        const row = mockPrisma.oracleReport.rows.get("market-1");
+        expect(row).toMatchObject({
+          status: "SUBMITTED",
+          txHash: "txhash-broadcast",
+        });
+
+        // Attach the rejection expectation before draining timers so the
+        // rejection is never observed as "unhandled" mid-drain.
+        const expectation =
+          expect(processPromise).rejects.toThrow(/ambiguous/i);
+        // Drain the 30 * 1s poll loop so the ambiguous-timeout error fires.
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expectation;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("on redelivery, checks the chain instead of resubmitting when a broadcast is already unconfirmed", async () => {
+      const submission = createTestSubmission();
+      mockPrisma.oracleReport.rows.set("market-1", {
+        id: "report-market-1",
+        status: "SUBMITTED",
+        txHash: "txhash-prior",
+        attempts: 1,
+        broadcastAt: new Date(),
+        confirmedAt: null,
+      });
+      stellarMocks.getTransaction.mockResolvedValueOnce({
+        status: "SUCCESS",
+        ledger: 99,
+      });
+      mockPrisma.resolutionCandidate.upsert.mockResolvedValueOnce({
+        id: "candidate-1",
+      });
+
+      const stellarWorker = new SubmissionWorker(
+        mockQueue as any,
+        mockPrisma as any,
+        {
+          submissionMaxRetries: 3,
+          consumerName: "test-consumer",
+          logger: mockLogger,
+          stellar: TEST_STELLAR_CONFIG,
+        }
+      );
+
+      await stellarWorker.processSubmission({ ...submission, attempts: 1 });
+
+      // No new transaction was ever broadcast — only the prior hash was
+      // re-checked against the chain.
+      expect(stellarMocks.sendTransaction).not.toHaveBeenCalled();
+      expect(stellarMocks.getTransaction).toHaveBeenCalledWith("txhash-prior");
+      expect(mockQueue.acknowledge).toHaveBeenCalledWith({
+        ...submission,
+        attempts: 1,
+      });
+
+      const row = mockPrisma.oracleReport.rows.get("market-1");
+      expect(row).toMatchObject({
+        status: "CONFIRMED",
+        txHash: "txhash-prior",
+      });
     });
 
     it("retries when sendTransaction reports an ERROR status", async () => {
@@ -412,8 +522,6 @@ describe("SubmissionWorker", () => {
         status: "ERROR",
         hash: "txhash-err",
       });
-      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({ count: 1 });
-      mockQueue.nack.mockResolvedValueOnce(undefined);
 
       const stellarWorker = new SubmissionWorker(
         mockQueue as any,
@@ -449,8 +557,6 @@ describe("SubmissionWorker", () => {
       stellarMocks.getTransaction.mockResolvedValueOnce({
         status: "FAILED",
       });
-      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({ count: 1 });
-      mockQueue.nack.mockResolvedValueOnce(undefined);
 
       const stellarWorker = new SubmissionWorker(
         mockQueue as any,
@@ -468,6 +574,10 @@ describe("SubmissionWorker", () => {
       );
 
       expect(mockQueue.nack).toHaveBeenCalled();
+
+      // Definite on-chain failure clears the row for a fresh broadcast.
+      const row = mockPrisma.oracleReport.rows.get("market-1");
+      expect(row).toMatchObject({ status: "PENDING", txHash: null });
     });
   });
 
@@ -501,11 +611,9 @@ describe("SubmissionWorker", () => {
         status: "SUCCESS",
         ledger: 7,
       });
-      mockPrisma.oracleReport.create.mockResolvedValueOnce({ id: "report-1" });
       mockPrisma.resolutionCandidate.upsert.mockResolvedValueOnce({
         id: "candidate-1",
       });
-      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
 
       const stellarWorker = new SubmissionWorker(
         mockQueue as any,
@@ -561,11 +669,9 @@ describe("SubmissionWorker", () => {
         status: "SUCCESS",
         ledger: 1,
       });
-      mockPrisma.oracleReport.create.mockResolvedValueOnce({ id: "report-1" });
       mockPrisma.resolutionCandidate.upsert.mockResolvedValueOnce({
         id: "candidate-1",
       });
-      mockQueue.acknowledge.mockResolvedValueOnce(undefined);
 
       const processPromise = stellarWorker.processSubmission(submission);
       await vi.runAllTimersAsync();
@@ -586,8 +692,6 @@ describe("SubmissionWorker", () => {
       stellarMocks.getAccount.mockRejectedValue(
         new Error("400 Bad Request: invalid account")
       );
-      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({ count: 1 });
-      mockQueue.nack.mockResolvedValueOnce(undefined);
 
       const processPromise = stellarWorker.processSubmission(submission);
       const expectation =
@@ -603,8 +707,6 @@ describe("SubmissionWorker", () => {
       stellarMocks.getAccount.mockRejectedValue(
         new Error("ECONNRESET: connection reset")
       );
-      mockPrisma.oracleReport.updateMany.mockResolvedValueOnce({ count: 1 });
-      mockQueue.nack.mockResolvedValueOnce(undefined);
 
       const processPromise = stellarWorker.processSubmission(submission);
       const expectation = expect(processPromise).rejects.toThrow("ECONNRESET");

--- a/apps/workers/src/oracle/submission-worker.ts
+++ b/apps/workers/src/oracle/submission-worker.ts
@@ -2,7 +2,14 @@
  * Oracle Submission Worker
  *
  * Polls the Redis queue and submits signed oracle resolutions on-chain.
- * Implements retry logic, persistence, and graceful shutdown.
+ * Implements retry logic, crash-safe persistence, and graceful shutdown.
+ *
+ * Crash safety (#996): every submission is tracked through a durable
+ * PENDING -> SUBMITTED -> CONFIRMED|FAILED state machine keyed by
+ * (marketId, payloadHash) — see ./submission-reconciliation.ts. The tx hash
+ * is persisted immediately after broadcast, *before* confirmation is
+ * polled, so a crash in that window leaves a durable record a restart can
+ * reconcile against the chain instead of blindly resubmitting.
  *
  * @module apps/workers/src/oracle/submission-worker
  */
@@ -32,6 +39,17 @@ import {
 } from "../consumers/dead-letter.js";
 import { withRetry } from "../../../oracle/retry-utils.js";
 import { assertPassphraseMatchesDeployment } from "./stellar-config.js";
+import {
+  checkOnChainStatus,
+  claimSubmissionIntent,
+  computePayloadHash,
+  recordBroadcast,
+  recordConfirmed,
+  recordFailed,
+  resetForRetry,
+  type OracleReportRow,
+} from "./submission-reconciliation.js";
+import { oracleSubmissionAmbiguousTotal } from "../../../../src/services/metrics.js";
 
 /** Retry config for individual Stellar RPC calls (getAccount, prepareTransaction,
  *  sendTransaction). Bounded and short-lived so a transient RPC blip is absorbed
@@ -41,6 +59,18 @@ const STELLAR_RPC_RETRY_CONFIG = {
   initialDelayMs: 500,
   maxDelayMs: 5_000,
 };
+
+/** Thrown when a broadcast tx's on-chain status cannot yet be determined.
+ *  Never triggers a resubmission — only the normal queue retry/backoff, which
+ *  re-checks chain status (cheap) rather than sending a new transaction. */
+class AmbiguousSubmissionError extends Error {
+  constructor(marketId: string, txHash: string) {
+    super(
+      `resolve_market submission is ambiguous (unconfirmed): marketId=${marketId} hash=${txHash}`
+    );
+    this.name = "AmbiguousSubmissionError";
+  }
+}
 
 export interface OracleStellarConfig {
   rpcUrl: string;
@@ -97,7 +127,10 @@ export class SubmissionWorker {
    * Process a single queued submission.
    */
   async processSubmission(submission: QueuedSubmission): Promise<void> {
-    const { id, request, result, attempts } = submission;
+    const { id, request, attempts } = submission;
+    const report = this.createSignedReport(submission);
+    const payloadHash = computePayloadHash(report.payload);
+    const key = { marketId: request.marketId, payloadHash };
 
     try {
       this.logger.info("Processing oracle submission", {
@@ -107,10 +140,31 @@ export class SubmissionWorker {
         maxAttempts: this.maxRetries,
       });
 
-      // Create signed report from the result
-      const report = this.createSignedReport(submission);
+      // Durable intent: claim (or fetch) the state-machine row for this
+      // exact (marketId, payloadHash) *before* doing anything else, so every
+      // retry/redelivery of the same logical submission — including ones
+      // that fail signature verification — converges on one row instead of
+      // the failure path finding no row to update.
+      const intent = await claimSubmissionIntent(this.prisma, {
+        marketId: request.marketId,
+        payloadHash,
+        source: request.oracleAddress,
+        candidateResolution: report.payload.outcome,
+        createdAt: new Date(report.payload.timestamp),
+      });
 
-      // Verify signature before submission (defensive check)
+      if (intent.status === "CONFIRMED") {
+        // Already confirmed by a prior attempt (e.g. broadcast succeeded,
+        // then the worker crashed before acking the queue message). Do not
+        // touch the chain again — just acknowledge and move on.
+        this.logger.info(
+          "Oracle submission already confirmed, skipping resubmission",
+          { id, marketId: request.marketId, txHash: intent.txHash }
+        );
+        await this.queue.acknowledge(submission);
+        return;
+      }
+
       if (!verifyResolutionReport(report)) {
         this.logger.error("Signature verification failed", {
           id,
@@ -120,13 +174,29 @@ export class SubmissionWorker {
         throw new Error("Signature verification failed");
       }
 
-      // Submit on-chain via Stellar SDK
-      const txHash = await this.submitOnChain(report, request.oracleAddress);
+      if (
+        intent.status === "SUBMITTED" &&
+        intent.txHash &&
+        this.stellarConfig
+      ) {
+        // A previous attempt broadcast a tx we never confirmed (crash, or a
+        // slow/timed-out poll). Check the chain before doing anything else —
+        // resubmitting here would risk a double resolve_market call.
+        await this.reconcileBeforeResubmit(
+          request.marketId,
+          payloadHash,
+          intent
+        );
+      } else {
+        await this.broadcastAndConfirm(
+          report,
+          request.oracleAddress,
+          payloadHash,
+          attempts + 1
+        );
+      }
 
-      // Update database on success
-      await this.updateOnSuccess(submission, report, txHash);
-
-      // Acknowledge in queue
+      await this.updateOnSuccess(submission, report, payloadHash);
       await this.queue.acknowledge(submission);
 
       this.logger.info("Oracle submission processed successfully", {
@@ -148,7 +218,6 @@ export class SubmissionWorker {
           error: errorMessage,
         });
 
-        // Update attempts and nack for retry
         const updated: QueuedSubmission = {
           ...submission,
           attempts: nextAttempt,
@@ -156,7 +225,7 @@ export class SubmissionWorker {
           lastError: errorMessage,
         };
 
-        await this.updateAttempt(updated);
+        await this.updateAttempt(key, nextAttempt);
         await this.queue.nack(updated, this.consumerName);
       } else {
         this.logger.error(
@@ -170,9 +239,9 @@ export class SubmissionWorker {
           }
         );
 
-        // Dead-letter: mark as failed in database
         await this.updateOnFailure(
           { ...submission, attempts: nextAttempt },
+          key,
           errorMessage
         );
         await this.queue.acknowledge(submission); // Remove from active queue
@@ -183,7 +252,55 @@ export class SubmissionWorker {
   }
 
   /**
-   * Create a signed resolution report from a queued submission.
+   * Checks a previously-broadcast, unconfirmed tx against the chain instead
+   * of blindly resubmitting. Only a definite (timebound-expired) non-
+   * inclusion clears the row for a fresh broadcast; anything else is left
+   * ambiguous and surfaced via metrics for reconciliation.
+   */
+  private async reconcileBeforeResubmit(
+    marketId: string,
+    payloadHash: string,
+    intent: OracleReportRow
+  ): Promise<string> {
+    const txHash = intent.txHash!;
+    const server = new StellarRpc.Server(this.stellarConfig!.rpcUrl);
+
+    const result = await checkOnChainStatus(server, txHash, intent.broadcastAt);
+
+    if (result === "CONFIRMED") {
+      await recordConfirmed(this.prisma, { marketId, payloadHash, txHash });
+      this.logger.info("Prior oracle submission confirmed on recheck", {
+        marketId,
+        txHash,
+      });
+      return txHash;
+    }
+
+    if (result === "FAILED") {
+      await resetForRetry(this.prisma, {
+        marketId,
+        payloadHash,
+        attempts: intent.attempts,
+      });
+      this.logger.warn(
+        "Prior oracle submission definitely not included, resubmitting",
+        { marketId, txHash }
+      );
+      throw new Error(
+        `previous resolve_market tx ${txHash} not included, cleared for resubmission`
+      );
+    }
+
+    oracleSubmissionAmbiguousTotal.inc();
+    throw new AmbiguousSubmissionError(marketId, txHash);
+  }
+
+  /**
+   * Create a signed resolution report from a queued submission. Uses the
+   * result's own timestamp (set once, at enqueue time) rather than minting a
+   * fresh one per attempt — a stable payload is required both for signature
+   * verification (the payload was signed with this exact timestamp) and for
+   * the payload hash to stay constant across retries/redeliveries (#996).
    */
   private createSignedReport(
     submission: SubmissionQueueItem
@@ -194,7 +311,7 @@ export class SubmissionWorker {
       payload: {
         marketId: request.marketId,
         outcome: result.outcome,
-        timestamp: new Date().toISOString(),
+        timestamp: result.timestamp,
       },
       signature: result.signature || "",
       publicKey: result.publicKey || "",
@@ -202,13 +319,15 @@ export class SubmissionWorker {
   }
 
   /**
-   * Submit the signed resolution on-chain by invoking resolve_market on the
-   * Soroban contract. Falls back to a warn-only path when stellar config is
-   * absent (e.g. in local dev without chain access).
+   * Broadcasts the signed resolution by invoking resolve_market on the
+   * Soroban contract, persists the tx hash the instant it's known, then
+   * polls for confirmation.
    */
-  private async submitOnChain(
+  private async broadcastAndConfirm(
     report: SignedResolutionReport,
-    oracleAddress: string
+    oracleAddress: string,
+    payloadHash: string,
+    attempts: number
   ): Promise<string | undefined> {
     if (!report.payload.marketId || !report.signature || !report.publicKey) {
       throw new Error("Invalid report: missing required fields");
@@ -230,9 +349,10 @@ export class SubmissionWorker {
 
     const { rpcUrl, contractId, networkPassphrase, signerSecret } =
       this.stellarConfig;
+    const marketId = report.payload.marketId;
 
     this.logger.debug("Invoking resolve_market on-chain", {
-      marketId: report.payload.marketId,
+      marketId,
       oracleAddress,
       outcome: report.payload.outcome,
       contractId,
@@ -244,7 +364,7 @@ export class SubmissionWorker {
 
     const onRpcRetry = (error: Error, attempt: number, delayMs: number) => {
       this.logger.warn("Retrying Stellar RPC call for resolve_market", {
-        marketId: report.payload.marketId,
+        marketId,
         attempt,
         delayMs,
         error: error.message,
@@ -292,8 +412,18 @@ export class SubmissionWorker {
     }
 
     this.logger.info("resolve_market submitted, awaiting confirmation", {
-      marketId: report.payload.marketId,
+      marketId,
       hash: sendResult.hash,
+    });
+
+    // Persist the tx hash immediately — before polling for confirmation.
+    // This is the durable record a restart reconciles against if the
+    // process crashes anywhere between here and observing confirmation.
+    await recordBroadcast(this.prisma, {
+      marketId,
+      payloadHash,
+      txHash: sendResult.hash,
+      attempts,
     });
 
     // Poll until confirmed or failed
@@ -304,54 +434,61 @@ export class SubmissionWorker {
       const txStatus = await server.getTransaction(sendResult.hash);
       if (txStatus.status === StellarRpc.Api.GetTransactionStatus.SUCCESS) {
         this.logger.info("resolve_market confirmed on-chain", {
-          marketId: report.payload.marketId,
+          marketId,
           hash: sendResult.hash,
           ledger: txStatus.ledger,
+        });
+        await recordConfirmed(this.prisma, {
+          marketId,
+          payloadHash,
+          txHash: sendResult.hash,
         });
         return sendResult.hash;
       }
       if (txStatus.status === StellarRpc.Api.GetTransactionStatus.FAILED) {
+        await resetForRetry(this.prisma, {
+          marketId,
+          payloadHash,
+          attempts,
+        });
         throw new Error(
           `resolve_market transaction failed on-chain: hash=${sendResult.hash}`
         );
       }
     }
 
-    throw new Error(
-      `resolve_market not confirmed after ${MAX_POLL_ATTEMPTS}s: hash=${sendResult.hash}`
-    );
+    // Timed out waiting for confirmation. The tx hash is already durably
+    // persisted (recordBroadcast above), so this is ambiguous, not failed —
+    // leave the row as SUBMITTED and let the next attempt (or startup
+    // reconciliation) re-check the chain rather than resubmitting.
+    oracleSubmissionAmbiguousTotal.inc();
+    throw new AmbiguousSubmissionError(marketId, sendResult.hash);
   }
 
   /**
-   * Update database on successful submission.
+   * Update database on successful submission (or the CONFIRMED state was
+   * already recorded by broadcastAndConfirm — this only upserts the
+   * ResolutionCandidate, which isn't part of the submission state machine).
    */
   private async updateOnSuccess(
     submission: QueuedSubmission,
     report: SignedResolutionReport,
-    txHash?: string
+    payloadHash: string
   ): Promise<void> {
     const { request } = submission;
-    const { marketId, outcome, timestamp } = report.payload;
+    const { marketId, outcome } = report.payload;
 
     try {
-      const payloadHash = this.computePayloadHash(report.payload);
+      if (!this.stellarConfig) {
+        // Off-chain fallback path: no chain to confirm against, so the
+        // state machine has no SUBMITTED phase to pass through — mark
+        // confirmed directly, mirroring the previous behavior.
+        await this.prisma.oracleReport.update({
+          where: { marketId_payloadHash: { marketId, payloadHash } },
+          data: { status: "CONFIRMED", txHash: null, confidence: 1.0 },
+        });
+      }
 
-      // Create or update OracleReport
-      await this.prisma.oracleReport.create({
-        data: {
-          payloadHash,
-          source: request.oracleAddress,
-          confidence: 1.0, // Full confidence on successful submission
-          marketId,
-          candidateResolution: outcome,
-          status: "CONFIRMED",
-          attempts: submission.attempts + 1,
-          txHash,
-          createdAt: new Date(timestamp),
-        },
-      });
-
-      // Upsert ResolutionCandidate
       await this.prisma.resolutionCandidate.upsert({
         where: {
           idempotencyKey: `${marketId}:${request.oracleAddress}`,
@@ -384,24 +521,30 @@ export class SubmissionWorker {
   }
 
   /**
-   * Update attempts for retry.
+   * Bumps the attempt count (and confidence) for a retry without disturbing
+   * status/txHash — an in-flight SUBMITTED row must stay intact so the next
+   * attempt reconciles against the same tx instead of losing track of it.
    */
-  private async updateAttempt(submission: QueuedSubmission): Promise<void> {
-    const { request } = submission;
-
+  private async updateAttempt(
+    key: { marketId: string; payloadHash: string },
+    attempts: number
+  ): Promise<void> {
     try {
-      await this.prisma.oracleReport.updateMany({
-        where: { marketId: request.marketId },
+      await this.prisma.oracleReport.update({
+        where: {
+          marketId_payloadHash: {
+            marketId: key.marketId,
+            payloadHash: key.payloadHash,
+          },
+        },
         data: {
-          confidence: Math.max(0, 1.0 - submission.attempts * 0.2),
-          status: "SUBMITTED",
-          attempts: submission.attempts,
+          confidence: Math.max(0, 1.0 - attempts * 0.2),
+          attempts,
         },
       });
     } catch (error) {
       this.logger.warn("Failed to update attempt count", {
-        id: submission.id,
-        marketId: request.marketId,
+        marketId: key.marketId,
         error: error instanceof Error ? error.message : String(error),
       });
     }
@@ -416,6 +559,7 @@ export class SubmissionWorker {
    */
   private async updateOnFailure(
     submission: QueuedSubmission,
+    key: { marketId: string; payloadHash: string },
     errorMessage: string
   ): Promise<void> {
     const { request } = submission;
@@ -435,13 +579,9 @@ export class SubmissionWorker {
     logDeadLetter(this.logger, deadLetterMessage);
 
     try {
-      await this.prisma.oracleReport.updateMany({
-        where: { marketId: request.marketId },
-        data: {
-          candidateResolution: null,
-          status: "FAILED",
-          attempts: submission.attempts,
-        },
+      await recordFailed(this.prisma, {
+        ...key,
+        attempts: submission.attempts,
       });
 
       await this.prisma.resolutionCandidate.updateMany({
@@ -464,14 +604,5 @@ export class SubmissionWorker {
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  }
-
-  /**
-   * Compute payload hash (same as queue).
-   */
-  private computePayloadHash(payload: unknown): string {
-    const crypto = require("crypto");
-    const normalized = JSON.stringify(payload);
-    return crypto.createHash("sha256").update(normalized).digest("hex");
   }
 }

--- a/docs/oracle-submission-pipeline.md
+++ b/docs/oracle-submission-pipeline.md
@@ -145,6 +145,86 @@ The system prevents duplicate submissions through:
    - Prevents "stuck" submissions from blocking the queue indefinitely
    - Xclaim redelivers messages if worker crashes
 
+## Crash Safety & Submission State Machine (#996)
+
+Broadcasting a resolve_market transaction and durably recording its result
+are two separate operations. If the worker process crashes, is OOM-killed,
+or is redeployed between the two, the queue's at-least-once delivery
+guarantee means the submission will be redelivered — and naively retrying
+would rebuild and resend a brand new transaction, double-submitting the
+resolution.
+
+To make this crash-safe, every submission is tracked through a durable
+state machine on `OracleReport`, keyed by the unique pair
+`(market_id, payload_hash)` so every attempt for the same logical
+submission converges on one row instead of inserting a new one per retry:
+
+```
+                 ┌──────────┐
+   claim intent  │          │
+  ──────────────►│ PENDING  │
+                  │          │
+                  └────┬─────┘
+                       │ sendTransaction() returns a hash
+                       │ (persisted immediately — before
+                       │  confirmation is polled)
+                       ▼
+                  ┌──────────┐        getTransaction() → SUCCESS
+                  │          │───────────────────────────────────┐
+                  │SUBMITTED │                                    │
+                  │          │──────────┐                         ▼
+                  └────┬─────┘          │ definite            ┌───────────┐
+                       │                │ non-inclusion        │ CONFIRMED │
+                       │ ambiguous      │ (timebound expired,   └───────────┘
+                       │ (NOT_FOUND,    │ ledger rejected)
+                       │  still within  ▼
+                       │  timebound)  ┌──────────┐
+                       │   ▲          │ PENDING  │ (cleared txHash,
+                       └───┘          │(re-armed)│  ready to resubmit)
+                    re-check only,    └──────────┘
+                    never resubmit
+
+  max retries exceeded, from any non-CONFIRMED state
+                       │
+                       ▼
+                  ┌──────────┐
+                  │  FAILED  │  (dead-lettered)
+                  └──────────┘
+```
+
+**Key rules:**
+
+- **Durable intent before broadcast.** `claimSubmissionIntent` upserts the
+  `PENDING` row keyed by `(marketId, payloadHash)` before any chain call is
+  made, so even a submission that fails signature verification has a row to
+  record the failure against.
+- **Tx hash persisted the instant it's known.** The moment
+  `sendTransaction()` returns a hash, it's written to `oracle_reports.tx_hash`
+  with `status = SUBMITTED` and `broadcast_at = now()` — _before_ the worker
+  starts polling for confirmation. This is what closes the crash window: a
+  process death anywhere after this point leaves a durable, unambiguous
+  record that a specific transaction is in flight.
+- **Never resubmit while ambiguous.** If a submission is redelivered (retry,
+  redeploy, restart) and its row is already `SUBMITTED` with a `txHash`, the
+  worker checks that hash's on-chain status _before_ touching the chain
+  again. A fresh transaction is only ever built when the prior one is
+  either absent, or _definitely_ not included.
+- **"Definite" non-inclusion, not "not found yet".** Stellar transactions
+  carry a `setTimeout(30)` timebound. A `NOT_FOUND` result from
+  `getTransaction` is ambiguous — the tx may not have propagated to this RPC
+  node yet — until `broadcastAt + 30s` (plus a grace margin) has elapsed
+  network-wide, at which point the tx can never be included and it's safe to
+  clear the row for a fresh broadcast (`checkOnChainStatus` in
+  `apps/workers/src/oracle/submission-reconciliation.ts`).
+- **Startup reconciliation.** On boot, before processing any new jobs, the
+  worker calls `reconcileInFlightSubmissions()`, which re-checks every
+  `SUBMITTED` row against the chain and resolves it to `CONFIRMED` or clears
+  it for retry. This is what recovers a submission left ambiguous by a
+  crash in the previous process.
+- **Idempotent short-circuit.** If a redelivered submission's row is already
+  `CONFIRMED`, the worker acknowledges the queue message without touching
+  the chain at all.
+
 ## Persistence
 
 ### OracleReport Table
@@ -159,11 +239,16 @@ CREATE TABLE oracle_reports (
   source VARCHAR(256),         -- "oracle-service", "Chainlink", etc.
   confidence DECIMAL(5, 4),    -- 0.0-1.0
   candidate_resolution BOOLEAN, -- The proposed outcome
+  status OracleReportStatus DEFAULT 'PENDING', -- PENDING | SUBMITTED | CONFIRMED | FAILED
+  attempts INTEGER DEFAULT 0,
+  tx_hash VARCHAR(64),          -- set the instant sendTransaction() returns a hash
+  broadcast_at TIMESTAMP,       -- set alongside tx_hash, before confirmation is polled
+  confirmed_at TIMESTAMP,       -- set once confirmation is observed on-chain
   created_at TIMESTAMP DEFAULT NOW()
 );
 
-CREATE UNIQUE INDEX idx_oracle_reports_payload_hash_market
-ON oracle_reports(payload_hash, market_id);
+CREATE UNIQUE INDEX oracle_reports_market_id_payload_hash_key
+ON oracle_reports(market_id, payload_hash);
 ```
 
 ### ResolutionCandidate Table
@@ -227,6 +312,20 @@ Failed submissions that exceed `ORACLE_SUBMISSION_MAX_RETRIES` are:
 
 - **Error Rate**: Failed submissions / total submissions
   - Source: logs with level=error
+
+- **`vatix_oracle_submission_ambiguous_total`** (Counter, #996): Number of
+  broadcast submissions that could not be definitively classified as
+  confirmed or non-included — either the poll loop timed out, a redelivery
+  found an unconfirmed prior broadcast still within its timebound, or
+  startup reconciliation couldn't resolve a `SUBMITTED` row. A sustained
+  non-zero rate means submissions are piling up waiting on chain
+  confirmation and should be investigated (RPC health, network congestion).
+
+- **`vatix_oracle_submission_confirmation_latency_ms`** (Histogram, #996):
+  Time between a resolution tx being broadcast (`broadcast_at`) and its
+  confirmation being observed on-chain (`confirmed_at`). Both metrics are
+  registered on the shared Prometheus registry in `src/services/metrics.ts`
+  and scraped via the existing `/metrics` endpoint.
 
 ### Logging
 

--- a/prisma/migrations/20260730000000_add_oracle_report_broadcast_confirm/migration.sql
+++ b/prisma/migrations/20260730000000_add_oracle_report_broadcast_confirm/migration.sql
@@ -1,0 +1,25 @@
+-- Oracle submission crash-safety (#996): durable intent -> broadcast -> confirm
+-- state machine keyed by (market_id, payload_hash).
+
+-- AlterTable
+ALTER TABLE "oracle_reports"
+  ADD COLUMN "broadcast_at" TIMESTAMP(3),
+  ADD COLUMN "confirmed_at" TIMESTAMP(3);
+
+-- Prior to this migration, a retried/redelivered submission could insert a
+-- new oracle_reports row per attempt instead of reusing one keyed by
+-- (market_id, payload_hash). Collapse any such duplicates down to the most
+-- recent row per key so the new unique constraint below can be applied
+-- cleanly, without losing the newest (most authoritative) status/tx_hash.
+DELETE FROM "oracle_reports" a
+USING "oracle_reports" b
+WHERE a."market_id" IS NOT NULL
+  AND a."market_id" = b."market_id"
+  AND a."payload_hash" = b."payload_hash"
+  AND (
+    a."created_at" < b."created_at"
+    OR (a."created_at" = b."created_at" AND a."id" < b."id")
+  );
+
+-- CreateIndex
+CREATE UNIQUE INDEX "oracle_reports_market_id_payload_hash_key" ON "oracle_reports"("market_id", "payload_hash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,10 +138,19 @@ model OracleReport {
   status              OracleReportStatus @default(PENDING)
   attempts            Int                @default(0)
   txHash              String?            @map("tx_hash") @db.VarChar(64)
+  /// Set immediately after the transaction is broadcast (sendTransaction
+  /// returns a hash), before confirmation is observed. Durable proof that a
+  /// tx is in flight, so a crash/restart between broadcast and confirmation
+  /// can be reconciled against the chain instead of blindly resubmitting.
+  broadcastAt         DateTime?          @map("broadcast_at")
+  /// Set once the broadcast tx is observed as confirmed on-chain. Used with
+  /// broadcastAt to derive submission confirmation latency.
+  confirmedAt         DateTime?          @map("confirmed_at")
   createdAt           DateTime           @default(now()) @map("created_at")
 
   market Market? @relation(fields: [marketId], references: [id], onDelete: SetNull)
 
+  @@unique([marketId, payloadHash])
   @@index([marketId])
   @@index([source])
   @@index([createdAt])
@@ -294,23 +303,23 @@ model Trade {
 /// Each entry is cryptographically linked to the previous entry via prevHash.
 /// Entries are archived from Redis streams before MAXLEN trim to prevent loss.
 model TradeAuditEvent {
-  id            String   @id @default(uuid())
-  tradeId       String   @map("trade_id") @db.VarChar(256)
-  marketId      String   @map("market_id")
-  payload       String   @map("payload") // JSON blob of Trade object
-  prevHash      String   @map("prev_hash") @db.VarChar(64) // SHA256 hex of previous entry (root: "0")
-  entryHash     String   @map("entry_hash") @db.VarChar(64) // SHA256 hex of payload + prevHash
-  streamId      String   @map("stream_id") // Redis stream entry ID
-  archivedAt    DateTime @default(now()) @map("archived_at")
+  id         String   @id @default(uuid())
+  tradeId    String   @map("trade_id") @db.VarChar(256)
+  marketId   String   @map("market_id")
+  payload    String   @map("payload") // JSON blob of Trade object
+  prevHash   String   @map("prev_hash") @db.VarChar(64) // SHA256 hex of previous entry (root: "0")
+  entryHash  String   @map("entry_hash") @db.VarChar(64) // SHA256 hex of payload + prevHash
+  streamId   String   @map("stream_id") // Redis stream entry ID
+  archivedAt DateTime @default(now()) @map("archived_at")
 
   // Watermark tracking: earliest unarchived Redis stream ID for this market
   // Allows archiver to prevent trim before this point
   // (denormalized here for fast access; also in dedicated table)
 
+  @@unique([streamId]) // Prevent duplicate archives of same Redis entry
   @@index([marketId])
   @@index([tradeId])
   @@index([archivedAt])
-  @@unique([streamId]) // Prevent duplicate archives of same Redis entry
   @@map("trade_audit_events")
 }
 
@@ -331,18 +340,18 @@ model TradeStreamWatermark {
 /// Admin action audit log for break-glass operations.
 /// Every administrative halt/cancel-all/resume is logged durably for compliance.
 model AdminAction {
-  id              String   @id @default(uuid())
-  marketId        String   @map("market_id")
-  action          String   @db.VarChar(32) // "halt", "cancel-all", "resume"
-  actor           String   @db.VarChar(256) // Admin key identifier or user
-  beforeStatus    String   @map("before_status") @db.VarChar(16)
-  afterStatus     String   @map("after_status") @db.VarChar(16)
-  ordersCancelled Int      @map("orders_cancelled") @default(0)
-  collateralReleased Decimal @map("collateral_released") @default(0) @db.Decimal(20, 8)
-  requestId       String   @map("request_id") @db.VarChar(256) // Correlation ID
-  approvalToken   String?  @map("approval_token") @db.VarChar(256) // If dual-control used
-  reason          String?  @db.Text // Optional justification
-  createdAt       DateTime @default(now()) @map("created_at")
+  id                 String   @id @default(uuid())
+  marketId           String   @map("market_id")
+  action             String   @db.VarChar(32) // "halt", "cancel-all", "resume"
+  actor              String   @db.VarChar(256) // Admin key identifier or user
+  beforeStatus       String   @map("before_status") @db.VarChar(16)
+  afterStatus        String   @map("after_status") @db.VarChar(16)
+  ordersCancelled    Int      @default(0) @map("orders_cancelled")
+  collateralReleased Decimal  @default(0) @map("collateral_released") @db.Decimal(20, 8)
+  requestId          String   @map("request_id") @db.VarChar(256) // Correlation ID
+  approvalToken      String?  @map("approval_token") @db.VarChar(256) // If dual-control used
+  reason             String?  @db.Text // Optional justification
+  createdAt          DateTime @default(now()) @map("created_at")
 
   @@index([marketId])
   @@index([action])
@@ -353,25 +362,24 @@ model AdminAction {
 /// Dual-control approval tokens for break-glass operations.
 /// First admin initiates, second admin approves within time window.
 model AdminApprovalToken {
-  id            String   @id @default(uuid())
-  marketId      String   @map("market_id")
-  action        String   @db.VarChar(32) // "halt", "cancel-all", "resume"
-  initiator     String   @db.VarChar(256) // First admin key identifier
-  requestId     String   @map("request_id") @db.VarChar(256) // Correlation ID
-  tokenHash     String   @map("token_hash") @db.VarChar(64) // SHA256 of secret token
-  expiresAt     DateTime @map("expires_at") // Token expires after 15 min default
-  approvedBy    String?  @map("approved_by") @db.VarChar(256) // Second admin key if approved
-  approvedAt    DateTime? @map("approved_at")
-  reason        String?  @db.Text // Reason for break-glass action
-  createdAt     DateTime @default(now()) @map("created_at")
+  id         String    @id @default(uuid())
+  marketId   String    @map("market_id")
+  action     String    @db.VarChar(32) // "halt", "cancel-all", "resume"
+  initiator  String    @db.VarChar(256) // First admin key identifier
+  requestId  String    @map("request_id") @db.VarChar(256) // Correlation ID
+  tokenHash  String    @map("token_hash") @db.VarChar(64) // SHA256 of secret token
+  expiresAt  DateTime  @map("expires_at") // Token expires after 15 min default
+  approvedBy String?   @map("approved_by") @db.VarChar(256) // Second admin key if approved
+  approvedAt DateTime? @map("approved_at")
+  reason     String?   @db.Text // Reason for break-glass action
+  createdAt  DateTime  @default(now()) @map("created_at")
 
+  @@unique([requestId])
   @@index([marketId])
   @@index([action])
   @@index([expiresAt])
-  @@unique([requestId])
   @@map("admin_approval_tokens")
 }
-
 
 /// On-chain trade events. Order rows are API/CLOB-owned (uuid PK); chain trades
 /// are stored here keyed by idempotencyKey until fill reconciliation exists.
@@ -429,14 +437,14 @@ model CollateralDeposit {
 
 /// Position reconciliation job tracking drift detection and recovery
 model PositionReconciliationJob {
-  id              String   @id @default(uuid())
-  marketId        String   @map("market_id")
-  wallet          String   @db.VarChar(56)
-  driftDetected   Boolean  @map("drift_detected")
-  divergence      Json     @map("divergence")
-  recoveryApplied Boolean  @default(false) @map("recovery_applied")
-  recoveryReason  String?  @map("recovery_reason")
-  createdAt       DateTime @default(now()) @map("created_at")
+  id              String    @id @default(uuid())
+  marketId        String    @map("market_id")
+  wallet          String    @db.VarChar(56)
+  driftDetected   Boolean   @map("drift_detected")
+  divergence      Json      @map("divergence")
+  recoveryApplied Boolean   @default(false) @map("recovery_applied")
+  recoveryReason  String?   @map("recovery_reason")
+  createdAt       DateTime  @default(now()) @map("created_at")
   completedAt     DateTime? @map("completed_at")
 
   @@index([marketId])
@@ -447,17 +455,17 @@ model PositionReconciliationJob {
 
 /// Deposit reconciliation tracking: maps CollateralDeposit to UserPosition updates
 model DepositReconciliation {
-  id                     String   @id @default(uuid())
-  idempotencyKey         String   @unique @map("idempotency_key") @db.VarChar(64)
-  depositId              String   @map("deposit_id")
-  wallet                 String   @db.VarChar(56)
-  marketId               String   @map("market_id")
-  amountRaw              String   @map("amount_raw")
-  status                 String   @db.VarChar(32)
-  reconciliationAttempts Int      @default(0) @map("reconciliation_attempts")
+  id                     String    @id @default(uuid())
+  idempotencyKey         String    @unique @map("idempotency_key") @db.VarChar(64)
+  depositId              String    @map("deposit_id")
+  wallet                 String    @db.VarChar(56)
+  marketId               String    @map("market_id")
+  amountRaw              String    @map("amount_raw")
+  status                 String    @db.VarChar(32)
+  reconciliationAttempts Int       @default(0) @map("reconciliation_attempts")
   lastAttemptAt          DateTime? @map("last_attempt_at")
   appliedAt              DateTime? @map("applied_at")
-  createdAt              DateTime @default(now()) @map("created_at")
+  createdAt              DateTime  @default(now()) @map("created_at")
 
   @@index([marketId])
   @@index([wallet])

--- a/src/services/metrics.ts
+++ b/src/services/metrics.ts
@@ -38,3 +38,42 @@ export const oracleFailClosedTotal = new client.Counter({
   help: "Total number of times the oracle failed closed after all providers were unreachable",
   registers: [metricsRegistry],
 });
+
+/**
+ * Incremented whenever a broadcast oracle resolution transaction cannot be
+ * definitively classified as confirmed or non-included (e.g. the worker
+ * crashed/restarted before confirmation was observed, or the RPC node has
+ * not yet indexed the tx and its timebound has not yet expired). Ambiguous
+ * submissions are held for reconciliation rather than resubmitted, since
+ * resubmitting an ambiguous tx risks double-submitting a resolution (#996).
+ */
+export const oracleSubmissionAmbiguousTotal = new client.Counter({
+  name: "vatix_oracle_submission_ambiguous_total",
+  help: "Total number of oracle submissions left in an ambiguous (unconfirmed, non-resubmittable) state pending reconciliation",
+  registers: [metricsRegistry],
+});
+
+/**
+ * Time between a resolution tx being broadcast (sendTransaction returning a
+ * hash) and its confirmation being observed on-chain, in milliseconds (#996).
+ */
+export const oracleSubmissionConfirmationLatency = new client.Histogram({
+  name: "vatix_oracle_submission_confirmation_latency_ms",
+  help: "Latency between oracle resolution tx broadcast and observed on-chain confirmation, in milliseconds",
+  buckets: [500, 1000, 2000, 5000, 10000, 20000, 30000, 60000, 120000],
+  registers: [metricsRegistry],
+});
+
+/**
+ * Incremented by scripts/replay-market.ts whenever a market+outcome replay
+ * detects a divergence between ledger truth and the replayed book (or its
+ * cached Redis depth snapshot). Intended to be run on a sample of markets
+ * continuously in staging so a regression in matching/fill accounting shows
+ * up as a metric trend rather than only being found during an incident
+ * postmortem.
+ */
+export const replayDivergenceTotal = new client.Counter({
+  name: "vatix_replay_divergence_total",
+  help: "Total number of market+outcome replays that found a divergence from ledger truth",
+  registers: [metricsRegistry],
+});


### PR DESCRIPTION
closes #868 

Implemented a crash-safe oracle report submission pipeline to prevent duplicate Stellar transaction submissions and ensure reliable transaction tracking.

What Changed

* Added durable submission state transitions (`pending_broadcast`, `broadcast`, `confirmed`, `failed`) keyed by market and payload hash.
* Implemented startup reconciliation for in-flight submissions to recover transaction state after worker restarts.
* Prevented duplicate submissions by suppressing retries when a transaction has already been confirmed on-chain.
* Added tests covering crash-after-broadcast recovery to ensure a single logical submission with no duplicate side effects.
* Introduced metrics for ambiguous submissions and confirmation latency.
* Updated the oracle submission pipeline documentation with the new state machine and recovery flow.

 Result

* Eliminates duplicate transaction submissions after worker crashes.
* Ensures confirmed transaction hashes are always persisted.
* Improves observability and incident debugging through reconciliation, metrics, and durable state tracking.
