### PR TITLE
test: cover rate limit policy enforcement on orders POST

### DIFF
--- a/src/api/routes/orders.test.ts
+++ b/src/api/routes/orders.test.ts
@@ -689,6 +689,48 @@ describe("POST /orders", () => {
     expect(body.filledQuantity).toBe(0);
   });
 
+  it("should return 429 with RATE_LIMITED body once the write limit is exceeded", async () => {
+    (
+      mockPrismaClient.market.findUnique as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(validMarket);
+    (
+      mockMatchingService.placeOrder as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      order: { id: "order-1", status: "OPEN" },
+      trades: [],
+      filledQuantity: 0,
+    });
+
+    const newOrder = {
+      marketId: "market-1",
+      userAddress: validAddress,
+      side: "BUY" as const,
+      outcome: "YES" as const,
+      price: 0.6,
+      quantity: 100,
+    };
+
+    // Default write tier allows 10 req/min (see RATE_LIMIT_POLICY.md); the
+    // 11th request in the same window must be rejected.
+    let last;
+    for (let i = 0; i < 11; i++) {
+      last = await app.inject({
+        method: "POST",
+        url: "/orders",
+        payload: newOrder,
+      });
+    }
+
+    expect(last!.statusCode).toBe(429);
+    expect(last!.headers["retry-after"]).toBeDefined();
+    const body = JSON.parse(last!.body);
+    expect(body).toMatchObject({
+      error: "Too Many Requests",
+      code: "RATE_LIMITED",
+      statusCode: 429,
+    });
+  });
+
   it("normalizes trade timestamps to ISO-8601 in the response", async () => {
     const newOrder = {
       marketId: "market-1",


### PR DESCRIPTION
## Summary
`POST /v1/orders` was already wired to `writeLimiter` per `RATE_LIMIT_POLICY.md` (`src/api/routes/orders.ts`), but there was no test asserting the burst-over-limit behavior for this specific route. Adds a targeted test in `orders.test.ts` confirming the 11th request in a window returns 429 with the documented body shape.

## Context / before-after
Before: `writeLimiter` middleware was applied but untested at the route level (only the shared `rateLimiter.test.ts` covered the tier logic generically). After: a route-level regression test locks in that POST /orders enforces the write tier (10 req/min default) and returns `{ error: "Too Many Requests", code: "RATE_LIMITED", statusCode: 429 }` with a `Retry-After` header once exceeded.

## Testing
Added `should return 429 with RATE_LIMITED body once the write limit is exceeded` to `src/api/routes/orders.test.ts`, following the existing `clearRateLimitStores()` setup/teardown pattern used elsewhere in the suite. (Dependencies aren't installed in this environment, so the suite wasn't executed locally — the test follows the same structure and mocks as the passing `should create a valid order` test directly above it.)

Closes #799