### PR TITLE
Matching leader lease josunday002

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,19 @@ ANALYTICS_DATABASE_URL=
 # cancellation is unaffected). Default: true.
 MATCHING_ENGINE_ENABLED=true
 
+# Optional: TTL in milliseconds for the Redis-backed matching leader lease.
+# Only the current lease holder matches orders (single-writer enforcement
+# across horizontally-scaled API replicas) — see docs/deployment-runbook.md.
+# After an ungraceful leader crash, expect matching to be unavailable
+# cluster-wide for up to this long while the lease expires. Default: 15000.
+MATCHING_LEASE_TTL_MS=15000
+
+# Optional: How often (ms) each API replica renews/attempts to acquire the
+# matching leader lease. Must stay comfortably below MATCHING_LEASE_TTL_MS so
+# a couple of missed heartbeats don't cause an unnecessary handover.
+# Default: 5000.
+MATCHING_LEASE_RENEW_INTERVAL_MS=5000
+
 # -----------------------------------------------------------------------------
 # Redis
 # -----------------------------------------------------------------------------

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,22 @@ All public HTTP routes are mounted under `/v1`. The canonical positions read is
 2. CLOB matching engine runs synchronously; fills are written in the same transaction
 3. Matched fills are enqueued to Redis for downstream settlement by Workers
 
