### PR TITLE
Add deterministic order/trade replay & forensics tool

### DIFF
--- a/docs/replay-forensics.md
+++ b/docs/replay-forensics.md
@@ -1,0 +1,161 @@
+# Order/Trade Replay & Forensics
+
+## Overview
+
+`scripts/replay-market.ts` deterministically replays a market+outcome's full
+order history through the real matching engine (`src/matching/engine.ts` /
+`src/matching/orderbook.ts`) into a fresh, isolated `OrderBook`, then diffs
+the result against ledger truth (`Order`/`Trade` rows) and the cached Redis
+depth snapshot. It exits non-zero and prints a structured JSON report on any
+divergence.
+
+Hydrating only the currently-resting orders (what `matching-service.ts` does
+on cold start) trusts `filledQuantity`/`status` as given — it can never catch
+a historical fill-accounting bug, because it never re-derives a single fill.
+Replay does: every trade in the report is recomputed from scratch by running
+the same order arrivals through `matchOrder`, so any drift between "what the
+engine would do" and "what actually got recorded" surfaces immediately.
+
+## When to run it
+
+- **After any matching-related incident or suspected data corruption**, before
+  writing the postmortem — run it for every market+outcome touched in the
+  incident window (`--as-of` the moment of the incident) to get an
+  order-id-level account of what diverged.
+- **Before enabling multi-instance matching** for a market, to confirm the
+  current single-instance history replays clean.
+- **Continuously in staging**, sampling a handful of markets, to catch a
+  matching/fill-accounting regression as a metric trend rather than only
+  during a live incident (see "Continuous sampling" below).
+
+## Usage
+
+```bash
+# Single market + outcome, as of now
+npx tsx scripts/replay-market.ts --market <marketId> --outcome YES
+
+# As of a specific point in time (useful for incident postmortems)
+npx tsx scripts/replay-market.ts --market <marketId> --outcome NO --as-of 2026-07-29T00:00:00Z
+
+# Sample N markets (both outcomes) — for staging cron/continuous checks
+npx tsx scripts/replay-market.ts --sample 20
+```
+
+Exit code is `0` when replay matches ledger truth (and the Redis snapshot, if
+present) exactly, `1` on any divergence or error.
+
+The script is **read-only**: it only issues Prisma `findMany` reads and a
+Redis `GET` for the cached depth snapshot. It never writes to the database or
+cache, so it's safe to run against production.
+
+## How it works
+
+1. Loads every `Order` and `Trade` row for the given `(marketId, outcome)`
+   with `createdAt`/`tradedAt <= --as-of`.
+2. Builds an ordered event stream (`src/matching/replay.ts`): one `create`
+   event per order (timestamped by `createdAt`), plus a `cancel` event for
+   every `CANCELLED` order (see "Cancel timing" below for how it's placed).
+3. Feeds the event stream through `replayEvents`, which calls the real
+   `matchOrder` for every `create` event against the book built up so far —
+   the same sequence `matching-service.ts#placeOrder` would drive in
+   production, minus the DB/Redis/audit side effects.
+4. Diffs (`src/matching/replay-diff.ts`) the replayed book/trades against:
+   - the ledger's own `filledQuantity`/`status` per order,
+   - the ledger's `Trade` rows (matched by `buyOrderId`/`sellOrderId`/
+     `quantity`/`price`, not by trade id — see "Why not trade ids" below),
+   - the cached Redis depth snapshot (`redis.getOrderBook`), if one exists —
+     the 60s TTL means an idle market may have no cached snapshot; that's not
+     itself a divergence, just a skipped check.
+
+## Interpreting a divergence report
+
+```jsonc
+{
+  "marketId": "...",
+  "outcome": "YES",
+  "orderMismatches": [
+    {
+      "orderId": "...",
+      "field": "filledQuantity",
+      "expected": 90,
+      "actual": 60,
+    },
+  ],
+  "missingOrderIds": [], // resting in the ledger, absent from the replayed book
+  "extraOrderIds": [], // present in the replayed book, absent from the ledger
+  "missingTrades": [], // recorded but never reproduced by replay
+  "extraTrades": [], // reproduced by replay but never recorded
+  "depthDeltas": [], // price-level quantity mismatches vs. the Redis cache
+  "cancelAmbiguities": [], // cancels whose timing had to be approximated
+  "hasDivergence": true,
+}
+```
+
+- **`orderMismatches` (`filledQuantity`/`remaining`/`status`)** — the ledger's
+  own bookkeeping disagrees with what the engine actually computed. This is
+  the "fill accounting" bug class the tool exists to catch (e.g. a Trade
+  upsert that silently no-op'd, or a double-applied fill).
+- **`missingOrderIds` / `extraOrderIds`** — an order that should (or
+  shouldn't) be resting isn't (or is). Points at hydration/cancel bugs.
+- **`missingTrades` / `extraTrades`** — the set of trades the engine would
+  produce from the order history doesn't match what's recorded. Points at a
+  matching-algorithm bug (price-time priority, self-trade handling, etc.) or
+  a bad cancel anchor (check `cancelAmbiguities` first).
+- **`depthDeltas`** — the live Redis depth cache has drifted from ledger
+  truth (e.g. the best-effort cache refresh in `placeOrder` silently failed —
+  it's wrapped in a try/catch that only logs).
+- **`cancelAmbiguities`** — not itself a divergence. Lists orders where cancel
+  timing was approximated (see below); treat any _other_ divergence touching
+  these order ids with extra scrutiny before declaring it a real bug.
+
+## Known limitation: cancel timing
+
+The `Order` table does not currently persist a cancellation timestamp — only
+that a cancel happened, via `status: CANCELLED`. Exact interleaving of a
+cancel against other orders arriving around the same time cannot be
+reconstructed with certainty from that alone.
+
+To stay safe rather than guess blindly, the CLI anchors each cancel event
+immediately after the _last_ trade that touched the order (or immediately
+after the order's own creation if it was never touched). This bounds the
+replay's uncertainty to the window `(last fill, actual cancel]` — only an
+order arriving in that narrow window could produce a false divergence, versus
+the much larger error from assuming "cancelled instantly" or "cancelled at the
+very end." Affected order ids are listed in `cancelAmbiguities`.
+
+If cancel-related false positives become a recurring problem, the real fix is
+adding a `cancelledAt` timestamp column and setting it in
+`matching-service.ts#cancelOrder`'s transaction — out of scope here since this
+tool is intentionally read-only against production.
+
+## Why not compare by trade id
+
+`matchOrder` stamps every trade with `Date.now()` captured at match time, and
+the trade id embeds that timestamp. Replaying historical orders inevitably
+captures a different `Date.now()` than the original request did, so trade ids
+will differ even for a perfectly faithful replay. The diff instead compares
+trades structurally, by `(buyOrderId, sellOrderId, quantity, price)`.
+
+## Continuous sampling in staging
+
+`--sample N` picks N markets and replays both outcomes for each, incrementing
+the `vatix_replay_divergence_total` Prometheus counter
+(`src/services/metrics.ts`) once per divergent book. Wire it into a staging
+cron (e.g. hourly) to catch a matching/fill-accounting regression as a metric
+trend:
+
+```bash
+npx tsx scripts/replay-market.ts --sample 20
+```
+
+## Golden test corpus
+
+`src/matching/replay.test.ts` proves `replayEvents` reproduces byte-identical
+trades to directly driving `matchOrder`/`OrderBook` for the same fill
+scenarios as the existing `#729` snapshot corpus
+(`src/matching/engine.fills.snapshot.test.ts`), plus a cancel scenario.
+
+`src/matching/replay-diff.test.ts` proves a consistent corpus yields zero
+diff, and that injected corruption (bad `filledQuantity`, a phantom/missing
+order, a stale Redis depth snapshot) is detected with clear order-id-level
+output.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "prepare": "husky install",
     "generate:keypair": "tsx scripts/generate-keypair.ts",
     "load-test:orders": "tsx scripts/load-test-orders.ts",
+    "replay:market": "tsx scripts/replay-market.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,11 +23,12 @@ Scripts that require environment variables will fail fast with a clear error if 
 
 ## Available Scripts
 
-| Script                   | pnpm alias              | Purpose                                                                                                                                                                |
-| ------------------------ | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `generate-keypair.ts`    | `pnpm generate:keypair` | Generate a Stellar keypair for oracle signing                                                                                                                          |
-| `validate-migrations.ts` | `pnpm prisma:validate`  | Validate Prisma migration files against the schema                                                                                                                     |
-| `load-test-orders.ts`    | `pnpm load-test:orders` | Local-only load test: places signed orders against `POST /v1/orders` at a target rps (see [docs/docker-compose.md](../docs/docker-compose.md#load-testing-local-only)) |
+| Script                   | pnpm alias              | Purpose                                                                                                                                                                                                                   |
+| ------------------------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `generate-keypair.ts`    | `pnpm generate:keypair` | Generate a Stellar keypair for oracle signing                                                                                                                                                                             |
+| `validate-migrations.ts` | `pnpm prisma:validate`  | Validate Prisma migration files against the schema                                                                                                                                                                        |
+| `load-test-orders.ts`    | `pnpm load-test:orders` | Local-only load test: places signed orders against `POST /v1/orders` at a target rps (see [docs/docker-compose.md](../docs/docker-compose.md#load-testing-local-only))                                                    |
+| `replay-market.ts`       | `pnpm replay:market`    | Read-only forensics: replays a market+outcome's order/trade history through the matching engine and diffs it against ledger truth and the Redis depth cache (see [docs/replay-forensics.md](../docs/replay-forensics.md)) |
 
 ## Adding a Script
 

--- a/scripts/replay-market.ts
+++ b/scripts/replay-market.ts
@@ -1,0 +1,335 @@
+#!/usr/bin/env tsx
+/**
+ * Deterministic order/trade replay & forensics CLI.
+ *
+ * Given a marketId + outcome, replays the full order arrival history through
+ * the real matching engine (src/matching/engine.ts) into a fresh, isolated
+ * OrderBook, then diffs the result against ledger truth (Order/Trade rows)
+ * and the cached Redis depth snapshot. Exits non-zero on divergence with a
+ * structured JSON report.
+ *
+ * Read-only: only ever issues Prisma `findMany`/`findUnique` reads and Redis
+ * `GET`s. Never writes to the database or cache.
+ *
+ * See docs/replay-forensics.md for when to run this and how to interpret a
+ * divergence report.
+ *
+ * Usage:
+ *   npx tsx scripts/replay-market.ts --market <id> --outcome YES
+ *   npx tsx scripts/replay-market.ts --market <id> --outcome NO --as-of 2026-07-29T00:00:00Z
+ *   npx tsx scripts/replay-market.ts --sample 20   # sample N random active markets (both outcomes)
+ */
+import { getPrismaClient } from "../src/services/prisma.js";
+import { redis } from "../src/services/redis.js";
+import { replayEvents, type ReplayEvent } from "../src/matching/replay.js";
+import {
+  buildDivergenceReport,
+  type LedgerOrder,
+  type LedgerTrade,
+  type ReplayDivergenceReport,
+} from "../src/matching/replay-diff.js";
+import { replayDivergenceTotal } from "../src/services/metrics.js";
+import type { Outcome, OrderSide } from "../src/types/index.js";
+
+interface Args {
+  marketId?: string;
+  outcome?: Outcome;
+  asOf: Date;
+  sample?: number;
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  let marketId: string | undefined;
+  let outcome: Outcome | undefined;
+  let asOf = new Date();
+  let sample: number | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--market" && args[i + 1]) {
+      marketId = args[++i];
+    } else if (args[i] === "--outcome" && args[i + 1]) {
+      const value = args[++i].toUpperCase();
+      if (value !== "YES" && value !== "NO") {
+        throw new Error(`--outcome must be YES or NO, got "${value}"`);
+      }
+      outcome = value;
+    } else if (args[i] === "--as-of" && args[i + 1]) {
+      const parsed = new Date(args[++i]);
+      if (Number.isNaN(parsed.getTime())) {
+        throw new Error("--as-of must be a valid date/time string");
+      }
+      asOf = parsed;
+    } else if (args[i] === "--sample" && args[i + 1]) {
+      sample = parseInt(args[++i], 10);
+      if (!Number.isFinite(sample) || sample < 1) {
+        throw new Error("--sample must be a positive integer");
+      }
+    }
+  }
+
+  if (sample === undefined && (!marketId || !outcome)) {
+    throw new Error(
+      "Usage: replay-market.ts --market <id> --outcome <YES|NO> [--as-of <iso-date>]  OR  --sample <N>"
+    );
+  }
+
+  return { marketId, outcome, asOf, sample };
+}
+
+function log(
+  level: string,
+  message: string,
+  meta?: Record<string, unknown>
+): void {
+  console.log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      level,
+      component: "replay-market",
+      message,
+      ...meta,
+    })
+  );
+}
+
+/**
+ * Anchor cancel events for orders with no persisted cancellation timestamp.
+ *
+ * The Order table does not currently record when a cancel happened (only
+ * that it did, via `status: CANCELLED`), so exact interleaving with later
+ * order arrivals cannot be reconstructed with certainty. This anchors each
+ * cancel immediately after the *last* trade event that touched the order
+ * (or immediately after its own create event if it was never touched),
+ * which bounds the uncertainty window to (last fill, actual cancel] rather
+ * than guessing "at creation" or "at the end" — see docs/replay-forensics.md
+ * for the full rationale. Orders resolved this way are returned as
+ * `ambiguous` so the report can surface them distinctly from hard
+ * divergences.
+ */
+interface RawOrder {
+  id: string;
+  userAddress: string;
+  side: OrderSide;
+  price: number;
+  quantity: number;
+  createdAt: Date;
+  status: string;
+}
+
+function buildReplayEvents(
+  ordersRaw: RawOrder[],
+  trades: Array<LedgerTrade & { tradedAt: Date }>
+): { events: ReplayEvent[]; ambiguous: string[] } {
+  const createdAtById = new Map(
+    ordersRaw.map((o) => [o.id, o.createdAt.getTime()])
+  );
+
+  const events: ReplayEvent[] = ordersRaw
+    .map((o) => ({
+      type: "create" as const,
+      id: o.id,
+      userAddress: o.userAddress,
+      side: o.side,
+      price: o.price,
+      quantity: o.quantity,
+      timestamp: o.createdAt.getTime(),
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp || a.id.localeCompare(b.id));
+
+  const ambiguous: string[] = [];
+  const cancelInsertions: Array<{ afterOrderId: string; event: ReplayEvent }> =
+    [];
+
+  for (const o of ordersRaw) {
+    if (o.status !== "CANCELLED") continue;
+
+    const touchingTrades = trades.filter(
+      (t) => t.buyOrderId === o.id || t.sellOrderId === o.id
+    );
+
+    let anchorOrderId = o.id;
+    if (touchingTrades.length > 0) {
+      const lastTrade = touchingTrades.reduce((latest, t) =>
+        t.tradedAt.getTime() > latest.tradedAt.getTime() ? t : latest
+      );
+      const counterpartyId =
+        lastTrade.buyOrderId === o.id
+          ? lastTrade.sellOrderId
+          : lastTrade.buyOrderId;
+      const ownCreatedAt = createdAtById.get(o.id) ?? -Infinity;
+      const counterpartyCreatedAt =
+        createdAtById.get(counterpartyId) ?? -Infinity;
+      // The taker is whichever side was created later — see doc comment above.
+      anchorOrderId =
+        counterpartyCreatedAt > ownCreatedAt ? counterpartyId : o.id;
+      ambiguous.push(o.id);
+    }
+
+    cancelInsertions.push({
+      afterOrderId: anchorOrderId,
+      event: {
+        type: "cancel",
+        id: o.id,
+        timestamp: createdAtById.get(o.id) ?? 0,
+      },
+    });
+  }
+
+  for (const { afterOrderId, event } of cancelInsertions) {
+    const idx = events.findIndex(
+      (e) => e.type === "create" && e.id === afterOrderId
+    );
+    events.splice(idx === -1 ? events.length : idx + 1, 0, event);
+  }
+
+  return { events, ambiguous };
+}
+
+async function replayMarketOutcome(
+  marketId: string,
+  outcome: Outcome,
+  asOf: Date
+): Promise<ReplayDivergenceReport> {
+  const prisma = getPrismaClient();
+
+  const ordersRaw = await prisma.order.findMany({
+    where: { marketId, outcome, createdAt: { lte: asOf } },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+  });
+
+  const tradesRaw = await prisma.trade.findMany({
+    where: { marketId, outcome, tradedAt: { lte: asOf } },
+    orderBy: [{ tradedAt: "asc" }, { id: "asc" }],
+  });
+
+  const ledgerOrders: LedgerOrder[] = ordersRaw.map((o) => ({
+    id: o.id,
+    userAddress: o.userAddress,
+    side: o.side,
+    price: Number(o.price),
+    quantity: o.quantity,
+    filledQuantity: o.filledQuantity,
+    status: o.status as LedgerOrder["status"],
+  }));
+
+  const ledgerTrades: Array<LedgerTrade & { tradedAt: Date }> = tradesRaw.map(
+    (t) => ({
+      buyOrderId: t.buyOrderId,
+      sellOrderId: t.sellOrderId,
+      quantity: t.quantity,
+      price: Number(t.price),
+      tradedAt: t.tradedAt,
+    })
+  );
+
+  const normalizedOrdersRaw: RawOrder[] = ordersRaw.map((o) => ({
+    id: o.id,
+    userAddress: o.userAddress,
+    side: o.side,
+    price: Number(o.price),
+    quantity: o.quantity,
+    createdAt: o.createdAt,
+    status: o.status,
+  }));
+
+  const { events, ambiguous } = buildReplayEvents(
+    normalizedOrdersRaw,
+    ledgerTrades
+  );
+
+  const replay = replayEvents(marketId, outcome, events);
+
+  let redisSnapshot = null;
+  try {
+    redisSnapshot = await redis.getOrderBook(marketId, outcome);
+  } catch (error) {
+    log(
+      "warn",
+      "Failed to read Redis order book snapshot; skipping depth cross-check",
+      {
+        marketId,
+        outcome,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    );
+  }
+
+  return buildDivergenceReport({
+    marketId,
+    outcome,
+    asOf,
+    ledgerOrders,
+    ledgerTrades,
+    replay,
+    redisSnapshot,
+    cancelAmbiguities: ambiguous,
+  });
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const prisma = getPrismaClient();
+  let exitCode = 0;
+
+  try {
+    if (args.sample !== undefined) {
+      const markets = await prisma.market.findMany({
+        where: { deletedAt: null },
+        select: { id: true },
+        take: args.sample,
+        orderBy: { createdAt: "desc" },
+      });
+
+      const outcomes: Outcome[] = ["YES", "NO"];
+      let divergentCount = 0;
+
+      for (const market of markets) {
+        for (const outcome of outcomes) {
+          const report = await replayMarketOutcome(
+            market.id,
+            outcome,
+            args.asOf
+          );
+          if (report.hasDivergence) {
+            divergentCount++;
+            replayDivergenceTotal.inc();
+            log("error", "Replay divergence detected", { report });
+          } else {
+            log("info", "Replay clean", {
+              marketId: market.id,
+              outcome,
+              ordersReplayed: report.ordersReplayed,
+              tradesReplayed: report.tradesReplayed,
+            });
+          }
+        }
+      }
+
+      log("info", "Sample replay complete", {
+        marketsChecked: markets.length,
+        divergentBookChecks: divergentCount,
+      });
+
+      exitCode = divergentCount > 0 ? 1 : 0;
+    } else {
+      const report = await replayMarketOutcome(
+        args.marketId!,
+        args.outcome!,
+        args.asOf
+      );
+      console.log(JSON.stringify(report, null, 2));
+      exitCode = report.hasDivergence ? 1 : 0;
+    }
+  } finally {
+    await redis.disconnect();
+    await prisma.$disconnect();
+  }
+
+  process.exit(exitCode);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/matching/replay-diff.test.ts
+++ b/src/matching/replay-diff.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import { replayEvents, type ReplayEvent } from "./replay.js";
+import {
+  buildDivergenceReport,
+  type LedgerOrder,
+  type LedgerTrade,
+} from "./replay-diff.js";
+
+/**
+ * Proves the acceptance criteria for the replay forensics tool:
+ *  - replaying a known-consistent corpus yields zero diff
+ *  - injected book corruption (bad filledQuantity, phantom order, wrong
+ *    depth) is detected with clear order-id level output
+ */
+describe("buildDivergenceReport", () => {
+  const marketId = "market-diff";
+  const outcome = "YES" as const;
+
+  function baseCorpus(): {
+    events: ReplayEvent[];
+    ledgerOrders: LedgerOrder[];
+    ledgerTrades: LedgerTrade[];
+  } {
+    const events: ReplayEvent[] = [
+      {
+        type: "create",
+        id: "maker-1",
+        userAddress: "GMAKER00000000000000000000000000000000000000000001",
+        side: "SELL",
+        price: 0.4,
+        quantity: 100,
+        timestamp: 1_700_000_000_000,
+      },
+      {
+        type: "create",
+        id: "taker-1",
+        userAddress: "GTAKER00000000000000000000000000000000000000000001",
+        side: "BUY",
+        price: 0.4,
+        quantity: 60,
+        timestamp: 1_700_000_001_000,
+      },
+    ];
+
+    // Ground truth ledger: maker-1 partially filled (60/100), still resting;
+    // taker-1 fully filled.
+    const ledgerOrders: LedgerOrder[] = [
+      {
+        id: "maker-1",
+        userAddress: "GMAKER00000000000000000000000000000000000000000001",
+        side: "SELL",
+        price: 0.4,
+        quantity: 100,
+        filledQuantity: 60,
+        status: "PARTIALLY_FILLED",
+      },
+      {
+        id: "taker-1",
+        userAddress: "GTAKER00000000000000000000000000000000000000000001",
+        side: "BUY",
+        price: 0.4,
+        quantity: 60,
+        filledQuantity: 60,
+        status: "FILLED",
+      },
+    ];
+
+    const ledgerTrades: LedgerTrade[] = [
+      {
+        buyOrderId: "taker-1",
+        sellOrderId: "maker-1",
+        quantity: 60,
+        price: 0.4,
+      },
+    ];
+
+    return { events, ledgerOrders, ledgerTrades };
+  }
+
+  it("reports zero diff for a consistent corpus", () => {
+    const { events, ledgerOrders, ledgerTrades } = baseCorpus();
+    const replay = replayEvents(marketId, outcome, events);
+
+    const report = buildDivergenceReport({
+      marketId,
+      outcome,
+      asOf: new Date(),
+      ledgerOrders,
+      ledgerTrades,
+      replay,
+    });
+
+    expect(report.hasDivergence).toBe(false);
+    expect(report.orderMismatches).toEqual([]);
+    expect(report.missingOrderIds).toEqual([]);
+    expect(report.extraOrderIds).toEqual([]);
+    expect(report.missingTrades).toEqual([]);
+    expect(report.extraTrades).toEqual([]);
+  });
+
+  it("detects a filledQuantity accounting bug with order-id level output", () => {
+    const { events, ledgerOrders, ledgerTrades } = baseCorpus();
+    const replay = replayEvents(marketId, outcome, events);
+
+    // Corrupt the ledger: pretend maker-1's filledQuantity was recorded wrong
+    // (e.g. a double-counted fill never actually applied by the engine).
+    const corruptedOrders = ledgerOrders.map((o) =>
+      o.id === "maker-1" ? { ...o, filledQuantity: 90 } : o
+    );
+
+    const report = buildDivergenceReport({
+      marketId,
+      outcome,
+      asOf: new Date(),
+      ledgerOrders: corruptedOrders,
+      ledgerTrades,
+      replay,
+    });
+
+    expect(report.hasDivergence).toBe(true);
+    expect(report.orderMismatches).toContainEqual({
+      orderId: "maker-1",
+      field: "filledQuantity",
+      expected: 90,
+      actual: 60,
+    });
+    expect(report.orderMismatches).toContainEqual({
+      orderId: "maker-1",
+      field: "remaining",
+      expected: 10,
+      actual: 40,
+    });
+  });
+
+  it("detects a phantom order missing from the ledger", () => {
+    const { events, ledgerOrders, ledgerTrades } = baseCorpus();
+    const replay = replayEvents(marketId, outcome, events);
+
+    // Drop maker-1 from the ledger entirely, as if its DB row vanished
+    // while the engine still resurrected it into the book.
+    const withoutMaker = ledgerOrders.filter((o) => o.id !== "maker-1");
+
+    const report = buildDivergenceReport({
+      marketId,
+      outcome,
+      asOf: new Date(),
+      ledgerOrders: withoutMaker,
+      ledgerTrades,
+      replay,
+    });
+
+    expect(report.hasDivergence).toBe(true);
+    expect(report.extraOrderIds).toEqual(["maker-1"]);
+  });
+
+  it("detects a resting order missing from the replayed book", () => {
+    const { ledgerOrders, ledgerTrades } = baseCorpus();
+    // Replay only the taker event, never adding maker-1 to the book at all
+    // (simulating a hydration bug that dropped a resting order).
+    const replay = replayEvents(marketId, outcome, [
+      {
+        type: "create",
+        id: "taker-1",
+        userAddress: "GTAKER00000000000000000000000000000000000000000001",
+        side: "BUY",
+        price: 0.4,
+        quantity: 60,
+        timestamp: 1_700_000_001_000,
+      },
+    ]);
+
+    const report = buildDivergenceReport({
+      marketId,
+      outcome,
+      asOf: new Date(),
+      ledgerOrders,
+      ledgerTrades,
+      replay,
+    });
+
+    expect(report.hasDivergence).toBe(true);
+    expect(report.missingOrderIds).toEqual(["maker-1"]);
+    // taker-1 never matches without maker-1 resting, so the recorded trade
+    // never gets reproduced either.
+    expect(report.missingTrades).toHaveLength(1);
+  });
+
+  it("detects a price-level depth mismatch against the Redis snapshot", () => {
+    const { events, ledgerOrders, ledgerTrades } = baseCorpus();
+    const replay = replayEvents(marketId, outcome, events);
+
+    const report = buildDivergenceReport({
+      marketId,
+      outcome,
+      asOf: new Date(),
+      ledgerOrders,
+      ledgerTrades,
+      replay,
+      // Redis cache stale: reports 25 resting at 0.4 instead of the true 40.
+      redisSnapshot: { bids: [], asks: [{ price: 0.4, quantity: 25 }] },
+    });
+
+    expect(report.hasDivergence).toBe(true);
+    expect(report.depthDeltas).toContainEqual({
+      side: "ask",
+      price: 0.4,
+      expectedQuantity: 25,
+      actualQuantity: 40,
+    });
+  });
+});

--- a/src/matching/replay-diff.ts
+++ b/src/matching/replay-diff.ts
@@ -1,0 +1,237 @@
+/**
+ * Structured divergence report: ledger (Order/Trade rows) vs. a replayed
+ * OrderBook, optionally cross-checked against a cached Redis depth snapshot.
+ *
+ * See docs/replay-forensics.md for when to run this and how to read a
+ * divergence report.
+ */
+import type { Outcome, OrderSide } from "../types/index.js";
+import type { ReplayResult } from "./replay.js";
+
+export interface LedgerOrder {
+  id: string;
+  userAddress: string;
+  side: OrderSide;
+  price: number;
+  quantity: number;
+  filledQuantity: number;
+  status: "OPEN" | "FILLED" | "CANCELLED" | "PARTIALLY_FILLED";
+}
+
+export interface LedgerTrade {
+  buyOrderId: string;
+  sellOrderId: string;
+  quantity: number;
+  price: number;
+}
+
+export interface DepthSnapshot {
+  bids: Array<{ price: number; quantity: number }>;
+  asks: Array<{ price: number; quantity: number }>;
+}
+
+export interface OrderMismatch {
+  orderId: string;
+  field: "filledQuantity" | "remaining" | "status";
+  expected: unknown;
+  actual: unknown;
+}
+
+export interface DepthDelta {
+  side: "bid" | "ask";
+  price: number;
+  expectedQuantity: number;
+  actualQuantity: number;
+}
+
+export interface ReplayDivergenceReport {
+  marketId: string;
+  outcome: Outcome;
+  asOf: string;
+  ordersReplayed: number;
+  tradesReplayed: number;
+  orderMismatches: OrderMismatch[];
+  missingOrderIds: string[];
+  extraOrderIds: string[];
+  missingTrades: string[];
+  extraTrades: string[];
+  depthDeltas: DepthDelta[];
+  cancelAmbiguities: string[];
+  hasDivergence: boolean;
+}
+
+function tradeKey(
+  buyOrderId: string,
+  sellOrderId: string,
+  quantity: number,
+  price: number
+): string {
+  return `${buyOrderId}:${sellOrderId}:${quantity}:${price}`;
+}
+
+function diffMultisets(
+  expected: string[],
+  actual: string[]
+): { missing: string[]; extra: string[] } {
+  const expectedCounts = new Map<string, number>();
+  for (const k of expected)
+    expectedCounts.set(k, (expectedCounts.get(k) ?? 0) + 1);
+  const actualCounts = new Map<string, number>();
+  for (const k of actual) actualCounts.set(k, (actualCounts.get(k) ?? 0) + 1);
+
+  const missing: string[] = [];
+  for (const [key, count] of expectedCounts) {
+    const have = actualCounts.get(key) ?? 0;
+    for (let i = have; i < count; i++) missing.push(key);
+  }
+
+  const extra: string[] = [];
+  for (const [key, count] of actualCounts) {
+    const want = expectedCounts.get(key) ?? 0;
+    for (let i = want; i < count; i++) extra.push(key);
+  }
+
+  return { missing, extra };
+}
+
+function diffDepthSide(
+  side: "bid" | "ask",
+  expected: Array<{ price: number; quantity: number }>,
+  actual: Array<{ price: number; quantity: number }>
+): DepthDelta[] {
+  const expectedByPrice = new Map(expected.map((l) => [l.price, l.quantity]));
+  const actualByPrice = new Map(actual.map((l) => [l.price, l.quantity]));
+  const prices = new Set([...expectedByPrice.keys(), ...actualByPrice.keys()]);
+
+  const deltas: DepthDelta[] = [];
+  for (const price of prices) {
+    const expectedQuantity = expectedByPrice.get(price) ?? 0;
+    const actualQuantity = actualByPrice.get(price) ?? 0;
+    if (expectedQuantity !== actualQuantity) {
+      deltas.push({ side, price, expectedQuantity, actualQuantity });
+    }
+  }
+  return deltas.sort((a, b) => a.price - b.price);
+}
+
+/**
+ * Build a structured divergence report comparing ledger truth (Order/Trade
+ * rows) against a replayed OrderBook, and optionally a cached Redis depth
+ * snapshot.
+ *
+ * `cancelAmbiguities` should list order ids whose cancel timing had to be
+ * approximated (see replay-market.ts's anchoring logic) — they are surfaced
+ * separately from hard divergences since they represent a known data gap
+ * (no `cancelledAt` timestamp exists yet), not necessarily a bug.
+ */
+export function buildDivergenceReport(params: {
+  marketId: string;
+  outcome: Outcome;
+  asOf: Date;
+  ledgerOrders: LedgerOrder[];
+  ledgerTrades: LedgerTrade[];
+  replay: ReplayResult;
+  redisSnapshot?: DepthSnapshot | null;
+  cancelAmbiguities?: string[];
+}): ReplayDivergenceReport {
+  const { marketId, outcome, asOf, ledgerOrders, ledgerTrades, replay } =
+    params;
+
+  const orderMismatches: OrderMismatch[] = [];
+  const missingOrderIds: string[] = [];
+  const extraOrderIds: string[] = [];
+
+  const ledgerById = new Map(ledgerOrders.map((o) => [o.id, o]));
+
+  for (const ledgerOrder of ledgerOrders) {
+    const replayed = replay.orders.get(ledgerOrder.id);
+    const expectedRemaining = ledgerOrder.quantity - ledgerOrder.filledQuantity;
+    const expectedResting =
+      (ledgerOrder.status === "OPEN" ||
+        ledgerOrder.status === "PARTIALLY_FILLED") &&
+      expectedRemaining > 0;
+
+    if (!replayed) {
+      if (expectedResting) missingOrderIds.push(ledgerOrder.id);
+      continue;
+    }
+
+    if (replayed.filledQuantity !== ledgerOrder.filledQuantity) {
+      orderMismatches.push({
+        orderId: ledgerOrder.id,
+        field: "filledQuantity",
+        expected: ledgerOrder.filledQuantity,
+        actual: replayed.filledQuantity,
+      });
+    }
+
+    if (replayed.remaining !== expectedRemaining) {
+      orderMismatches.push({
+        orderId: ledgerOrder.id,
+        field: "remaining",
+        expected: expectedRemaining,
+        actual: replayed.remaining,
+      });
+    }
+
+    const replayedRestingNow = replayed.remaining > 0;
+    if (replayedRestingNow !== expectedResting) {
+      orderMismatches.push({
+        orderId: ledgerOrder.id,
+        field: "status",
+        expected: expectedResting ? "resting" : "not resting",
+        actual: replayedRestingNow ? "resting" : "not resting",
+      });
+    }
+  }
+
+  for (const orderId of replay.orders.keys()) {
+    if (!ledgerById.has(orderId)) {
+      extraOrderIds.push(orderId);
+    }
+  }
+
+  const expectedTradeKeys = ledgerTrades.map((t) =>
+    tradeKey(t.buyOrderId, t.sellOrderId, t.quantity, t.price)
+  );
+  const actualTradeKeys = replay.trades.map((t) =>
+    tradeKey(t.buyOrderId, t.sellOrderId, t.quantity, t.price)
+  );
+  const { missing: missingTrades, extra: extraTrades } = diffMultisets(
+    expectedTradeKeys,
+    actualTradeKeys
+  );
+
+  let depthDeltas: DepthDelta[] = [];
+  if (params.redisSnapshot) {
+    const replayDepth = params.replay.book.getDepth(Number.MAX_SAFE_INTEGER);
+    depthDeltas = [
+      ...diffDepthSide("bid", params.redisSnapshot.bids, replayDepth.bids),
+      ...diffDepthSide("ask", params.redisSnapshot.asks, replayDepth.asks),
+    ];
+  }
+
+  const hasDivergence =
+    orderMismatches.length > 0 ||
+    missingOrderIds.length > 0 ||
+    extraOrderIds.length > 0 ||
+    missingTrades.length > 0 ||
+    extraTrades.length > 0 ||
+    depthDeltas.length > 0;
+
+  return {
+    marketId,
+    outcome,
+    asOf: asOf.toISOString(),
+    ordersReplayed: ledgerOrders.length,
+    tradesReplayed: replay.trades.length,
+    orderMismatches,
+    missingOrderIds,
+    extraOrderIds,
+    missingTrades,
+    extraTrades,
+    depthDeltas,
+    cancelAmbiguities: params.cancelAmbiguities ?? [],
+    hasDivergence,
+  };
+}

--- a/src/matching/replay.test.ts
+++ b/src/matching/replay.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { matchOrder, type MatchingOrder } from "./engine.js";
+import { OrderBook, type Order as BookOrder } from "./orderbook.js";
+import { replayEvents, type ReplayEvent } from "./replay.js";
+
+/**
+ * Golden replay corpus (forensics): proves `replayEvents` — the pure
+ * function driving scripts/replay-market.ts — reproduces byte-identical
+ * trades to directly driving `matchOrder`/`OrderBook`, for the same fill
+ * scenarios as the #729 snapshot corpus in engine.fills.snapshot.test.ts.
+ *
+ * `matchOrder` stamps trades with `Date.now()`, so it's frozen per taker
+ * event just like the existing snapshot corpus.
+ */
+describe("replayEvents (golden corpus, replay equals live engine output)", () => {
+  const marketId = "market-replay";
+  const outcome = "YES" as const;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fully fills a taker order against a single resting maker", () => {
+    const makerTs = 1_700_000_000_000;
+    const takerTs = 1_700_000_001_000;
+
+    const events: ReplayEvent[] = [
+      {
+        type: "create",
+        id: "maker-1",
+        userAddress: "GMAKER00000000000000000000000000000000000000000001",
+        side: "SELL",
+        price: 0.5,
+        quantity: 100,
+        timestamp: makerTs,
+      },
+      {
+        type: "create",
+        id: "taker-1",
+        userAddress: "GTAKER00000000000000000000000000000000000000000001",
+        side: "BUY",
+        price: 0.5,
+        quantity: 100,
+        timestamp: takerTs,
+      },
+    ];
+
+    vi.spyOn(Date, "now").mockReturnValue(takerTs);
+    const replayResult = replayEvents(marketId, outcome, events);
+
+    // Directly drive the live engine the same way matching-service.ts does.
+    const liveBook = new OrderBook(marketId, 0);
+    liveBook.addOrder(
+      bookOrder(
+        "maker-1",
+        "GMAKER00000000000000000000000000000000000000000001",
+        "ask",
+        0.5,
+        100,
+        makerTs
+      )
+    );
+    vi.spyOn(Date, "now").mockReturnValue(takerTs);
+    const liveResult = matchOrder(
+      matchingOrder(
+        "taker-1",
+        "GTAKER00000000000000000000000000000000000000000001",
+        "BUY",
+        0.5,
+        100,
+        takerTs
+      ),
+      liveBook
+    );
+
+    expect(replayResult.trades).toEqual(liveResult.trades);
+    expect(replayResult.book.getOrderCount()).toBe(liveBook.getOrderCount());
+    expect(replayResult.orders.get("maker-1")?.remaining).toBe(0);
+    expect(replayResult.orders.get("taker-1")?.remaining).toBe(0);
+  });
+
+  it("partially fills a taker order and leaves a remaining resting order", () => {
+    const makerTs = 1_700_000_000_000;
+    const takerTs = 1_700_000_001_000;
+
+    const events: ReplayEvent[] = [
+      {
+        type: "create",
+        id: "maker-1",
+        userAddress: "GMAKER00000000000000000000000000000000000000000002",
+        side: "SELL",
+        price: 0.45,
+        quantity: 40,
+        timestamp: makerTs,
+      },
+      {
+        type: "create",
+        id: "taker-1",
+        userAddress: "GTAKER00000000000000000000000000000000000000000002",
+        side: "BUY",
+        price: 0.5,
+        quantity: 100,
+        timestamp: takerTs,
+      },
+    ];
+
+    vi.spyOn(Date, "now").mockReturnValue(takerTs);
+    const replayResult = replayEvents(marketId, outcome, events);
+
+    const liveBook = new OrderBook(marketId, 0);
+    liveBook.addOrder(
+      bookOrder(
+        "maker-1",
+        "GMAKER00000000000000000000000000000000000000000002",
+        "ask",
+        0.45,
+        40,
+        makerTs
+      )
+    );
+    vi.spyOn(Date, "now").mockReturnValue(takerTs);
+    const liveResult = matchOrder(
+      matchingOrder(
+        "taker-1",
+        "GTAKER00000000000000000000000000000000000000000002",
+        "BUY",
+        0.5,
+        100,
+        takerTs
+      ),
+      liveBook
+    );
+
+    expect(replayResult.trades).toEqual(liveResult.trades);
+    expect(replayResult.orders.get("maker-1")?.remaining).toBe(0);
+    expect(replayResult.orders.get("taker-1")?.remaining).toBe(60);
+    expect(replayResult.book.getOrderCount()).toBe(1); // taker's remainder rests
+  });
+
+  it("a cancelled maker is excluded from later matches", () => {
+    const maker1Ts = 1_700_000_000_000;
+    const maker2Ts = 1_700_000_000_500;
+    const cancelTs = 1_700_000_000_800;
+    const takerTs = 1_700_000_001_000;
+
+    const events: ReplayEvent[] = [
+      {
+        type: "create",
+        id: "maker-1",
+        userAddress: "GMAKER00000000000000000000000000000000000000000003",
+        side: "SELL",
+        price: 0.5,
+        quantity: 50,
+        timestamp: maker1Ts,
+      },
+      {
+        type: "create",
+        id: "maker-2",
+        userAddress: "GMAKER00000000000000000000000000000000000000000004",
+        side: "SELL",
+        price: 0.5,
+        quantity: 50,
+        timestamp: maker2Ts,
+      },
+      { type: "cancel", id: "maker-1", timestamp: cancelTs },
+      {
+        type: "create",
+        id: "taker-1",
+        userAddress: "GTAKER00000000000000000000000000000000000000000003",
+        side: "BUY",
+        price: 0.5,
+        quantity: 50,
+        timestamp: takerTs,
+      },
+    ];
+
+    vi.spyOn(Date, "now").mockReturnValue(takerTs);
+    const replayResult = replayEvents(marketId, outcome, events);
+
+    expect(replayResult.trades).toHaveLength(1);
+    expect(replayResult.trades[0].sellOrderId).toBe("maker-2");
+    expect(replayResult.orders.get("maker-1")?.remaining).toBe(50); // never filled, just cancelled
+    expect(replayResult.book.getOrdersAtPrice("ask", 0.5)).toHaveLength(0);
+  });
+
+  it("skips a self-trade and matches the next resting order at the same price", () => {
+    const sameUser = "GSAMEUSER0000000000000000000000000000000000000001";
+    const selfTs = 1_700_000_000_000;
+    const makerTs = 1_700_000_000_500;
+    const takerTs = 1_700_000_001_000;
+
+    const events: ReplayEvent[] = [
+      {
+        type: "create",
+        id: "self-1",
+        userAddress: sameUser,
+        side: "SELL",
+        price: 0.5,
+        quantity: 100,
+        timestamp: selfTs,
+      },
+      {
+        type: "create",
+        id: "maker-1",
+        userAddress: "GMAKER00000000000000000000000000000000000000000006",
+        side: "SELL",
+        price: 0.5,
+        quantity: 100,
+        timestamp: makerTs,
+      },
+      {
+        type: "create",
+        id: "taker-1",
+        userAddress: sameUser,
+        side: "BUY",
+        price: 0.5,
+        quantity: 100,
+        timestamp: takerTs,
+      },
+    ];
+
+    vi.spyOn(Date, "now").mockReturnValue(takerTs);
+    const replayResult = replayEvents(marketId, outcome, events);
+
+    expect(replayResult.trades).toHaveLength(1);
+    expect(replayResult.trades[0].sellOrderId).toBe("maker-1");
+    expect(replayResult.book.getOrderCount()).toBe(0);
+  });
+});
+
+function bookOrder(
+  id: string,
+  userAddress: string,
+  side: "bid" | "ask",
+  price: number,
+  quantity: number,
+  timestamp: number
+): BookOrder {
+  return {
+    id,
+    userAddress,
+    side,
+    price,
+    quantity,
+    timestamp,
+    marketId: "market-replay",
+    outcome: 0,
+  };
+}
+
+function matchingOrder(
+  id: string,
+  userAddress: string,
+  side: "BUY" | "SELL",
+  price: number,
+  quantity: number,
+  timestamp: number
+): MatchingOrder {
+  return {
+    id,
+    userAddress,
+    side,
+    price,
+    quantity,
+    marketId: "market-replay",
+    outcome: "YES",
+    timestamp,
+  };
+}

--- a/src/matching/replay.ts
+++ b/src/matching/replay.ts
@@ -1,0 +1,143 @@
+/**
+ * Deterministic order/trade replay over a fresh OrderBook (#forensics).
+ *
+ * Replays a market+outcome's order history through the *same* matching
+ * engine (`matchOrder`) used in production, in a fresh, isolated `OrderBook`.
+ * This is the pure, DB/Redis-free core used by both the golden test corpus
+ * and the `scripts/replay-market.ts` forensics CLI — see docs/replay-forensics.md
+ * for how the two layers fit together and how to interpret a divergence.
+ *
+ * Hydrating only the currently-resting orders (as `matching-service.ts`
+ * does on cold start) can never catch a historical fill-accounting bug: it
+ * trusts `filledQuantity`/`status` as given. Replaying the full order
+ * arrival sequence through `matchOrder` instead re-derives every trade from
+ * scratch, so any divergence between "what the engine would have done" and
+ * "what actually got recorded" surfaces immediately.
+ */
+import type { Outcome, OrderSide } from "../types/index.js";
+import { OrderBook, type Order as BookOrder } from "./orderbook.js";
+import { matchOrder, outcomeToNumber, type Trade } from "./engine.js";
+
+/** A resting/taker order entering the book, in arrival order. */
+export interface ReplayOrderCreate {
+  type: "create";
+  id: string;
+  userAddress: string;
+  side: OrderSide;
+  price: number;
+  quantity: number;
+  timestamp: number;
+}
+
+/** An order leaving the book without being filled. */
+export interface ReplayOrderCancel {
+  type: "cancel";
+  id: string;
+  timestamp: number;
+}
+
+export type ReplayEvent = ReplayOrderCreate | ReplayOrderCancel;
+
+export interface ReplayedOrderState {
+  id: string;
+  userAddress: string;
+  side: OrderSide;
+  price: number;
+  quantity: number;
+  filledQuantity: number;
+  remaining: number;
+}
+
+export interface ReplayResult {
+  book: OrderBook;
+  trades: Trade[];
+  /** Final per-order state derived purely from replaying the event stream. */
+  orders: Map<string, ReplayedOrderState>;
+}
+
+/**
+ * Replay an ordered event stream for a single (marketId, outcome) book.
+ *
+ * Callers are responsible for ordering `events` deterministically (by
+ * `timestamp`, tie-broken by a stable secondary key such as row id) before
+ * calling this function — it applies events strictly in the order given.
+ *
+ * Each `create` event is run through the real `matchOrder` engine against
+ * the book being built up so far, exactly mirroring
+ * `matching-service.ts#placeOrder`'s in-memory sequence (minus the DB/Redis
+ * side effects). Each `cancel` event removes the order from the book with
+ * no trade side effects, mirroring `matching-service.ts#cancelOrder`.
+ */
+export function replayEvents(
+  marketId: string,
+  outcome: Outcome,
+  events: ReplayEvent[]
+): ReplayResult {
+  const outcomeNum = outcomeToNumber(outcome);
+  const book = new OrderBook(marketId, outcomeNum);
+  const trades: Trade[] = [];
+  const orders = new Map<string, ReplayedOrderState>();
+
+  for (const event of events) {
+    if (event.type === "create") {
+      orders.set(event.id, {
+        id: event.id,
+        userAddress: event.userAddress,
+        side: event.side,
+        price: event.price,
+        quantity: event.quantity,
+        filledQuantity: 0,
+        remaining: event.quantity,
+      });
+
+      const result = matchOrder(
+        {
+          id: event.id,
+          userAddress: event.userAddress,
+          side: event.side,
+          price: event.price,
+          quantity: event.quantity,
+          marketId,
+          outcome,
+          timestamp: event.timestamp,
+        },
+        book
+      );
+
+      for (const trade of result.trades) {
+        trades.push(trade);
+        applyFill(orders, trade.buyOrderId, trade.quantity);
+        applyFill(orders, trade.sellOrderId, trade.quantity);
+      }
+
+      if (result.remainingOrder) {
+        const bookOrder: BookOrder = {
+          id: result.remainingOrder.id,
+          userAddress: result.remainingOrder.userAddress,
+          side: event.side === "BUY" ? "bid" : "ask",
+          price: result.remainingOrder.price,
+          quantity: result.remainingOrder.quantity,
+          timestamp: event.timestamp,
+          marketId,
+          outcome: outcomeNum,
+        };
+        book.addOrder(bookOrder);
+      }
+    } else {
+      book.removeOrder(event.id);
+    }
+  }
+
+  return { book, trades, orders };
+}
+
+function applyFill(
+  orders: Map<string, ReplayedOrderState>,
+  orderId: string,
+  quantity: number
+): void {
+  const state = orders.get(orderId);
+  if (!state) return;
+  state.filledQuantity += quantity;
+  state.remaining = state.quantity - state.filledQuantity;
+}

--- a/src/services/metrics.ts
+++ b/src/services/metrics.ts
@@ -38,3 +38,17 @@ export const oracleFailClosedTotal = new client.Counter({
   help: "Total number of times the oracle failed closed after all providers were unreachable",
   registers: [metricsRegistry],
 });
+
+/**
+ * Incremented by scripts/replay-market.ts whenever a market+outcome replay
+ * detects a divergence between ledger truth and the replayed book (or its
+ * cached Redis depth snapshot). Intended to be run on a sample of markets
+ * continuously in staging so a regression in matching/fill accounting shows
+ * up as a metric trend rather than only being found during an incident
+ * postmortem.
+ */
+export const replayDivergenceTotal = new client.Counter({
+  name: "vatix_replay_divergence_total",
+  help: "Total number of market+outcome replays that found a divergence from ledger truth",
+  registers: [metricsRegistry],
+});


### PR DESCRIPTION
closes #873 

Implemented a deterministic replay and forensic validation tool for the matching engine. The solution rebuilds an OrderBook from historical order events and compares the reconstructed state against the hydrated live book/Redis snapshot, generating a structured diff report and exiting with a non-zero status when inconsistencies are detected.

Changes
Added deterministic replay for order creation, fills, and cancellations using the existing matching engine.
Introduced a read-only replay script with support for --market, --outcome, and --as-of.
Implemented detailed diff reporting for:
Price-level depth differences
Missing or extra order IDs
Filled quantity mismatches
Added golden tests to validate replay consistency against known matching scenarios.
Documented replay workflow and divergence analysis for incident investigations.
Impact

This provides a reliable forensic workflow for validating order book integrity, detecting historical matching inconsistencies, and supporting postmortems and future multi-instance matching deployments.