### PR TITLE
fix: add wallet-address indexes on indexed_trades for positions lookups

### DIFF
--- a/prisma/migrations/20260729170000_add_indexed_trades_wallet_indexes/migration.sql
+++ b/prisma/migrations/20260729170000_add_indexed_trades_wallet_indexes/migration.sql
@@ -1,0 +1,10 @@
+-- Add wallet-address indexes to indexed_trades so per-wallet positions queries
+-- (prisma.indexedTrade.findMany({ where: { OR: [{ traderAddress }, { counterpartyAddress }] } }))
+-- hit an index instead of a full table scan. Mirrors the existing per-column
+-- index pattern already used on trades.buyer_address / trades.seller_address.
+
+-- CreateIndex
+CREATE INDEX "indexed_trades_trader_address_idx" ON "indexed_trades"("trader_address");
+
+-- CreateIndex
+CREATE INDEX "indexed_trades_counterparty_address_idx" ON "indexed_trades"("counterparty_address");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -393,6 +393,8 @@ model IndexedTrade {
 
   @@index([marketId])
   @@index([ledger])
+  @@index([traderAddress])
+  @@index([counterpartyAddress])
   @@map("indexed_trades")
 }
 


### PR DESCRIPTION
## Summary
Audited `findMany` calls filtering by wallet address for the positions endpoint (`src/api/routes/positions.ts`). `UserPosition` and `Trade` already had per-wallet indexes, but `IndexedTrade` only had indexes on `marketId`/`ledger` — the `prisma.indexedTrade.findMany({ where: { OR: [{ traderAddress }, { counterpartyAddress }] } })` call in `computeLockedCollateral` was doing a full table scan. Adds indexes on both columns.

## Context / before-after
Before: `indexed_trades` had no index covering `trader_address` or `counterparty_address`, so wallet-scoped position/collateral lookups scanned the full table. After: `@@index([traderAddress])` and `@@index([counterpartyAddress])` added to the Prisma schema, mirroring the existing per-column pattern already used on `trades.buyer_address`/`trades.seller_address`, plus migration `20260729170000_add_indexed_trades_wallet_indexes`.

## Testing
Schema/migration change only — no query code changed, so existing unit tests are unaffected. Dependencies/DB aren't available in this environment to run migrations or `EXPLAIN`; verification was done by reading the query in `positions.ts` against the Prisma schema's `@@index` declarations before and after.

Closes #797