### PR TITLE
fix(indexer): harden tradeParser against malformed payloads, add pars…

### DIFF
--- a/apps/indexer/fixtures/contract-event-vectors.json
+++ b/apps/indexer/fixtures/contract-event-vectors.json
@@ -59,6 +59,36 @@
             "quantityRaw": "1000000000000"
           }
         }
+      ],
+      "malformedVectors": [
+        {
+          "label": "empty valueXdr string",
+          "topicsXdr": ["AAAADwAAABR0cmFkZV9leGVjdXRlZF9ldmVudA=="],
+          "valueXdr": "",
+          "expectedError": "TradeParseError",
+          "note": "Empty string is not valid base64 XDR — parser must not throw uncaught"
+        },
+        {
+          "label": "valid base64 but not a valid ScVal",
+          "topicsXdr": ["AAAADwAAABR0cmFkZV9leGVjdXRlZF9ldmVudA=="],
+          "valueXdr": "aGVsbG8gd29ybGQ=",
+          "expectedError": "TradeParseError",
+          "note": "'hello world' base64-encoded — decodes fine but is not a Soroban ScVal"
+        },
+        {
+          "label": "wrong topic discriminator",
+          "topicsXdr": ["AAAADwAAAAt3cm9uZ19ldmVudA=="],
+          "valueXdr": "AAAAEQAAAAEAAAAJAAAADwAAAAltYXJrZXRfaWQAAAAAAAAPAAAACm1hcmtldC1hYmMAAAAAAA8AAAAGdHJhZGVyAAAAAAAPAAAACEdBQkMxMjM0AAAADwAAAAxjb3VudGVycGFydHkAAAAPAAAACEdYWVo1Njc4AAAADwAAAAlkaXJlY3Rpb24AAAAAAAAPAAAAA2J1eQAAAAAPAAAAB291dGNvbWUAAAAADwAAAANZRVMAAAAADwAAAAVwcmljZQAAAAAAAAoAAAAAAAAAAAAAAAAATEtAAAAADwAAAAhxdWFudGl0eQAAAAoAAAAAAAAAAAAAAAAAAABkAAAADwAAAAxidXlfb3JkZXJfaWQAAAAPAAAABWJ1eS0xAAAAAAAADwAAAA1zZWxsX29yZGVyX2lkAAAAAAAADwAAAAZzZWxsLTEAAA==",
+          "expectedError": "TradeParseError",
+          "note": "ScvSymbol 'wrong_event' — valid XDR but not the trade_executed_event discriminator"
+        },
+        {
+          "label": "empty topicsXdr array",
+          "topicsXdr": [],
+          "valueXdr": "AAAAEQAAAAEAAAAJAAAADwAAAAltYXJrZXRfaWQAAAAAAAAPAAAACm1hcmtldC1hYmMAAAAAAA8AAAAGdHJhZGVyAAAAAAAPAAAACEdBQkMxMjM0AAAADwAAAAxjb3VudGVycGFydHkAAAAPAAAACEdYWVo1Njc4AAAADwAAAAlkaXJlY3Rpb24AAAAAAAAPAAAAA2J1eQAAAAAPAAAAB291dGNvbWUAAAAADwAAAANZRVMAAAAADwAAAAVwcmljZQAAAAAAAAoAAAAAAAAAAAAAAAAATEtAAAAADwAAAAhxdWFudGl0eQAAAAoAAAAAAAAAAAAAAAAAAABkAAAADwAAAAxidXlfb3JkZXJfaWQAAAAPAAAABWJ1eS0xAAAAAAAADwAAAA1zZWxsX29yZGVyX2lkAAAAAAAADwAAAAZzZWxsLTEAAA==",
+          "expectedError": "TradeParseError",
+          "note": "No topics at all — isTradeEvent returns false immediately"
+        }
       ]
     },
 