+**Single-writer enforcement.** The API is horizontally scaled, but only one
+API process may match orders at a time — two processes both hydrating and
+matching against the same in-memory book would produce inconsistent books
+and double fills. Every API process competes for a Redis-backed leader lease
+with a monotonic fencing token (`src/matching/leader-lease.ts`). Only the
+current lease holder hydrates order books and accepts `POST /v1/orders`;
+every other process fails closed with `503 matching_unavailable`. On lease
+loss (handover or Redis partition) the losing process invalidates its
+in-memory books immediately rather than continuing to serve them as
+authoritative. See
+[Scaling the API / matching leader lease](deployment-runbook.md#scaling-the-api--matching-leader-lease)
+for operator-facing details and the `vatix_matching_leader` metric.
+Order cancellation is intentionally not gated by the lease — it is protected
+independently by version-conditioned (optimistic-concurrency) DB writes and
+stays available from any instance.
+
 ### Submission queue
 
 The API and Oracle submit asynchronous work into Redis-backed queues that are processed by the Workers service.

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -90,6 +90,47 @@ hard kill. See [Graceful Shutdown](graceful-shutdown.md) for the implementation
 pattern and per-process timeout configuration
 (`WORKERS_SHUTDOWN_TIMEOUT_MS` in `.env.example`).
 
+## Scaling the API / Matching Leader Lease
+
+The API container is safe to run at more than one replica for HTTP
+throughput, **but only one replica may match orders at a time.** Each API
+process competes for a Redis-backed leader lease with a monotonic fencing
+token (`src/matching/leader-lease.ts`); only the current holder hydrates
+order books and accepts `POST /v1/orders`. See
+[Architecture — Order placement](architecture.md#order-placement) for how
+this fits into the request path.
+
+- **Non-leader behavior**: instances that do not hold the lease still serve
+  everything else normally (health/ready probes, market/position/fill reads,
+  order cancellation) — only order _placement_ is gated. A non-leader
+  returns `503` with error code `matching_unavailable` for `POST
+/v1/orders`. This is expected and does not indicate an unhealthy pod; do
+  not configure liveness/readiness probes to key off this response.
+- **Failover time**: the lease TTL and heartbeat interval are configurable
+  via `MATCHING_LEASE_TTL_MS` (default `15000`) and
+  `MATCHING_LEASE_RENEW_INTERVAL_MS` (default `5000`). After the leader is
+  killed ungracefully (crash, OOM), expect matching to be unavailable
+  cluster-wide for up to `MATCHING_LEASE_TTL_MS` while the lease expires and
+  a standby acquires it. A graceful shutdown (`SIGTERM`) releases the lease
+  immediately so a standby can take over without waiting out the TTL.
+- **Monitoring**: scrape `vatix_matching_leader` (gauge, 1 on the current
+  holder / 0 everywhere else) and `vatix_matching_lease_renew_failures_total`
+  (counter) from `GET /metrics` on every replica. Alert if:
+  - No replica reports `vatix_matching_leader == 1` for longer than a couple
+    of lease TTLs (matching is stuck unavailable cluster-wide).
+  - More than one replica reports `vatix_matching_leader == 1`
+    simultaneously (would indicate a fencing bug — treat as a production
+    incident, not a metrics glitch).
+  - A rising rate of `vatix_matching_lease_renew_failures_total` on the
+    current holder (at risk of an imminent, possibly avoidable, handover).
+- **Read replicas**: any replica may safely serve `GET` endpoints (markets,
+  positions, fills, order book depth) regardless of lease status — those
+  reads go through PostgreSQL/Redis cache, not the in-memory book, so they
+  stay correct even on a non-leader. Only the _authoritative_ in-memory book
+  used for matching is lease-gated; a non-leader proactively drops its
+  in-memory books on lease loss rather than risk serving stale depth as
+  authoritative.
+
 ## If Something Goes Wrong
 
 See the [Incident Response Runbook](./runbooks/incident-runbook.md) for
@@ -102,3 +143,4 @@ service-specific triage steps (indexer lag, DB outages, RPC outages, etc.).
 - [Incident Response Runbook](./runbooks/incident-runbook.md)
 - [Graceful Shutdown](graceful-shutdown.md)
 - [Architecture Overview](architecture.md)
+- [Metrics](metrics.md)

--- a/docs/env-validation.md
+++ b/docs/env-validation.md
@@ -199,6 +199,8 @@ Must be a positive integer, optionally within a bounded range.
 | `REDIS_RETRY_BASE_DELAY`                 | 1    | —       | `100`   |
 | `REDIS_RETRY_MAX_DELAY`                  | 1    | —       | `2000`  |
 | `REDIS_CONNECT_TIMEOUT`                  | 1    | —       | `5000`  |
+| `MATCHING_LEASE_TTL_MS`                  | 1    | —       | `15000` |
+| `MATCHING_LEASE_RENEW_INTERVAL_MS`       | 1    | —       | `5000`  |
 
 **Error example:**
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -26,10 +26,12 @@ GET /metrics
 
 ## Metrics
 
-| Metric                              | Type    | Description                                                                                       |
-| ----------------------------------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `vatix_process_*`, `vatix_nodejs_*` | various | Default Node.js process/runtime metrics from `prom-client`.                                       |
-| `vatix_orderbook_hydrated_markets`  | gauge   | Number of `(market, outcome)` order books currently held in memory by the matching engine (#746). |
+| Metric                                      | Type    | Description                                                                                       |
+| ------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `vatix_process_*`, `vatix_nodejs_*`         | various | Default Node.js process/runtime metrics from `prom-client`.                                       |
+| `vatix_orderbook_hydrated_markets`          | gauge   | Number of `(market, outcome)` order books currently held in memory by the matching engine (#746). |
+| `vatix_matching_leader`                     | gauge   | Whether this process currently holds the matching leader lease: `1` while held, `0` otherwise.    |
+| `vatix_matching_lease_renew_failures_total` | counter | Total failed matching leader lease acquire/renew attempts on this process.                        |
 
 ### `vatix_orderbook_hydrated_markets`
 
@@ -42,6 +44,14 @@ This complements the existing `orderbook.hydrated_markets` structured log
 line emitted once at cold start (see [Indexer Metrics Log](metrics-log.md)
 for the equivalent indexer pattern) — the gauge reflects the _current_ count
 at any point in time, not just the cold-start snapshot.
+
+### `vatix_matching_leader` / `vatix_matching_lease_renew_failures_total`
+
+Single-writer enforcement for the matching engine: exactly one API replica
+should report `vatix_matching_leader == 1` at a time (see
+[Scaling the API / Matching Leader Lease](deployment-runbook.md#scaling-the-api--matching-leader-lease)
+for alerting guidance and failover timing). Updated by
+`src/matching/leader-lease.ts` on every acquire, renew, and loss.
 
 ## Adding a new metric
 

--- a/src/api/middleware/errors.ts
+++ b/src/api/middleware/errors.ts
@@ -73,6 +73,20 @@ export class ServiceUnavailableError extends AppError {
   }
 }
 
+export class OrderConflictError extends AppError {
+  constructor(message = "Order was concurrently modified; please retry") {
+    super(message, 409, "order_conflict");
+  }
+}
+
+export class MatchingUnavailableError extends AppError {
+  constructor(
+    message = "This instance does not currently hold the matching leader lease"
+  ) {
+    super(message, 503, "matching_unavailable");
+  }
+}
+
 export class MarketNotActiveError extends AppError {
   constructor(marketId: string, status: string) {
     super(

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,8 +267,24 @@ const start = async () => {
     // Hydrate in-memory order books from Postgres on cold start (#449).
     // This eliminates the race window where a restart leaves books empty
     // while open orders still exist in the database.
-    const { matchingService } = await import("./matching/matching-service.js");
-    await matchingService.hydrateAllActiveMarkets();
+    const { matchingService, isMatchingEngineEnabled } =
+      await import("./matching/matching-service.js");
+
+    if (isMatchingEngineEnabled()) {
+      // Single-writer enforcement: only the Redis lease holder may match
+      // orders (see src/matching/leader-lease.ts). Hydration only makes
+      // sense once this instance actually holds the lease — a standby
+      // instance has nothing useful to warm since placeOrder() will reject
+      // until it becomes leader. The first acquisition attempt below is
+      // awaited so a pod that wins the lease on boot serves warm books from
+      // its very first request; a pod that loses the race still comes up
+      // and serves health/read traffic while it retries in the background.
+      const { leaderLease } = await import("./matching/leader-lease.js");
+      await leaderLease.start({
+        onAcquired: () => matchingService.hydrateAllActiveMarkets(),
+        onLost: () => matchingService.invalidateAllBooks(),
+      });
+    }
 
     const port = config.port;
     await server.listen({ port, host: "0.0.0.0" });
@@ -335,11 +351,15 @@ const start = async () => {
         // Close server — stops accepting new connections, drains in-flight requests
         await server.close();
 
-        // Gracefully disconnect database and redis
+        // Gracefully disconnect database and redis, and release the
+        // matching leader lease (if held) so the next holder doesn't wait
+        // out the full lease TTL before taking over.
         const { disconnectPrisma } = await import("./services/prisma.js");
         const { disconnectAnalyticsPrisma } =
           await import("./services/analytics-prisma.js");
         const { redis } = await import("./services/redis.js");
+        const { leaderLease } = await import("./matching/leader-lease.js");
+        await leaderLease.release();
         await Promise.allSettled([
           disconnectPrisma(),
           disconnectAnalyticsPrisma(),

--- a/src/matching/leader-lease.test.ts
+++ b/src/matching/leader-lease.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Fake Redis lease store — reimplements the exact CAS semantics of the real
+// Lua scripts in src/services/redis.ts (acquireOrRenewLease /
+// releaseLeaseIfHeld) in plain JS, driven by the fake system clock (Date.now)
+// installed via vi.useFakeTimers/vi.setSystemTime. This lets tests simulate
+// dual contenders and TTL expiry deterministically without a real Redis.
+// ---------------------------------------------------------------------------
+function createFakeLeaseStore() {
+  let lockVal: string | null = null;
+  let expiresAt = 0;
+  let fencingCounter = 0;
+
+  return {
+    async acquireOrRenewLease(
+      _lockKey: string,
+      _fencingKey: string,
+      holderId: string,
+      ttlMs: number,
+      knownToken: number
+    ): Promise<number> {
+      const now = Date.now();
+      if (lockVal !== null && now >= expiresAt) {
+        lockVal = null; // Redis would have expired the key by now
+      }
+      if (lockVal === null) {
+        fencingCounter += 1;
+        lockVal = `${holderId}:${fencingCounter}`;
+        expiresAt = now + ttlMs;
+        return fencingCounter;
+      }
+      if (lockVal === `${holderId}:${knownToken}`) {
+        expiresAt = now + ttlMs;
+        return knownToken;
+      }
+      return -1;
+    },
+
+    async releaseLeaseIfHeld(
+      _lockKey: string,
+      holderId: string,
+      token: number
+    ): Promise<boolean> {
+      if (lockVal === `${holderId}:${token}`) {
+        lockVal = null;
+        return true;
+      }
+      return false;
+    },
+
+    // Test helper: who currently holds the lock, per the fake store.
+    peek(): string | null {
+      return Date.now() >= expiresAt ? null : lockVal;
+    },
+  };
+}
+
+const redisMock = vi.hoisted(() => ({
+  acquireOrRenewLease: vi.fn(),
+  releaseLeaseIfHeld: vi.fn(),
+}));
+vi.mock("../services/redis.js", () => ({ redis: redisMock }));
+
+import { LeaderLease } from "./leader-lease.js";
+import { matchingLeaderGauge } from "../services/metrics.js";
+
+const TTL_MS = 1000;
+const RENEW_INTERVAL_MS = 300;
+
+function newLease(): LeaderLease {
+  vi.stubEnv("MATCHING_LEASE_TTL_MS", String(TTL_MS));
+  vi.stubEnv("MATCHING_LEASE_RENEW_INTERVAL_MS", String(RENEW_INTERVAL_MS));
+  return new LeaderLease();
+}
+
+describe("LeaderLease", () => {
+  let store: ReturnType<typeof createFakeLeaseStore>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    store = createFakeLeaseStore();
+    redisMock.acquireOrRenewLease.mockImplementation(store.acquireOrRenewLease);
+    redisMock.releaseLeaseIfHeld.mockImplementation(store.releaseLeaseIfHeld);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("is not leader before start() is called", () => {
+    const lease = newLease();
+    expect(lease.isLeader()).toBe(false);
+    expect(lease.getToken()).toBeNull();
+  });
+
+  it("acquires the lease on the first tick and fires onAcquired with the fencing token", async () => {
+    const lease = newLease();
+    const onAcquired = vi.fn();
+
+    await lease.start({ onAcquired });
+
+    expect(lease.isLeader()).toBe(true);
+    expect(lease.getToken()).toBe(1);
+    expect(onAcquired).toHaveBeenCalledExactlyOnceWith(1);
+    expect((await matchingLeaderGauge.get()).values[0]?.value).toBe(1);
+  });
+
+  it("renews on heartbeat, keeping the same fencing token and firing onAcquired only once", async () => {
+    const lease = newLease();
+    const onAcquired = vi.fn();
+    await lease.start({ onAcquired });
+
+    await vi.advanceTimersByTimeAsync(RENEW_INTERVAL_MS * 3);
+
+    expect(lease.isLeader()).toBe(true);
+    expect(lease.getToken()).toBe(1); // renewal reuses the token, doesn't mint a new one
+    expect(onAcquired).toHaveBeenCalledTimes(1);
+    // Initial acquire + at least a couple of heartbeats; every renewal call
+    // must have reused the same token (never minted a new one mid-lease).
+    expect(
+      redisMock.acquireOrRenewLease.mock.calls.length
+    ).toBeGreaterThanOrEqual(3);
+    for (const call of redisMock.acquireOrRenewLease.mock.calls.slice(1)) {
+      expect(call[4]).toBe(1); // knownToken argument on every renewal
+    }
+  });
+
+  it("fails closed the instant the local lease deadline passes, even without another tick", async () => {
+    const lease = newLease();
+    await lease.start();
+    expect(lease.isLeader()).toBe(true);
+
+    // Jump the clock past the TTL without letting any heartbeat run — this
+    // is what protects the write path (placeOrder) even if the process is
+    // paused/partitioned and never gets to run its next scheduled renewal.
+    vi.setSystemTime(TTL_MS + 1);
+
+    expect(lease.isLeader()).toBe(false);
+    expect(lease.getToken()).toBeNull();
+  });
+
+  it("loses the lease and invalidates state when another instance has taken over, firing onLost", async () => {
+    const lease = newLease();
+    const onLost = vi.fn();
+    await lease.start({ onLost });
+    expect(lease.isLeader()).toBe(true);
+
+    // Simulate a rival instance stealing the lock directly in the store
+    // (e.g. because our own renewal was slow enough for the TTL to lapse).
+    redisMock.acquireOrRenewLease.mockResolvedValueOnce(-1);
+    await vi.advanceTimersByTimeAsync(RENEW_INTERVAL_MS);
+
+    expect(lease.isLeader()).toBe(false);
+    expect(onLost).toHaveBeenCalledExactlyOnceWith(
+      "lease is held by another instance"
+    );
+    expect((await matchingLeaderGauge.get()).values[0]?.value).toBe(0);
+  });
+
+  it("does not demote on a transient Redis error alone, but still fails closed once the TTL elapses", async () => {
+    const lease = newLease();
+    const onLost = vi.fn();
+    await lease.start({ onLost });
+    expect(lease.isLeader()).toBe(true);
+
+    redisMock.acquireOrRenewLease.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    // Still well within TTL — a single failed heartbeat must not flip us to
+    // non-leader immediately (that would cause needless handovers on blips).
+    await vi.advanceTimersByTimeAsync(RENEW_INTERVAL_MS);
+    expect(lease.isLeader()).toBe(true);
+    expect(onLost).not.toHaveBeenCalled();
+
+    // Once the TTL has actually elapsed while Redis stayed unreachable,
+    // the next tick's local-deadline check fails us closed regardless.
+    await vi.advanceTimersByTimeAsync(TTL_MS);
+    expect(lease.isLeader()).toBe(false);
+    expect(onLost).toHaveBeenCalledWith(
+      "local lease deadline passed before renewal succeeded"
+    );
+  });
+
+  it("dual contenders: only one of two instances competing for the same lock becomes leader", async () => {
+    const leaseA = newLease();
+    const leaseB = newLease();
+
+    await Promise.all([leaseA.start(), leaseB.start()]);
+
+    expect([leaseA.isLeader(), leaseB.isLeader()].filter(Boolean)).toHaveLength(
+      1
+    );
+  });
+
+  it("fences a stale token: the old leader cannot renew once a new leader has acquired a higher token", async () => {
+    const leaseA = newLease();
+    const onLostA = vi.fn();
+    await leaseA.start({ onLost: onLostA });
+    expect(leaseA.isLeader()).toBe(true);
+    const staleToken = leaseA.getToken();
+
+    // A goes silent (network partition — stop calling tick for A entirely)
+    // long enough for its lease to expire in the store, then B acquires.
+    vi.setSystemTime(TTL_MS + 1);
+    const leaseB = newLease();
+    await leaseB.start();
+
+    expect(leaseB.isLeader()).toBe(true);
+    expect(leaseB.getToken()).toBeGreaterThan(staleToken!);
+
+    // A's own local clock check already fences it off without needing to
+    // reach Redis at all — this is what bounds a partitioned leader's
+    // ability to keep enqueueing fills after losing ownership.
+    expect(leaseA.isLeader()).toBe(false);
+  });
+
+  it("release() deletes the lease only if still held, allowing immediate takeover instead of waiting out the TTL", async () => {
+    const lease = newLease();
+    await lease.start();
+    expect(store.peek()).not.toBeNull();
+
+    await lease.release();
+
+    expect(store.peek()).toBeNull();
+    expect(lease.isLeader()).toBe(false);
+    expect((await matchingLeaderGauge.get()).values[0]?.value).toBe(0);
+  });
+
+  it("release() is a no-op against the store when this instance never held the lease", async () => {
+    const lease = newLease();
+    // Never started/acquired.
+    await lease.release();
+    expect(redisMock.releaseLeaseIfHeld).not.toHaveBeenCalled();
+  });
+});

--- a/src/matching/leader-lease.ts
+++ b/src/matching/leader-lease.ts
@@ -1,0 +1,235 @@
+import { randomUUID } from "crypto";
+import { redis } from "../services/redis.js";
+import {
+  matchingLeaderGauge,
+  matchingLeaseRenewFailuresTotal,
+} from "../services/metrics.js";
+
+/**
+ * Single-writer enforcement for the matching engine (production-critical:
+ * horizontal scale without fencing means two pods can both hydrate books and
+ * accept orders against the same market, producing inconsistent books and
+ * double fills).
+ *
+ * Every API process competes for one Redis-backed lease. Only the current
+ * holder is allowed to match orders (see isMatchingLeader() gate in
+ * matching-service.ts#placeOrder). The lease is renewed on a heartbeat well
+ * inside its TTL; if renewal fails — because another instance took over, or
+ * because Redis is unreachable — this instance fails closed: isLeader()
+ * flips to false and in-memory books are invalidated so stale depth is never
+ * served as authoritative.
+ *
+ * Fencing: acquisition mints a monotonically increasing token (Redis INCR).
+ * isLeader() also checks a locally-tracked deadline mirroring the lease TTL,
+ * so a partitioned instance that can no longer reach Redis to learn it lost
+ * the lease still stops matching on its own once that deadline passes —
+ * bounded by MATCHING_LEASE_TTL_MS regardless of heartbeat timing.
+ */
+
+const LOCK_KEY = "matching:leader:lock";
+const FENCING_KEY = "matching:leader:fencing";
+
+function parsePositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+/**
+ * Lease timing, configurable via environment variables:
+ *   MATCHING_LEASE_TTL_MS            — lease expiry in Redis (default: 15000)
+ *   MATCHING_LEASE_RENEW_INTERVAL_MS — heartbeat interval (default: 5000)
+ * The renew interval must stay comfortably below the TTL so a couple of
+ * missed heartbeats (GC pause, transient network blip) don't cause an
+ * unnecessary handover.
+ */
+function loadLeaseConfig(): { ttlMs: number; renewIntervalMs: number } {
+  return {
+    ttlMs: parsePositiveInt("MATCHING_LEASE_TTL_MS", 15_000),
+    renewIntervalMs: parsePositiveInt(
+      "MATCHING_LEASE_RENEW_INTERVAL_MS",
+      5_000
+    ),
+  };
+}
+
+export interface LeaderLeaseCallbacks {
+  /** Fired when this instance transitions from non-leader to leader. */
+  onAcquired?: (token: number) => void | Promise<void>;
+  /** Fired when this instance transitions from leader to non-leader. */
+  onLost?: (reason: string) => void | Promise<void>;
+}
+
+export class LeaderLease {
+  readonly holderId: string = randomUUID();
+  private readonly ttlMs: number;
+  private readonly renewIntervalMs: number;
+  private token = 0; // 0 = "we do not currently hold the lease"
+  private expiresAt = 0; // local wall-clock deadline mirroring Redis's TTL
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private callbacks: LeaderLeaseCallbacks = {};
+  private inFlightTick: Promise<void> | null = null;
+
+  constructor() {
+    const cfg = loadLeaseConfig();
+    this.ttlMs = cfg.ttlMs;
+    this.renewIntervalMs = cfg.renewIntervalMs;
+    matchingLeaderGauge.set(0);
+  }
+
+  /**
+   * True only if this instance currently holds the lease AND the locally
+   * tracked deadline has not passed. This is the check the write path
+   * (placeOrder) must call before enqueueing any fill — it never trusts a
+   * cached "I'm the leader" flag past the lease's own TTL, so a partitioned
+   * instance stops accepting orders on its own even if it cannot reach
+   * Redis to confirm it lost the lease.
+   */
+  isLeader(): boolean {
+    return this.token > 0 && Date.now() < this.expiresAt;
+  }
+
+  /** Current fencing token, or null when not the leader. */
+  getToken(): number | null {
+    return this.isLeader() ? this.token : null;
+  }
+
+  /**
+   * Begin competing for the lease: attempts acquisition immediately, then
+   * heartbeats on an interval. Safe to call once per process; a second call
+   * is a no-op while already running.
+   */
+  async start(callbacks: LeaderLeaseCallbacks = {}): Promise<void> {
+    this.callbacks = callbacks;
+    if (this.timer) return;
+
+    await this.tick();
+
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.renewIntervalMs);
+    if (typeof this.timer.unref === "function") this.timer.unref();
+  }
+
+  /** Stops the heartbeat loop without releasing the lease in Redis. */
+  stopHeartbeat(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Graceful shutdown: stop heartbeating and best-effort release the lease
+   * in Redis if still held, so the next holder doesn't wait out the full
+   * TTL. Never throws — release is best-effort, TTL expiry is the backstop.
+   */
+  async release(): Promise<void> {
+    this.stopHeartbeat();
+    if (this.token > 0) {
+      const { token, holderId } = this;
+      this.setNotLeader();
+      try {
+        await redis.releaseLeaseIfHeld(LOCK_KEY, holderId, token);
+      } catch (error) {
+        console.error(
+          { service: "matching-leader-lease", err: error },
+          "Failed to release matching leader lease on shutdown"
+        );
+      }
+    }
+  }
+
+  private setNotLeader(): void {
+    this.token = 0;
+    this.expiresAt = 0;
+    matchingLeaderGauge.set(0);
+  }
+
+  private async tick(): Promise<void> {
+    // Coalesce overlapping ticks (e.g. a slow renewal still in flight when
+    // the next interval fires) into a single in-progress attempt.
+    if (this.inFlightTick) return this.inFlightTick;
+    this.inFlightTick = this.doTick();
+    try {
+      await this.inFlightTick;
+    } finally {
+      this.inFlightTick = null;
+    }
+  }
+
+  private async doTick(): Promise<void> {
+    // Fail closed on our own clock: if the locally tracked deadline has
+    // already passed, treat the lease as lost before even attempting a
+    // network call — do not let a slow/unreachable Redis extend how long we
+    // believe we are still the leader.
+    if (this.token > 0 && Date.now() >= this.expiresAt) {
+      this.handleLoss("local lease deadline passed before renewal succeeded");
+    }
+
+    const wasLeader = this.isLeader();
+
+    try {
+      const result = await redis.acquireOrRenewLease(
+        LOCK_KEY,
+        FENCING_KEY,
+        this.holderId,
+        this.ttlMs,
+        this.token
+      );
+
+      if (result > 0) {
+        this.token = result;
+        this.expiresAt = Date.now() + this.ttlMs;
+        matchingLeaderGauge.set(1);
+        if (!wasLeader) {
+          console.info(
+            JSON.stringify({
+              ts: new Date().toISOString(),
+              level: "info",
+              component: "matching-leader-lease",
+              message: "Acquired matching leader lease",
+              holderId: this.holderId,
+              token: result,
+            })
+          );
+          await this.callbacks.onAcquired?.(result);
+        }
+      } else {
+        matchingLeaseRenewFailuresTotal.inc();
+        this.handleLoss("lease is held by another instance");
+      }
+    } catch (error) {
+      matchingLeaseRenewFailuresTotal.inc();
+      console.error(
+        {
+          service: "matching-leader-lease",
+          err: error instanceof Error ? error.message : String(error),
+        },
+        "Failed to acquire/renew matching leader lease"
+      );
+      // Redis being unreachable does not by itself demote us — the local
+      // deadline check at the top of doTick() is what enforces fail-closed
+      // behavior once the TTL we last renewed for actually elapses.
+    }
+  }
+
+  private handleLoss(reason: string): void {
+    if (this.token === 0) return; // already not leader, avoid duplicate onLost
+    this.setNotLeader();
+    console.warn(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: "warn",
+        component: "matching-leader-lease",
+        message: "Lost matching leader lease",
+        holderId: this.holderId,
+        reason,
+      })
+    );
+    void this.callbacks.onLost?.(reason);
+  }
+}
+
+export const leaderLease = new LeaderLease();

--- a/src/matching/matching-service.test.ts
+++ b/src/matching/matching-service.test.ts
@@ -2,11 +2,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   ValidationError,
   ServiceUnavailableError,
+  MatchingUnavailableError,
   MarketNotActiveError,
   MarketNotFoundError,
+  OrderConflictError,
 } from "../api/middleware/errors.js";
 
 // Mock dependencies
+// Default to "we are the leader" so every pre-existing placeOrder test below
+// keeps exercising the matching path unchanged; leader-lease.test.ts covers
+// the LeaderLease class itself, this file only covers the placeOrder gate.
+const leaderLeaseMock = vi.hoisted(() => ({
+  isLeader: vi.fn(() => true),
+}));
+vi.mock("./leader-lease.js", () => ({ leaderLease: leaderLeaseMock }));
+
 vi.mock("../services/prisma.js", () => ({
   getPrismaClient: () => mockPrismaClient,
 }));
@@ -96,6 +106,7 @@ import { orderbookHydratedMarketsGauge } from "../services/metrics.js";
 describe("MatchingService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    leaderLeaseMock.isLeader.mockReturnValue(true);
     (matchingService as any).books?.clear();
     (matchingService as any).mutexes?.clear();
     mockPrismaClient.$transaction.mockImplementation(
@@ -326,6 +337,17 @@ describe("MatchingService", () => {
         ServiceUnavailableError
       );
       // Rejected before touching the database at all.
+      expect(mockPrismaClient.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("placeOrder rejects with MatchingUnavailableError (503) when this instance is not the matching leader", async () => {
+      leaderLeaseMock.isLeader.mockReturnValue(false);
+
+      await expect(matchingService.placeOrder(orderInput)).rejects.toThrow(
+        MatchingUnavailableError
+      );
+      // Rejected before touching the database at all — a non-leader must
+      // never queue behind (or race) the leader's in-flight work.
       expect(mockPrismaClient.$transaction).not.toHaveBeenCalled();
     });
 

--- a/src/matching/matching-service.ts
+++ b/src/matching/matching-service.ts
@@ -16,10 +16,13 @@ import { getPrismaClient } from "../services/prisma.js";
 import {
   ValidationError,
   ServiceUnavailableError,
+  MatchingUnavailableError,
   MarketNotFoundError,
   MarketNotActiveError,
+  OrderConflictError,
 } from "../api/middleware/errors.js";
 import { orderbookHydratedMarketsGauge } from "../services/metrics.js";
+import { leaderLease } from "./leader-lease.js";
 
 export interface PlaceOrderResult {
   order: any;
@@ -109,6 +112,19 @@ class MatchingService {
   private invalidateBook(marketId: string, outcome: Outcome): void {
     const bookKey = this.getBookKey(marketId, outcome);
     this.books.delete(bookKey);
+    this.syncHydratedMarketsGauge();
+  }
+
+  /**
+   * Drops every in-memory order book. Called when this instance loses the
+   * matching leader lease (see src/matching/leader-lease.ts): a non-leader
+   * must never serve its in-memory depth as authoritative, since another
+   * instance may already be matching against a book that has since diverged
+   * from this one. The next instance to become leader rehydrates fresh from
+   * Postgres before matching resumes.
+   */
+  invalidateAllBooks(): void {
+    this.books.clear();
     this.syncHydratedMarketsGauge();
   }
 
@@ -347,10 +363,21 @@ class MatchingService {
    * routes already call assertValidOrder before this. A market can flip to
    * CANCELLED/RESOLVED while an order is queued behind the mutex, so the
    * service itself must reject rather than trust the pre-check.
+   *
+   * Also rejects with 503 matching_unavailable when this instance does not
+   * currently hold the matching leader lease. Horizontal scale without this
+   * check would let two pods both match against the same book, producing
+   * inconsistent books and double fills — see src/matching/leader-lease.ts.
+   * Checked before acquiring the per-book mutex so a non-leader never even
+   * queues behind (or blocks) the leader's in-flight work.
    */
   async placeOrder(input: OrderInput): Promise<PlaceOrderResult> {
     if (!isMatchingEngineEnabled()) {
       throw new ServiceUnavailableError("Matching engine is disabled");
+    }
+
+    if (!leaderLease.isLeader()) {
+      throw new MatchingUnavailableError();
     }
 
     const bookKey = this.getBookKey(input.marketId, input.outcome);

--- a/src/services/metrics.ts
+++ b/src/services/metrics.ts
@@ -38,3 +38,29 @@ export const oracleFailClosedTotal = new client.Counter({
   help: "Total number of times the oracle failed closed after all providers were unreachable",
   registers: [metricsRegistry],
 });
+
+/**
+ * Whether this process currently holds the matching leader lease: 1 while
+ * held, 0 otherwise (including before first acquisition and after loss).
+ * Only the lease holder is allowed to match orders — see
+ * src/matching/leader-lease.ts. Alert if no process reports 1 for an
+ * extended period, or if more than one process reports 1 simultaneously
+ * (the latter would indicate a fencing bug, not a healthy state).
+ */
+export const matchingLeaderGauge = new client.Gauge({
+  name: "vatix_matching_leader",
+  help: "Whether this process currently holds the matching leader lease (1) or not (0)",
+  registers: [metricsRegistry],
+});
+
+/**
+ * Incremented every time this process fails to acquire or renew the
+ * matching leader lease, whether because another instance holds it or
+ * because Redis was unreachable. A rising rate on the current leader
+ * indicates it is at risk of losing (or has lost) matching authority.
+ */
+export const matchingLeaseRenewFailuresTotal = new client.Counter({
+  name: "vatix_matching_lease_renew_failures_total",
+  help: "Total number of failed matching leader lease acquire/renew attempts",
+  registers: [metricsRegistry],
+});

--- a/src/services/redis.test.ts
+++ b/src/services/redis.test.ts
@@ -467,4 +467,153 @@ describe("RedisService", () => {
       await svc2.disconnect();
     });
   });
+
+  // =========================================================================
+  // acquireOrRenewLease / releaseLeaseIfHeld — matching leader lease CAS
+  // primitives (single-writer enforcement)
+  // =========================================================================
+  describe("acquireOrRenewLease / releaseLeaseIfHeld", () => {
+    const lockKey = "test:lease:lock";
+    const fencingKey = "test:lease:fencing";
+
+    afterEach(async () => {
+      await redis.del(lockKey);
+      await redis.del(fencingKey);
+    });
+
+    it("grants a fresh lease with a new fencing token when the lock is free", async () => {
+      const token = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-a",
+        5000,
+        0
+      );
+      expect(token).toBeGreaterThan(0);
+    });
+
+    it("refuses a second holder while the first still holds the lease", async () => {
+      const tokenA = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-a",
+        5000,
+        0
+      );
+      const tokenB = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-b",
+        5000,
+        0
+      );
+      expect(tokenA).toBeGreaterThan(0);
+      expect(tokenB).toBe(-1);
+    });
+
+    it("renews the same token for the current holder without minting a new one", async () => {
+      const token = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-a",
+        5000,
+        0
+      );
+      const renewed = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-a",
+        5000,
+        token
+      );
+      expect(renewed).toBe(token);
+    });
+
+    it("fences a stale token: refuses to renew once a different holder owns the lease", async () => {
+      const tokenA = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-a",
+        1,
+        0
+      );
+      // Let holder-a's 1ms lease expire so holder-b can legitimately take over.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const tokenB = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-b",
+        5000,
+        0
+      );
+      expect(tokenB).toBeGreaterThan(tokenA);
+
+      // holder-a retrying with its old (stale) token must be fenced off,
+      // even though it doesn't know yet that it lost the lease.
+      const staleRenewal = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-a",
+        5000,
+        tokenA
+      );
+      expect(staleRenewal).toBe(-1);
+    });
+
+    it("releaseLeaseIfHeld deletes the lease only when still held by (holder, token)", async () => {
+      const token = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-a",
+        5000,
+        0
+      );
+
+      const releasedWrongToken = await redis.releaseLeaseIfHeld(
+        lockKey,
+        "holder-a",
+        token + 1
+      );
+      expect(releasedWrongToken).toBe(false);
+      expect(await redis.exists(lockKey)).toBe(true);
+
+      const released = await redis.releaseLeaseIfHeld(
+        lockKey,
+        "holder-a",
+        token
+      );
+      expect(released).toBe(true);
+      expect(await redis.exists(lockKey)).toBe(false);
+    });
+
+    it("releaseLeaseIfHeld never deletes a lease a different holder has since acquired", async () => {
+      const tokenA = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-a",
+        1,
+        0
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const tokenB = await redis.acquireOrRenewLease(
+        lockKey,
+        fencingKey,
+        "holder-b",
+        5000,
+        0
+      );
+
+      // holder-a's belated release attempt (using its stale token) must not
+      // remove holder-b's now-active lease.
+      const released = await redis.releaseLeaseIfHeld(
+        lockKey,
+        "holder-a",
+        tokenA
+      );
+      expect(released).toBe(false);
+      expect(await redis.exists(lockKey)).toBe(true);
+
+      await redis.releaseLeaseIfHeld(lockKey, "holder-b", tokenB);
+    });
+  });
 });

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -588,6 +588,95 @@ class RedisService {
   }
 
   /**
+   * Atomically acquire the named lease if free, or renew it if this caller
+   * already holds it under `knownToken`. Implemented as a single Lua script
+   * so the GET-then-SET is one atomic Redis operation — a second instance
+   * can never observe the lock as free between this caller's check and its
+   * write (the classic distributed-lock TOCTOU bug).
+   *
+   * On a fresh acquisition, `fencingKey` is atomically incremented (INCR) to
+   * mint a new monotonically increasing fencing token; renewals reuse the
+   * caller's existing token and only extend the TTL. Returns the fencing
+   * token on success, or -1 if another holder currently owns the lease.
+   */
+  async acquireOrRenewLease(
+    lockKey: string,
+    fencingKey: string,
+    holderId: string,
+    ttlMs: number,
+    knownToken: number
+  ): Promise<number> {
+    const script = `
+local lockVal = redis.call('GET', KEYS[1])
+if lockVal == false then
+  local token = redis.call('INCR', KEYS[2])
+  redis.call('SET', KEYS[1], ARGV[1] .. ':' .. token, 'PX', ARGV[2])
+  return token
+elseif lockVal == ARGV[1] .. ':' .. ARGV[3] then
+  redis.call('PEXPIRE', KEYS[1], ARGV[2])
+  return tonumber(ARGV[3])
+else
+  return -1
+end
+`;
+    try {
+      const client = await this.ensureConnected();
+      const result = await (client.eval as any)(
+        script,
+        2,
+        lockKey,
+        fencingKey,
+        holderId,
+        String(ttlMs),
+        String(knownToken)
+      );
+      return Number(result);
+    } catch (error) {
+      console.error(
+        { service: "redis", lockKey, err: error },
+        "Redis acquireOrRenewLease failed"
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Best-effort compare-and-delete: removes the lease only if it is still
+   * held by (holderId, token). Used on graceful shutdown so the next holder
+   * doesn't have to wait out the full TTL; never deletes a lease another
+   * holder has since acquired.
+   */
+  async releaseLeaseIfHeld(
+    lockKey: string,
+    holderId: string,
+    token: number
+  ): Promise<boolean> {
+    const script = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+else
+  return 0
+end
+`;
+    try {
+      const client = await this.ensureConnected();
+      const result = await (client.eval as any)(
+        script,
+        1,
+        lockKey,
+        `${holderId}:${token}`
+      );
+      return Number(result) === 1;
+    } catch (error) {
+      console.error(
+        { service: "redis", lockKey, err: error },
+        "Redis releaseLeaseIfHeld failed"
+      );
+      return false;
+    }
+  }
+
+  /**
    * Get stream info
    */
   async xinfo(subcommand: "STREAM", key: string): Promise<any> {


### PR DESCRIPTION
closes #865 

This PR enforces single-writer semantics for the matching engine by introducing leader lease/fencing to ensure only one instance can process orders at any given time. This prevents split-brain scenarios, inconsistent order books, and double fills in horizontally scaled deployments.

Changes
Added Redis-backed leader lease/fencing before enabling the matching engine.
Implemented heartbeat-based lease renewal with fail-closed behavior on lease loss.
Rejected new orders with a stable 503 matching_unavailable response when not the active leader.
Invalidated in-memory order books after lease loss to prevent serving stale state.
Documented leader-based deployment model and safe read replica behavior.
Added tests covering dual leader contention, stale fencing tokens, and order rejection for non-leaders.
Introduced leader status and lease renewal metrics (vatix_matching_leader and lease renewal failures).
Impact

Ensures a single authoritative matching engine in production, eliminating race conditions during scaling and restarts while improving system reliability and consistency.