--- a/apps/indexer/src/ingestion.ts
+++ b/apps/indexer/src/ingestion.ts
@@ -482,6 +482,7 @@ export class PollingIngestionLoop implements IngestionLoop {
     });
 
     for (const error of tradeErrors) {
+      this.metrics.incrementParseError();
       this.logger.warn("Trade parse error — skipping event", {
         eventId: error.eventId,
         error: error.message,

--- a/apps/indexer/src/metrics.ts
+++ b/apps/indexer/src/metrics.ts
@@ -7,6 +7,8 @@ export interface IndexerMetricsSnapshot {
   gapDetectedTotal: number;
   /** Total number of ledgers back-filled during gap catch-up since process start. */
   backfillLedgersTotal: number;
+  /** Total number of event parse errors (all parsers) since process start. */
+  parseErrorTotal: number;
 }
 
 /** Typed payload used when logging a metrics snapshot. */
@@ -17,6 +19,7 @@ export interface IndexerMetricsLog {
   lag: number | null;
   gapDetectedTotal: number;
   backfillLedgersTotal: number;
+  parseErrorTotal: number;
 }
 
 export class InternalIndexerMetricsService {
@@ -26,6 +29,8 @@ export class InternalIndexerMetricsService {
   private gapDetectedTotal = 0;
   /** Running total of ledgers back-filled since process start. */
   private backfillLedgersTotal = 0;
+  /** Running total of event parse errors (all parsers) since process start. */
+  private parseErrorTotal = 0;
 
   setLatestIndexedLedgerSequence(sequence: number): void {
     this.latestIndexedLedgerSequence = sequence;
@@ -81,6 +86,15 @@ export class InternalIndexerMetricsService {
     return this.backfillLedgersTotal;
   }
 
+  /** Increment the parse-error counter by `count` (defaults to 1). */
+  incrementParseError(count = 1): void {
+    this.parseErrorTotal += count;
+  }
+
+  getParseErrorTotal(): number {
+    return this.parseErrorTotal;
+  }
+
   getSnapshot(): IndexerMetricsSnapshot {
     return {
       latestIndexedLedgerSequence: this.latestIndexedLedgerSequence,
@@ -88,6 +102,7 @@ export class InternalIndexerMetricsService {
       lag: this.getLag(),
       gapDetectedTotal: this.gapDetectedTotal,
       backfillLedgersTotal: this.backfillLedgersTotal,
+      parseErrorTotal: this.parseErrorTotal,
     };
   }
 
@@ -99,6 +114,7 @@ export class InternalIndexerMetricsService {
       lag: this.getLag(),
       gapDetectedTotal: this.gapDetectedTotal,
       backfillLedgersTotal: this.backfillLedgersTotal,
+      parseErrorTotal: this.parseErrorTotal,
     };
   }
 }

--- a/apps/indexer/src/tradeParser.test.ts
+++ b/apps/indexer/src/tradeParser.test.ts
@@ -143,7 +143,68 @@ describe("parseTradeEvent", () => {
   });
 });
 
-// ─── parseTradeEvents (batch) ────────────────────────────────────────────────
+// ─── Malformed payload fixture tests ────────────────────────────────────────
+
+describe("parseTradeEvent — malformed payloads", () => {
+  it("throws TradeParseError on completely empty string valueXdr", () => {
+    expect(() => parseTradeEvent(makeEvent({ valueXdr: "" }))).toThrow(
+      TradeParseError
+    );
+  });
+
+  it("throws TradeParseError on null-byte / binary garbage valueXdr", () => {
+    expect(() =>
+      parseTradeEvent(makeEvent({ valueXdr: "\x00\x01\x02\x03" }))
+    ).toThrow(TradeParseError);
+  });
+
+  it("throws TradeParseError on valid base64 that is not XDR", () => {
+    // "hello world" base64-encoded — valid base64 but not a valid ScVal
+    expect(() =>
+      parseTradeEvent(makeEvent({ valueXdr: "aGVsbG8gd29ybGQ=" }))
+    ).toThrow(TradeParseError);
+  });
+
+  it("throws TradeParseError when topicsXdr contains only whitespace", () => {
+    expect(() =>
+      parseTradeEvent(makeEvent({ topicsXdr: ["   "] }))
+    ).toThrow(TradeParseError);
+  });
+
+  it("throws TradeParseError when topicsXdr has wrong discriminator symbol", () => {
+    // ScvSymbol 'wrong_event' — valid XDR but wrong topic
+    expect(() =>
+      parseTradeEvent(
+        makeEvent({ topicsXdr: ["AAAADwAAAAt3cm9uZ19ldmVudA=="] })
+      )
+    ).toThrow(TradeParseError);
+  });
+
+  it("does not throw on malformed event in parseTradeEvents batch", () => {
+    const events = [
+      makeEvent({ id: "good", valueXdr: XDR.value.validBuy }),
+      makeEvent({ id: "bad-empty", valueXdr: "" }),
+      makeEvent({ id: "bad-garbage", valueXdr: "not!!base64@@" }),
+      makeEvent({ id: "bad-b64", valueXdr: "aGVsbG8gd29ybGQ=" }),
+    ];
+    expect(() => parseTradeEvents(events)).not.toThrow();
+    const { trades, errors } = parseTradeEvents(events);
+    expect(trades).toHaveLength(1);
+    expect(trades[0].eventId).toBe("good");
+    expect(errors).toHaveLength(3);
+    expect(errors.every((e) => e instanceof TradeParseError)).toBe(true);
+  });
+
+  it("collects eventId on every malformed-payload error", () => {
+    const events = [
+      makeEvent({ id: "evt-bad-1", valueXdr: "" }),
+      makeEvent({ id: "evt-bad-2", valueXdr: "aGVsbG8gd29ybGQ=" }),
+    ];
+    const { errors } = parseTradeEvents(events);
+    expect(errors.map((e) => e.eventId)).toEqual(["evt-bad-1", "evt-bad-2"]);
+  });
+});
+
 
 describe("parseTradeEvents", () => {
   it("parses multiple valid events", () => {


### PR DESCRIPTION
Closes #771 

- Add parseErrorTotal counter to InternalIndexerMetricsService (incrementParseError / getParseErrorTotal, exposed in snapshot + log)
- Increment metric in ingestion.ts for every trade parse error
- Add fixture tests for malformed payloads in tradeParser.test.ts: empty valueXdr, binary garbage, valid-base64-but-not-XDR, whitespace topic, wrong discriminator, batch resilience, eventId capture
- Add malformedVectors section to contract-event-vectors.json fixture

Acceptance criteria met:
  - Malformed events do not crash the ingestion loop (parseTradeEvents already catches and collects; loop was already safe; metric now records)
  - Metric/log records each skip via metrics.incrementParseError()
  - Fixture tests cover all malformed payload paths